### PR TITLE
fix: Handle dots in Claude project path conversion

### DIFF
--- a/webhooks/claude_wrapper_v3.py
+++ b/webhooks/claude_wrapper_v3.py
@@ -768,7 +768,7 @@ class ClaudeWrapperV3:
         """Get the Claude project log directory for current working directory"""
         cwd = os.getcwd()
         # Convert path to Claude's format
-        project_name = cwd.replace("/", "-")
+        project_name = cwd.replace("/", "-").replace(".", "-")
         project_dir = CLAUDE_LOG_BASE / project_name
         return project_dir if project_dir.exists() else None
 


### PR DESCRIPTION
Claude Code project directories appear to convert dots to hyphens, similar to how slashes are converted, as shown in the following example:

Claude Code execution directory:
/Users/foo/src/github.com/omnara-ai/omnara

Claude Code Project directory:
/Users/foo/.claude/projects/-Users-foo-src-github-com-omnara-ai-omnara

Omnara's existing code did not handle dot conversion, which prevented Claude Code responses from being retrieved when running in such directories. 
This commit fixes the issue.