### PR TITLE
Fix database connection pool configuration for Supabase

### DIFF
--- a/shared/database/session.py
+++ b/shared/database/session.py
@@ -5,7 +5,16 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from ..config.settings import settings
 
-engine = create_engine(settings.database_url)
+# For Supabase session mode pooler (port 5432)
+# Keep pool small since Supabase pooler has 15 connection limit
+engine = create_engine(
+    settings.database_url,
+    pool_size=3,  # Small pool size to stay under Supabase's 15 limit
+    max_overflow=2,  # Allow 2 overflow connections (total: 5)
+    pool_timeout=30,  # Wait up to 30 seconds for connection
+    pool_recycle=1800,  # Recycle connections after 30 minutes
+    pool_pre_ping=True,  # Test connections before using them
+)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 


### PR DESCRIPTION
- Add proper connection pooling limits to prevent "Max client connections reached" errors
- Configure pool_size=3 and max_overflow=2 to stay under Supabase's 15 connection limit
- Add pool_pre_ping=True to detect and handle stale connections
- Set pool_recycle=1800 to refresh connections every 30 minutes
- Add pool_timeout=30 to gracefully handle connection unavailability

This configuration is optimized for Supabase's session mode pooler (port 5432) and prevents connection exhaustion issues.

🤖 Generated with [Claude Code](https://claude.ai/code)