### PR TITLE
fix: add servers module to backend Dockerfile

### DIFF
--- a/infrastructure/docker/backend.Dockerfile
+++ b/infrastructure/docker/backend.Dockerfile
@@ -5,12 +5,15 @@ WORKDIR /app
 # Copy requirements
 COPY src/backend/requirements.txt /app/backend/requirements.txt
 COPY src/shared/requirements.txt /app/shared/requirements.txt
+COPY src/servers/requirements.txt /app/servers/requirements.txt
 
 # Install dependencies
 RUN pip install --no-cache-dir -r backend/requirements.txt
+RUN pip install --no-cache-dir -r servers/requirements.txt
 
 # Copy application code
 COPY src/shared /app/shared
+COPY src/servers /app/servers
 COPY src/backend /app/backend
 
 # Set Python path


### PR DESCRIPTION
## Summary
- Add servers requirements.txt copy and installation to backend Dockerfile
- Add servers source code copy to backend image  
- This fixes the import error for `servers.shared.db` module that was causing backend pods to crash

## Test plan
- Built and tested locally - imports work correctly
- Backend image now includes servers module directory
- No circular import issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)