### PR TITLE
fix: respect CLAUDE_CONFIG_DIR environment variable

### DIFF
--- a/src/integrations/cli_wrappers/claude_code/claude_wrapper_v3.py
+++ b/src/integrations/cli_wrappers/claude_code/claude_wrapper_v3.py
@@ -39,7 +39,9 @@ from integrations.utils.git_utils import GitDiffTracker
 
 
 # Constants
-CLAUDE_LOG_BASE = Path.home() / ".claude" / "projects"
+# Respect CLAUDE_CONFIG_DIR environment variable for multiple profiles
+claude_config_dir = os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude"))
+CLAUDE_LOG_BASE = Path(claude_config_dir) / "projects"
 OMNARA_WRAPPER_LOG_DIR = Path.home() / ".omnara" / "claude_wrapper"
 
 


### PR DESCRIPTION
## Summary

- Fixed Omnara wrapper to respect `CLAUDE_CONFIG_DIR` environment variable for multiple Claude profiles
- Wrapper now finds Claude's JSONL logs in custom config directories

## Behavior

**Before this fix:**
Running `CLAUDE_CONFIG_DIR="$HOME/.claude-work" omnara --name test` would not send terminal responses to Omnara dashboard. Wrapper logs (`~/.omnara/claude_wrapper/<instance-id>.log`) never show "Found Claude JSONL log" message.

**After this fix:**
Wrapper correctly reads `CLAUDE_CONFIG_DIR` and finds Claude's JSONL logs in the custom directory. Terminal responses appear in dashboard as expected.

## Details

The wrapper hardcoded `~/.claude/projects` for Claude's JSONL logs. When `CLAUDE_CONFIG_DIR` is set, Claude writes logs to `$CLAUDE_CONFIG_DIR/projects/`, but the wrapper was looking in the wrong place. The fix reads the environment variable (defaulting to `~/.claude` if unset).