### PR TITLE
fix: restore --name parameter

### DIFF
--- a/src/integrations/cli_wrappers/claude_code/claude_wrapper_v3.py
+++ b/src/integrations/cli_wrappers/claude_code/claude_wrapper_v3.py
@@ -198,7 +198,7 @@ class ClaudeWrapperV3:
         self.agent_instance_id = str(uuid.uuid4())
         self.permission_mode = permission_mode
         self.dangerously_skip_permissions = dangerously_skip_permissions
-        self.name = name
+        self.name = os.environ.get("OMNARA_AGENT_DISPLAY_NAME") or name
         self.idle_delay = idle_delay
 
         # Set up logging


### PR DESCRIPTION
## Summary

- Fixed the `--name` parameter that was being ignored by the Claude wrapper
- Modified `claude_wrapper_v3.py` to read `OMNARA_AGENT_DISPLAY_NAME` environment variable

## Behavior

**Before this fix:**
Running `omnara --name AgentName` would ignore the passed name and use the Claude Code default name.

**After this fix:**
Running `omnara --name AgentName` correctly uses "AgentName" as the agent display name.

## Details

The CLI was already setting the `OMNARA_AGENT_DISPLAY_NAME` environment variable, but the wrapper wasn't reading it. This change makes the wrapper check the environment variable first, falling back to the default name if not set.