### PR TITLE
feat: support --resume and --continue in claude code

### DIFF
--- a/integrations/cli_wrappers/claude_code/claude_wrapper_v3.py
+++ b/integrations/cli_wrappers/claude_code/claude_wrapper_v3.py
@@ -810,7 +810,7 @@ class ClaudeWrapperV3:
                         # Extract session ID from filename and update our tracking
                         actual_session_id = latest_jsonl.stem
                         if actual_session_id != self.session_uuid:
-                            self.log(f"[INFO] Detected Claude session ID: {actual_session_id}")
+                            self.log(f"[INFO] Detected Existing Claude session ID: {actual_session_id}")
                             self.log(f"[INFO] Updating from Omnara session ID: {self.session_uuid}")
                             self.session_uuid = actual_session_id
                             
@@ -824,7 +824,6 @@ class ClaudeWrapperV3:
                         self.log(f"[INFO] Found Claude JSONL log: {self.claude_jsonl_path}")
                         break
                 else:
-                    # Normal case - look for our expected session ID
                     expected_filename = f"{self.session_uuid}.jsonl"
                     expected_path = project_dir / expected_filename
                     if expected_path.exists():

--- a/integrations/cli_wrappers/claude_code/claude_wrapper_v3.py
+++ b/integrations/cli_wrappers/claude_code/claude_wrapper_v3.py
@@ -795,16 +795,42 @@ class ClaudeWrapperV3:
     def monitor_claude_jsonl(self):
         """Monitor Claude's JSONL log file for messages"""
         # Wait for log file to be created
-        expected_filename = f"{self.session_uuid}.jsonl"
-
         while self.running and not self.claude_jsonl_path:
             project_dir = self.get_project_log_dir()
             if project_dir:
-                expected_path = project_dir / expected_filename
-                if expected_path.exists():
-                    self.claude_jsonl_path = expected_path
-                    self.log(f"[INFO] Found Claude JSONL log: {expected_path}")
-                    break
+                if hasattr(self, 'using_continue_or_resume') and self.using_continue_or_resume:
+                    # For --continue/--resume, look for any new JSONL file
+                    # and extract the session ID from it
+                    jsonl_files = list(project_dir.glob("*.jsonl"))
+                    if jsonl_files:
+                        # Sort by modification time to get the most recent
+                        latest_jsonl = max(jsonl_files, key=lambda f: f.stat().st_mtime)
+                        self.claude_jsonl_path = latest_jsonl
+                        
+                        # Extract session ID from filename and update our tracking
+                        actual_session_id = latest_jsonl.stem
+                        if actual_session_id != self.session_uuid:
+                            self.log(f"[INFO] Detected Claude session ID: {actual_session_id}")
+                            self.log(f"[INFO] Updating from Omnara session ID: {self.session_uuid}")
+                            self.session_uuid = actual_session_id
+                            
+                            # Update log file path to match actual session
+                            if self.debug_log_file:
+                                self.debug_log_file.close()
+                                new_log_path = OMNARA_WRAPPER_LOG_DIR / f"{self.session_uuid}.log"
+                                self.debug_log_file = open(new_log_path, "a")
+                                self.log("[INFO] Updated debug log file to match Claude session")
+                        
+                        self.log(f"[INFO] Found Claude JSONL log: {self.claude_jsonl_path}")
+                        break
+                else:
+                    # Normal case - look for our expected session ID
+                    expected_filename = f"{self.session_uuid}.jsonl"
+                    expected_path = project_dir / expected_filename
+                    if expected_path.exists():
+                        self.claude_jsonl_path = expected_path
+                        self.log(f"[INFO] Found Claude JSONL log: {expected_path}")
+                        break
             time.sleep(0.5)
 
         if not self.claude_jsonl_path:
@@ -1221,16 +1247,16 @@ class ClaudeWrapperV3:
         """Run Claude CLI in a PTY"""
         claude_path = self.find_claude_cli()
 
-        # Check if session-related flags are present (which conflict with --session-id)
-        has_session_flag = (
-            "--continue" in sys.argv
-            or "-c" in sys.argv
-            or "--resume" in sys.argv
-            or "-r" in sys.argv
+        # Check if --continue/-c or --resume/-r flags are present (which conflict with --session-id)
+        has_continue_or_resume = any(
+            arg in ["--continue", "-c", "--resume", "-r"] for arg in sys.argv[1:]
         )
 
+        # Store flag for JSONL monitoring
+        self.using_continue_or_resume = has_continue_or_resume
+
         # Build command - only add session ID if not using session-related flags
-        if has_session_flag:
+        if has_continue_or_resume:
             # Don't add session-id when using --continue/-c or --resume/-r
             cmd = [claude_path]
             self.log(


### PR DESCRIPTION
**Summary** 
This pr introduces support for `--continue` , `-c`, `-r`, `--resume` in the omnara CLI wrapper. 

Previously these flags would conflict with the --session-id parameter, but now we get the session id from the latest file.  Might need more scruitiny on resume, since it allows you to pick from a list of options for session id but it looks solid so far. 

Tested all flag combinations:
  - Long and short forms work correctly
  - Session correlation functions properly
  - Normal workflow unaffected
  - No conflicts with existing functionality