### PR TITLE
fix: Align CORS with token‑only auth

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -64,9 +64,10 @@ else:
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,
-    allow_credentials=True,
+    # We authenticate via Authorization header; no cross-site cookies needed
+    allow_credentials=False,
     allow_methods=["*"],
-    allow_headers=["*"],
+    allow_headers=["*"],  # includes Authorization
 )
 
 # Include routers with versioned API prefix


### PR DESCRIPTION
Set `allow_credentials=False` in `backend/main.py` CORS middleware. Disable credentialed CORS to reflect that the SPA no longer sends cookies; header-based auth remains the source of truth. With cookie-less, header-only auth, credentialed CORS is unnecessary and can cause mismatched expectations.