### PR TITLE
fix breaking change in claude code status display

### DIFF
--- a/integrations/cli_wrappers/claude_code/claude_wrapper_v3.py
+++ b/integrations/cli_wrappers/claude_code/claude_wrapper_v3.py
@@ -947,7 +947,7 @@ class ClaudeWrapperV3:
 
                                 # Check for both "esc to interrupt" and "ctrl+b to run in background"
                                 if (
-                                    "esc to interrupt)" in clean_text
+                                    "esc to interrupt" in clean_text
                                     or "ctrl+b to run in background" in clean_text
                                 ):
                                     self.last_esc_interrupt_seen = time.time()

--- a/omnara/cli.py
+++ b/omnara/cli.py
@@ -47,7 +47,11 @@ def check_for_updates():
 
         if latest_version != current_version and current_version != "unknown":
             print(f"\n✨ Update available: {current_version} → {latest_version}")
-            print("   Run: pip install --upgrade omnara\n")
+            print("   Run: pip install --upgrade omnara")
+            print(
+                "   Please keep omnara up-to-date for best compatibility with Claude Code"
+            )
+            print("   New versions often include important bug fixes\n")
     except Exception:
         pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omnara"
-version = "1.6.0"
+version = "1.6.1"
 description = "Omnara Agent Dashboard - MCP Server and Python SDK"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
we used to check if "esc to interrupt)" was in the terminal, but a recent update to Claude Code changed this behavior to not guarantee a paren at the end, so we remove the check for the paren at the end. This will stop the constant notifications.