### PR TITLE
fix: environment variable override for database configuration

### DIFF
--- a/shared/config/settings.py
+++ b/shared/config/settings.py
@@ -29,8 +29,9 @@ def get_port_from_env() -> int:
 class Settings(BaseSettings):
     # Environment Configuration
     environment: str = "development"
-    development_db_url: str = (
-        "postgresql://user:password@localhost:5432/agent_dashboard"
+    development_db_url: str = os.getenv(
+        "DEVELOPMENT_DB_URL",
+        "postgresql://user:password@localhost:5432/agent_dashboard",
     )
     production_db_url: str = ""
 


### PR DESCRIPTION
Fixes issue where `DEVELOPMENT_DB_URL` from `.env` file was ignored during database migrations.

Updates `shared/config/settings.py` to use `os.getenv()` with proper fallback, allowing environment variables to override hardcoded defaults.

**Testing:**
 - All 55 tests pass
 - Database migrations work with custom `.env` values
 - Maintains backward compatibility