### PR TITLE
fix: Claude project path conversion

### DIFF
--- a/integrations/cli_wrappers/claude_code/claude_wrapper_v3.py
+++ b/integrations/cli_wrappers/claude_code/claude_wrapper_v3.py
@@ -789,13 +789,7 @@ class ClaudeWrapperV3:
         """Get the Claude project log directory for current working directory"""
         cwd = os.getcwd()
         # Convert path to Claude's format
-        project_name = (
-            cwd.replace("/", "-")
-            .replace(".", "-")
-            .replace(" ", "-")
-            .replace("@", "-")
-            .replace("_", "-")
-        )
+        project_name = re.sub(r"[^a-zA-Z0-9]", "-", cwd)
         project_dir = CLAUDE_LOG_BASE / project_name
         return project_dir if project_dir.exists() else None
 


### PR DESCRIPTION
The project path conversion in Claude Code was still failing.
I investigated the issue.

Claude Code execution directory: 
 /Users/foo/test-`=~!@#$%^&*()_+[]{}|;':",.<>?åß∂ƒ©∆˚¬…あ

Claude Code project directory:
 /Users/foo/.claude/projects/-Users-foo-test-----------------------------------------

It appears that non-alphanumeric characters need to be converted to `-`.