### PR TITLE
chore: allow HTTP hosted API URLs

### DIFF
--- a/internal/modelprovider/hosted_credentials.go
+++ b/internal/modelprovider/hosted_credentials.go
@@ -18,7 +18,6 @@ import (
 	"github.com/omnara-ai/omnara/internal/outboundhttp"
 	"github.com/omnara-ai/omnara/internal/publicid"
 	"github.com/omnara-ai/omnara/internal/storage/modelstore"
-	"github.com/omnara-ai/omnara/internal/urlpolicy"
 )
 
 const (
@@ -154,12 +153,21 @@ func ValidateHostedAPIBaseURL(raw string) error {
 	if raw == "" || raw != strings.TrimSpace(raw) {
 		return errors.New("OMNARA_HOSTED_API_URL is required and cannot have surrounding whitespace")
 	}
-	if err := urlpolicy.RequireHTTPSOrLoopback(raw); err != nil {
-		return fmt.Errorf("OMNARA_HOSTED_API_URL: %w", err)
-	}
 	parsed, err := url.Parse(raw)
 	if err != nil {
 		return fmt.Errorf("parse OMNARA_HOSTED_API_URL: %w", err)
+	}
+	if parsed.Hostname() == "" || parsed.Opaque != "" {
+		return errors.New("OMNARA_HOSTED_API_URL must be absolute and include a host")
+	}
+	if parsed.User != nil {
+		return errors.New("OMNARA_HOSTED_API_URL must not include user information")
+	}
+	if parsed.Fragment != "" {
+		return errors.New("OMNARA_HOSTED_API_URL must not include a fragment")
+	}
+	if !strings.EqualFold(parsed.Scheme, "http") && !strings.EqualFold(parsed.Scheme, "https") {
+		return errors.New("OMNARA_HOSTED_API_URL must use HTTP or HTTPS")
 	}
 	if parsed.RawQuery != "" || parsed.ForceQuery {
 		return errors.New("OMNARA_HOSTED_API_URL must contain only scheme, host, and an optional path")

--- a/internal/modelprovider/hosted_credentials_test.go
+++ b/internal/modelprovider/hosted_credentials_test.go
@@ -254,17 +254,17 @@ func TestHTTPHostedCredentialProvisionerRejectsRedirect(t *testing.T) {
 
 func TestHostedAPIConfigurationValidation(t *testing.T) {
 	t.Parallel()
-	if err := ValidateHostedAPIBaseURL("http://hosted.example.test/internal"); err == nil {
-		t.Fatal("public HTTP hosted URL accepted")
+	if err := ValidateHostedAPIBaseURL("http://hosted.example.test/internal"); err != nil {
+		t.Fatalf("HTTP hosted URL: %v", err)
 	}
 	if err := ValidateHostedAPIBaseURL("http://127.0.0.1:4310/internal"); err != nil {
 		t.Fatalf("loopback hosted URL: %v", err)
 	}
 	endpoint, err := hostedCredentialEndpoint(
-		"https://hosted.example.test/private/",
+		"http://saas-api:4301/internal/",
 		HostedCredentialPath,
 	)
-	if err != nil || endpoint != "https://hosted.example.test/private/model-provider-credentials" {
+	if err != nil || endpoint != "http://saas-api:4301/internal/model-provider-credentials" {
 		t.Fatalf("endpoint = %q err=%v", endpoint, err)
 	}
 	if err := ValidateHostedAPIToken(strings.Repeat("a", MinimumHostedAPITokenBytes-1)); err == nil {


### PR DESCRIPTION
- allow `OMNARA_HOSTED_API_URL` to use either HTTP or HTTPS while preserving URL shape validation
- support private service addresses such as `http://saas-api:4301/internal`, including the expected `/model-provider-credentials` route
- keep the stricter HTTPS-or-loopback policy unchanged for OAuth, MCP, and other URL consumers
- leave transport encryption for hosted API traffic to the deployment network layer
