### PR TITLE
feat: reconcile default resources across organizations

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"net/http"
@@ -30,10 +31,15 @@ import (
 	"github.com/omnara-ai/omnara/internal/secrets"
 	"github.com/omnara-ai/omnara/internal/storage"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
+	"github.com/omnara-ai/omnara/internal/storage/orglifecycle"
 	"github.com/omnara-ai/omnara/internal/toolcatalog"
 )
 
-const outboundHTTPClientTimeout = 30 * time.Second
+const (
+	outboundHTTPClientTimeout  = 30 * time.Second
+	defaultReconciliationPlan  = "plan"
+	defaultReconciliationApply = "apply"
+)
 
 func main() {
 	cfg, err := config.Load()
@@ -41,6 +47,14 @@ func main() {
 		log := slog.New(logpkg.NewJSONHandler(os.Stdout, nil))
 		log.Error("load config", "error", err)
 		os.Exit(1)
+	}
+	if len(os.Args) > 1 {
+		if err := runDefaultReconciliation(context.Background(), cfg, os.Args[1:], os.Stdout); err != nil {
+			log := slog.New(logpkg.NewJSONHandler(os.Stdout, nil))
+			log.Error("run command", "error", err)
+			os.Exit(1)
+		}
+		return
 	}
 	if err := cfg.ValidateAPI(); err != nil {
 		log := slog.New(logpkg.NewJSONHandler(os.Stdout, nil))
@@ -206,6 +220,65 @@ func main() {
 	if exitCode != 0 {
 		os.Exit(exitCode)
 	}
+}
+
+func parseDefaultReconciliationMode(args []string) (string, error) {
+	if len(args) != 2 || args[0] != "reconcile-defaults" {
+		return "", errors.New("usage: omnara-api reconcile-defaults plan|apply")
+	}
+	switch args[1] {
+	case defaultReconciliationPlan, defaultReconciliationApply:
+		return args[1], nil
+	default:
+		return "", errors.New("usage: omnara-api reconcile-defaults plan|apply")
+	}
+}
+
+func runDefaultReconciliation(
+	ctx context.Context,
+	cfg config.Config,
+	args []string,
+	output io.Writer,
+) error {
+	mode, err := parseDefaultReconciliationMode(args)
+	if err != nil {
+		return err
+	}
+	if cfg.DatabaseURL == "" {
+		return errors.New("OMNARA_DATABASE_URL is required")
+	}
+	if len(cfg.DefaultMachinePools) == 0 && cfg.DefaultModelProvider == nil {
+		return errors.New("no default templates are configured")
+	}
+	db, err := storage.Open(ctx, cfg.DatabaseURL)
+	if err != nil {
+		return fmt.Errorf("open database: %w", err)
+	}
+	defer db.Close()
+	store := storage.NewStore(db, storage.WithMachinePoolProviders(machinepool.DefaultCatalog()))
+	result, err := store.Organizations().ReconcileDefaults(ctx, orglifecycle.ReconcileDefaultsInput{
+		Apply:                mode == defaultReconciliationApply,
+		DefaultMachinePools:  cfg.DefaultMachinePools,
+		DefaultModelProvider: cfg.DefaultModelProvider,
+	})
+	if err != nil {
+		return err
+	}
+	for _, change := range result.Changes {
+		if _, err := fmt.Fprintf(output, "%s: %s\n", mode, change); err != nil {
+			return err
+		}
+	}
+	for _, warning := range result.Warnings {
+		if _, err := fmt.Fprintf(output, "%s: warning: %s\n", mode, warning); err != nil {
+			return err
+		}
+	}
+	if len(result.Changes) == 0 {
+		_, err = fmt.Fprintf(output, "%s: no changes\n", mode)
+		return err
+	}
+	return nil
 }
 
 func bootstrapAuthConnectors(ctx context.Context, store *storage.Store, cfg config.Config) error {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -256,14 +256,11 @@ func runDefaultReconciliation(
 	}
 	defer db.Close()
 	store := storage.NewStore(db, storage.WithMachinePoolProviders(machinepool.DefaultCatalog()))
-	result, err := store.Organizations().ReconcileDefaults(ctx, orglifecycle.ReconcileDefaultsInput{
+	result, reconcileErr := store.Organizations().ReconcileDefaults(ctx, orglifecycle.ReconcileDefaultsInput{
 		Apply:                mode == defaultReconciliationApply,
 		DefaultMachinePools:  cfg.DefaultMachinePools,
 		DefaultModelProvider: cfg.DefaultModelProvider,
 	})
-	if err != nil {
-		return err
-	}
 	for _, change := range result.Changes {
 		if _, err := fmt.Fprintf(output, "%s: %s\n", mode, change); err != nil {
 			return err
@@ -273,6 +270,9 @@ func runDefaultReconciliation(
 		if _, err := fmt.Fprintf(output, "%s: warning: %s\n", mode, warning); err != nil {
 			return err
 		}
+	}
+	if reconcileErr != nil {
+		return reconcileErr
 	}
 	if len(result.Changes) == 0 {
 		_, err = fmt.Fprintf(output, "%s: no changes\n", mode)

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -63,3 +63,23 @@ func TestRequireWebIndexRejectsMissingIndex(t *testing.T) {
 		t.Fatalf("missing index error = %v, want source/index context", err)
 	}
 }
+
+func TestParseDefaultReconciliationMode(t *testing.T) {
+	for _, test := range []struct {
+		args      []string
+		wantMode  string
+		wantError bool
+	}{
+		{args: []string{"reconcile-defaults", "plan"}, wantMode: defaultReconciliationPlan},
+		{args: []string{"reconcile-defaults", "apply"}, wantMode: defaultReconciliationApply},
+		{wantError: true},
+		{args: []string{"unknown"}, wantError: true},
+		{args: []string{"reconcile-defaults", "unknown"}, wantError: true},
+		{args: []string{"reconcile-defaults", "plan", "extra"}, wantError: true},
+	} {
+		mode, err := parseDefaultReconciliationMode(test.args)
+		if (err != nil) != test.wantError || mode != test.wantMode {
+			t.Fatalf("parse reconciliation mode %v = mode %q, err %v", test.args, mode, err)
+		}
+	}
+}

--- a/internal/machinepool/manager.go
+++ b/internal/machinepool/manager.go
@@ -49,33 +49,9 @@ func NewManager(
 }
 
 func (m Manager) ValidateDefaultMachinePool(defaultPoolTemplate executionstore.DefaultMachinePoolTemplate) error {
-	if err := executionstore.ValidateDefaultMachinePoolTemplate(defaultPoolTemplate); err != nil {
-		return fmt.Errorf("default machine pool: %w", err)
-	}
-	defaultMachineProvisioning, err := executionstore.MachineProvisioningFromDefaults(
-		defaultPoolTemplate.DefaultMachineCPU,
-		defaultPoolTemplate.DefaultMachineMemoryMB,
-		defaultPoolTemplate.DefaultMachineProviderOptions,
-	)
-	if err != nil {
-		return fmt.Errorf("default machine pool: %w", err)
-	}
-	policy := executionstore.MachinePoolProviderPolicy{
-		DefaultProvisioning:      defaultMachineProvisioning,
-		RuntimeProtectionEnabled: defaultPoolTemplate.RuntimeProtectionEnabled,
-		ResourceLimits: executionstore.MachineResourceLimits{
-			MaxTotalCPU:        defaultPoolTemplate.MaxTotalCPU,
-			MaxTotalMemoryMB:   defaultPoolTemplate.MaxTotalMemoryMB,
-			MinMachineCPU:      defaultPoolTemplate.MinMachineCPU,
-			MinMachineMemoryMB: defaultPoolTemplate.MinMachineMemoryMB,
-			MaxMachineCPU:      defaultPoolTemplate.MaxMachineCPU,
-			MaxMachineMemoryMB: defaultPoolTemplate.MaxMachineMemoryMB,
-		},
-		ProviderConfig: defaultPoolTemplate.ProviderConfig,
-	}
-	if err := m.Catalog.ValidatePool(
-		defaultPoolTemplate.Provider,
-		policy,
+	if err := executionstore.ValidateDefaultMachinePoolTemplate(
+		defaultPoolTemplate,
+		m.Catalog,
 	); err != nil {
 		return fmt.Errorf("default machine pool: %w", err)
 	}

--- a/internal/storage/default_reconciliation_integration_test.go
+++ b/internal/storage/default_reconciliation_integration_test.go
@@ -174,6 +174,27 @@ func TestReconcileDefaults(t *testing.T) {
 	`, created.Org.ID); err != nil {
 		t.Fatalf("set pool limits: %v", err)
 	}
+	machineID := testID("default-reconciliation-runtime-mismatch")
+	tag, err := pool.Exec(ctx, `
+		INSERT INTO machines(
+			id, org_id, machine_pool_id, source_kind, display_name, provider,
+			lifecycle_state, lifecycle_changed_at, provider_resource_id,
+			provider_provision_attempted_at, cpu, memory_mb, cwd, env, secret_env,
+			provider_options, provider_runtime_mismatch_since, metadata, created_at, updated_at
+		)
+		SELECT $1, machine_pool.org_id, machine_pool.id, 'pool', 'runtime mismatch', machine_pool.provider,
+			'active', statement_timestamp(), 'default-reconciliation-runtime',
+			statement_timestamp(), 1, 512, '', '{}'::jsonb, '{}'::jsonb,
+			'{}'::jsonb, statement_timestamp(), '{}'::jsonb, statement_timestamp(), statement_timestamp()
+		FROM machine_pools machine_pool
+		WHERE machine_pool.org_id = $2 AND machine_pool.name = $3 AND machine_pool.deleted_at IS NULL
+	`, machineID, created.Org.ID, initialPool.Name)
+	if err != nil {
+		t.Fatalf("seed runtime mismatch marker: %v", err)
+	}
+	if tag.RowsAffected() != 1 {
+		t.Fatalf("seed runtime mismatch marker rows = %d, want 1", tag.RowsAffected())
+	}
 	invalidPool := initialPool
 	invalidPool.DefaultMachineMemoryMB = intPtrForMachinePoolTest(4096)
 	if _, err := store.Organizations().ReconcileDefaults(ctx, orglifecycle.ReconcileDefaultsInput{
@@ -186,9 +207,12 @@ func TestReconcileDefaults(t *testing.T) {
 	desiredPool.Description = "new pool"
 	desiredPool.DefaultMachineEnv = json.RawMessage(`{"NEW":"value"}`)
 	desiredPool.DefaultMachineProviderOptions = json.RawMessage(`{"image":"new","sleep_after_ms":30000}`)
+	desiredPool.RuntimeProtectionEnabled = true
 	desiredPool.MaxTotalMachines = 0
 	desiredPool.MaxTotalCPU = intPtrForMachinePoolTest(1)
 	desiredPool.MaxTotalMemoryMB = intPtrForMachinePoolTest(0)
+	desiredPool.MinMachineCPU = intPtrForMachinePoolTest(1)
+	desiredPool.MinMachineMemoryMB = intPtrForMachinePoolTest(512)
 	desiredPool.MaxMachineCPU = intPtrForMachinePoolTest(1)
 	desiredPool.MaxMachineMemoryMB = intPtrForMachinePoolTest(512)
 	desiredProvider := initialProvider
@@ -221,15 +245,30 @@ func TestReconcileDefaults(t *testing.T) {
 		t.Fatalf("get machine pool: %v", err)
 	}
 	if poolRecord.Description != desiredPool.Description ||
+		!poolRecord.RuntimeProtectionEnabled ||
 		poolRecord.MaxTotalMachines != 8 ||
 		poolRecord.MaxTotalCpu == nil || *poolRecord.MaxTotalCpu != 16 ||
 		poolRecord.MaxTotalMemoryMb == nil || *poolRecord.MaxTotalMemoryMb != 8192 ||
+		poolRecord.MinMachineCpu == nil || *poolRecord.MinMachineCpu != 1 ||
+		poolRecord.MinMachineMemoryMb == nil || *poolRecord.MinMachineMemoryMb != 512 ||
 		poolRecord.MaxMachineCpu == nil || *poolRecord.MaxMachineCpu != 4 ||
 		poolRecord.MaxMachineMemoryMb == nil || *poolRecord.MaxMachineMemoryMb != 2048 {
 		t.Fatalf("unexpected reconciled pool: %+v", poolRecord)
 	}
 	assertJSONRawEqual(t, poolRecord.DefaultMachineEnv, string(desiredPool.DefaultMachineEnv))
 	assertJSONRawEqual(t, poolRecord.DefaultMachineProviderOptions, string(desiredPool.DefaultMachineProviderOptions))
+	var hasRuntimeMismatch bool
+	if err := pool.QueryRow(
+		ctx,
+		`SELECT provider_runtime_mismatch_since IS NOT NULL FROM machines WHERE org_id = $1 AND id = $2`,
+		created.Org.ID,
+		machineID,
+	).Scan(&hasRuntimeMismatch); err != nil {
+		t.Fatalf("load runtime mismatch marker: %v", err)
+	}
+	if hasRuntimeMismatch {
+		t.Fatal("runtime mismatch marker survived runtime protection change")
+	}
 
 	reconciledProvider, err := store.Models().GetModelProviderConfigByName(ctx, created.Org.ID, desiredProvider.Name)
 	if err != nil {

--- a/internal/storage/default_reconciliation_integration_test.go
+++ b/internal/storage/default_reconciliation_integration_test.go
@@ -18,11 +18,25 @@ import (
 	"github.com/omnara-ai/omnara/internal/storage/orglifecycle"
 )
 
+type defaultReconciliationMachinePoolProviders struct {
+	mergingMachinePoolProviders
+}
+
+func (defaultReconciliationMachinePoolProviders) ValidatePool(
+	_ string,
+	policy executionstore.MachinePoolProviderPolicy,
+) error {
+	if policy.ResourceLimits.MaxTotalCPU != nil && *policy.ResourceLimits.MaxTotalCPU == 99 {
+		return errors.New("provider rejects max_total_cpu")
+	}
+	return nil
+}
+
 func TestReconcileDefaults(t *testing.T) {
 	ctx := context.Background()
 	pool := openIntegrationDB(t, ctx)
 	defer pool.Close()
-	store := newIntegrationStore(pool, WithMachinePoolProviders(mergingMachinePoolProviders{}))
+	store := newIntegrationStore(pool, WithMachinePoolProviders(defaultReconciliationMachinePoolProviders{}))
 	user := mustCreateIdentityUser(t, ctx, store, "reconcile-defaults@example.com", "Defaults Owner")
 
 	initialPool := defaultMachinePoolTemplateWithDefaultMachineForTest(
@@ -67,6 +81,13 @@ func TestReconcileDefaults(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("create org: %v", err)
+	}
+	providerInvalidPool := initialPool
+	providerInvalidPool.MaxTotalCPU = intPtrForMachinePoolTest(99)
+	if _, err := store.Organizations().ReconcileDefaults(ctx, orglifecycle.ReconcileDefaultsInput{
+		DefaultMachinePools: []executionstore.DefaultMachinePoolTemplate{providerInvalidPool},
+	}); err == nil || !strings.Contains(err.Error(), "provider rejects max_total_cpu") {
+		t.Fatalf("plan with provider-invalid template error = %v", err)
 	}
 	missingPool := initialPool
 	missingPool.Name = "missing-pool"
@@ -266,13 +287,18 @@ func TestReconcileDefaults(t *testing.T) {
 		t.Fatalf("delete default project: %v", err)
 	}
 	desiredPool.Description = "pool without default project"
+	desiredProvider.Models = []modelstore.DefaultConfiguredModelTemplate{
+		{Name: "update-model", ProviderModelSlug: "example/without-project", ContextWindowTokens: 16384, MaxOutputTokens: 2048},
+		{Name: "missing-project-model", ProviderModelSlug: "example/missing-project", ContextWindowTokens: 8192, MaxOutputTokens: 1024},
+	}
 	input.DefaultMachinePools = []executionstore.DefaultMachinePoolTemplate{desiredPool}
+	input.DefaultModelProvider = &desiredProvider
 	result, err = store.Organizations().ReconcileDefaults(ctx, input)
 	if err != nil {
 		t.Fatalf("apply without default project: %v", err)
 	}
-	if len(result.Changes) != 1 || len(result.Warnings) != 1 {
-		t.Fatalf("apply without default project result = %+v, want pool change and warning", result)
+	if len(result.Changes) != 4 || len(result.Warnings) != 1 {
+		t.Fatalf("apply without default project result = %+v, want four changes and one warning", result)
 	}
 	poolRecord, err = testQueries(store).GetMachinePoolByName(ctx, dbsqlc.GetMachinePoolByNameParams{
 		OrgID: created.Org.ID, Name: desiredPool.Name,
@@ -282,5 +308,147 @@ func TestReconcileDefaults(t *testing.T) {
 	}
 	if poolRecord.Description != desiredPool.Description {
 		t.Fatalf("machine pool description = %q, want %q", poolRecord.Description, desiredPool.Description)
+	}
+	updatedModel, err = store.Models().GetConfiguredModelByName(ctx, created.Org.ID, provider.ID, "update-model")
+	if err != nil || updatedModel.ProviderModelSlug != "example/without-project" {
+		t.Fatalf("unexpected model updated without default project: %+v, err %v", updatedModel, err)
+	}
+	if _, err := store.Models().GetConfiguredModelByName(
+		ctx, created.Org.ID, provider.ID, "missing-project-model",
+	); err != nil {
+		t.Fatalf("get model added without default project: %v", err)
+	}
+	if _, err := store.Models().GetConfiguredModelByName(
+		ctx, created.Org.ID, provider.ID, "add-model",
+	); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("get model removed without default project error = %v, want no rows", err)
+	}
+	result, err = store.Organizations().ReconcileDefaults(ctx, input)
+	if err != nil {
+		t.Fatalf("second apply without default project: %v", err)
+	}
+	if len(result.Changes) != 0 || len(result.Warnings) != 1 {
+		t.Fatalf("second apply without default project result = %+v, want only retained-model warning", result)
+	}
+}
+
+func TestReconcileDefaultsContinuesAfterOrganizationFailure(t *testing.T) {
+	ctx := context.Background()
+	pool := openIntegrationDB(t, ctx)
+	defer pool.Close()
+	store := newIntegrationStore(pool, WithMachinePoolProviders(mergingMachinePoolProviders{}))
+	user := mustCreateIdentityUser(t, ctx, store, "reconcile-partial@example.com", "Defaults Owner")
+
+	poolTemplate := func(name string) executionstore.DefaultMachinePoolTemplate {
+		return defaultMachinePoolTemplateWithDefaultMachineForTest(
+			executionstore.DefaultMachinePoolTemplate{
+				Name:               name,
+				Description:        "old",
+				Provider:           "blaxel",
+				ProviderAuthEnvVar: "RECONCILE_POOL_TOKEN",
+				MaxTotalMachines:   1,
+				MaxTotalMemoryMB:   intPtrForMachinePoolTest(4096),
+				MaxMachineMemoryMB: intPtrForMachinePoolTest(2048),
+			},
+			defaultMachineFieldsForTest{
+				DefaultMachineCPU:             1,
+				DefaultMachineMemoryMB:        512,
+				DefaultMachineProviderOptions: json.RawMessage(`{"image":"old"}`),
+			},
+		)
+	}
+	initialPools := []executionstore.DefaultMachinePoolTemplate{
+		poolTemplate("partial-pool-a"),
+		poolTemplate("partial-pool-b"),
+	}
+	createOrg := func(name, key string) identitystore.CreateOrgForUserRecord {
+		t.Helper()
+		created, err := store.Organizations().CreateOrgForUser(ctx, orglifecycle.CreateOrgForUserInput{
+			UserID:              user.ID,
+			Name:                name,
+			IdempotencyKey:      key,
+			DefaultMachinePools: initialPools,
+		})
+		if err != nil {
+			t.Fatalf("create org %q: %v", name, err)
+		}
+		return created
+	}
+	orgA := createOrg("Defaults Org A", "defaults-org-a")
+	orgB := createOrg("Defaults Org B", "defaults-org-b")
+	failingOrg, successfulOrg := orgA, orgB
+	if failingOrg.Org.ID.String() > successfulOrg.Org.ID.String() {
+		failingOrg, successfulOrg = successfulOrg, failingOrg
+	}
+	if _, err := pool.Exec(ctx, `
+		UPDATE machine_pools
+		SET max_machine_memory_mb = 512
+		WHERE org_id = $1 AND name = $2
+	`, failingOrg.Org.ID, initialPools[1].Name); err != nil {
+		t.Fatalf("restrict failing org pool: %v", err)
+	}
+
+	desiredPools := append([]executionstore.DefaultMachinePoolTemplate(nil), initialPools...)
+	desiredPools[0].Description = "new"
+	desiredPools[1].DefaultMachineMemoryMB = intPtrForMachinePoolTest(1024)
+	input := orglifecycle.ReconcileDefaultsInput{Apply: true, DefaultMachinePools: desiredPools}
+	result, err := store.Organizations().ReconcileDefaults(ctx, input)
+	if err == nil || !strings.Contains(err.Error(), failingOrg.Org.ID.String()) {
+		t.Fatalf("partial apply error = %v, want failing org ID", err)
+	}
+	if len(result.Changes) != 2 {
+		t.Fatalf("partial apply changes = %v, want two successful-org changes", result.Changes)
+	}
+	for _, change := range result.Changes {
+		if !strings.Contains(change, successfulOrg.Org.ID.String()) {
+			t.Fatalf("partial apply change = %q, want successful org only", change)
+		}
+	}
+	queries := testQueries(store)
+	successfulPoolA, err := queries.GetMachinePoolByName(ctx, dbsqlc.GetMachinePoolByNameParams{
+		OrgID: successfulOrg.Org.ID, Name: initialPools[0].Name,
+	})
+	if err != nil {
+		t.Fatalf("get successful org pool: %v", err)
+	}
+	failingPoolA, err := queries.GetMachinePoolByName(ctx, dbsqlc.GetMachinePoolByNameParams{
+		OrgID: failingOrg.Org.ID, Name: initialPools[0].Name,
+	})
+	if err != nil {
+		t.Fatalf("get failing org pool: %v", err)
+	}
+	if successfulPoolA.Description != "new" || failingPoolA.Description != "old" {
+		t.Fatalf(
+			"pool descriptions after partial apply = successful %q, failing %q",
+			successfulPoolA.Description,
+			failingPoolA.Description,
+		)
+	}
+
+	if _, err := pool.Exec(ctx, `
+		UPDATE machine_pools
+		SET max_machine_memory_mb = 2048
+		WHERE org_id = $1 AND name = $2
+	`, failingOrg.Org.ID, initialPools[1].Name); err != nil {
+		t.Fatalf("restore failing org pool limit: %v", err)
+	}
+	result, err = store.Organizations().ReconcileDefaults(ctx, input)
+	if err != nil {
+		t.Fatalf("retry apply: %v", err)
+	}
+	if len(result.Changes) != 2 {
+		t.Fatalf("retry changes = %v, want two recovered-org changes", result.Changes)
+	}
+	for _, change := range result.Changes {
+		if !strings.Contains(change, failingOrg.Org.ID.String()) {
+			t.Fatalf("retry change = %q, want recovered org only", change)
+		}
+	}
+	result, err = store.Organizations().ReconcileDefaults(ctx, input)
+	if err != nil {
+		t.Fatalf("idempotent apply: %v", err)
+	}
+	if len(result.Changes) != 0 {
+		t.Fatalf("idempotent apply changes = %v, want none", result.Changes)
 	}
 }

--- a/internal/storage/default_reconciliation_integration_test.go
+++ b/internal/storage/default_reconciliation_integration_test.go
@@ -1,0 +1,286 @@
+//go:build integration
+
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/omnara-ai/omnara/internal/modelprotocol"
+	"github.com/omnara-ai/omnara/internal/storage/executionstore"
+	"github.com/omnara-ai/omnara/internal/storage/identitystore"
+	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
+	"github.com/omnara-ai/omnara/internal/storage/modelstore"
+	"github.com/omnara-ai/omnara/internal/storage/orglifecycle"
+)
+
+func TestReconcileDefaults(t *testing.T) {
+	ctx := context.Background()
+	pool := openIntegrationDB(t, ctx)
+	defer pool.Close()
+	store := newIntegrationStore(pool, WithMachinePoolProviders(mergingMachinePoolProviders{}))
+	user := mustCreateIdentityUser(t, ctx, store, "reconcile-defaults@example.com", "Defaults Owner")
+
+	initialPool := defaultMachinePoolTemplateWithDefaultMachineForTest(
+		executionstore.DefaultMachinePoolTemplate{
+			Name:               "hosted-pool",
+			Description:        "old pool",
+			Provider:           "blaxel",
+			ProviderAuthEnvVar: "RECONCILE_POOL_TOKEN",
+			MaxTotalMachines:   1,
+			MaxTotalMemoryMB:   intPtrForMachinePoolTest(1024),
+		},
+		defaultMachineFieldsForTest{
+			DefaultMachineCPU:             1,
+			DefaultMachineMemoryMB:        512,
+			DefaultMachineEnv:             json.RawMessage(`{"OLD":"value"}`),
+			DefaultMachineProviderOptions: json.RawMessage(`{"image":"old"}`),
+		},
+	)
+	initialProvider := modelstore.DefaultModelProviderTemplate{
+		Provisioner:          "openrouter",
+		Name:                 "omnara-openrouter",
+		CredentialSecretName: "omnara-openrouter-key",
+		APIFormat:            modelprotocol.APIFormatOpenAIChatCompletions,
+		APIVariant:           modelprotocol.APIVariantOpenRouter,
+		BaseURL:              "https://old.example.com/v1",
+		EndpointPath:         "/chat/completions",
+		AuthKind:             modelstore.ModelProviderAuthKindBearerToken,
+		Models: []modelstore.DefaultConfiguredModelTemplate{
+			{Name: "update-model", ProviderModelSlug: "example/old", ContextWindowTokens: 8192, MaxOutputTokens: 1024},
+			{Name: "remove-model", ProviderModelSlug: "example/remove", ContextWindowTokens: 8192, MaxOutputTokens: 1024},
+			{Name: "retained-model", ProviderModelSlug: "example/retain", ContextWindowTokens: 8192, MaxOutputTokens: 1024},
+		},
+	}
+	created, err := store.Organizations().CreateOrgForUser(ctx, orglifecycle.CreateOrgForUserInput{
+		UserID:              user.ID,
+		Name:                "Defaults Org",
+		IdempotencyKey:      "defaults-org",
+		DefaultMachinePools: []executionstore.DefaultMachinePoolTemplate{initialPool},
+		DefaultModelProvider: &modelstore.ProvisionedDefaultModelProvider{
+			Template: initialProvider, CredentialValue: "provider-token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	missingPool := initialPool
+	missingPool.Name = "missing-pool"
+	if _, err := store.Organizations().ReconcileDefaults(ctx, orglifecycle.ReconcileDefaultsInput{
+		DefaultMachinePools: []executionstore.DefaultMachinePoolTemplate{missingPool},
+	}); err == nil {
+		t.Fatal("plan with missing machine pool succeeded")
+	}
+	missingProvider := initialProvider
+	missingProvider.Name = "missing-provider"
+	if _, err := store.Organizations().ReconcileDefaults(ctx, orglifecycle.ReconcileDefaultsInput{
+		DefaultModelProvider: &missingProvider,
+	}); err == nil {
+		t.Fatal("plan with missing model provider succeeded")
+	}
+	providerDriftPool := initialPool
+	providerDriftPool.Provider = "unikraft"
+	if _, err := store.Organizations().ReconcileDefaults(ctx, orglifecycle.ReconcileDefaultsInput{
+		DefaultMachinePools: []executionstore.DefaultMachinePoolTemplate{providerDriftPool},
+	}); err == nil {
+		t.Fatal("plan with changed machine pool provider succeeded")
+	}
+	authEnvDriftPool := initialPool
+	authEnvDriftPool.ProviderAuthEnvVar = "OTHER_POOL_TOKEN"
+	if _, err := store.Organizations().ReconcileDefaults(ctx, orglifecycle.ReconcileDefaultsInput{
+		DefaultMachinePools: []executionstore.DefaultMachinePoolTemplate{authEnvDriftPool},
+	}); err == nil {
+		t.Fatal("plan with changed machine pool provider auth env var succeeded")
+	}
+	provider, err := store.Models().GetModelProviderConfigByName(ctx, created.Org.ID, initialProvider.Name)
+	if err != nil {
+		t.Fatalf("get provider: %v", err)
+	}
+	updateModel, err := store.Models().GetConfiguredModelByName(ctx, created.Org.ID, provider.ID, "update-model")
+	if err != nil {
+		t.Fatalf("get update model: %v", err)
+	}
+	updateModelGrant, err := store.Models().GetActiveProjectModelGrantForConfiguredModel(
+		ctx, created.Org.ID, created.Project.ID, updateModel.ID,
+	)
+	if err != nil {
+		t.Fatalf("get update model default grant: %v", err)
+	}
+	if _, err := store.Models().DeleteProjectModelGrant(
+		ctx, created.Org.ID, created.Project.ID, updateModelGrant.ID,
+	); err != nil {
+		t.Fatalf("delete update model default grant: %v", err)
+	}
+	removeModel, err := store.Models().GetConfiguredModelByName(ctx, created.Org.ID, provider.ID, "remove-model")
+	if err != nil {
+		t.Fatalf("get remove model: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO agent_configs(
+			org_id, project_id, configured_model_id, definition,
+			source_hash, effective_definition_hash, created_at
+		) VALUES ($1, $2, $3, '{}'::jsonb, 'historical-remove-model', 'historical-remove-model', statement_timestamp())
+	`, created.Org.ID, created.Project.ID, removeModel.ID); err != nil {
+		t.Fatalf("create historical agent config: %v", err)
+	}
+	retainedModel, err := store.Models().GetConfiguredModelByName(ctx, created.Org.ID, provider.ID, "retained-model")
+	if err != nil {
+		t.Fatalf("get retained model: %v", err)
+	}
+	manualProject, err := store.Identity().CreateProjectForPrincipal(ctx, identitystore.CreateProjectForPrincipalInput{
+		OrgID: created.Org.ID, Creator: userPrincipal(user.ID), Name: "Manual", IdempotencyKey: "manual",
+	})
+	if err != nil {
+		t.Fatalf("create manual project: %v", err)
+	}
+	if _, err := store.Models().CreateProjectModelGrant(ctx, modelstore.CreateProjectModelGrantInput{
+		OrgID: created.Org.ID, ProjectID: manualProject.ID, ConfiguredModelID: retainedModel.ID,
+	}); err != nil {
+		t.Fatalf("grant retained model: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		UPDATE machine_pools
+		SET max_total_machines = 8,
+		    max_total_cpu = 16,
+		    max_total_memory_mb = 8192,
+		    max_machine_cpu = 4,
+		    max_machine_memory_mb = 2048
+		WHERE org_id = $1
+	`, created.Org.ID); err != nil {
+		t.Fatalf("set pool limits: %v", err)
+	}
+	invalidPool := initialPool
+	invalidPool.DefaultMachineMemoryMB = intPtrForMachinePoolTest(4096)
+	if _, err := store.Organizations().ReconcileDefaults(ctx, orglifecycle.ReconcileDefaultsInput{
+		DefaultMachinePools: []executionstore.DefaultMachinePoolTemplate{invalidPool},
+	}); err == nil || !strings.Contains(err.Error(), "org "+created.Org.ID.String()+":") {
+		t.Fatalf("plan with incompatible pool limits error = %v, want org ID", err)
+	}
+
+	desiredPool := initialPool
+	desiredPool.Description = "new pool"
+	desiredPool.DefaultMachineEnv = json.RawMessage(`{"NEW":"value"}`)
+	desiredPool.DefaultMachineProviderOptions = json.RawMessage(`{"image":"new","sleep_after_ms":30000}`)
+	desiredPool.MaxTotalMachines = 0
+	desiredPool.MaxTotalCPU = intPtrForMachinePoolTest(1)
+	desiredPool.MaxTotalMemoryMB = intPtrForMachinePoolTest(0)
+	desiredPool.MaxMachineCPU = intPtrForMachinePoolTest(1)
+	desiredPool.MaxMachineMemoryMB = intPtrForMachinePoolTest(512)
+	desiredProvider := initialProvider
+	desiredProvider.BaseURL = "https://new.example.com/v1"
+	desiredProvider.RequestTimeoutMS = 120000
+	desiredProvider.Models = []modelstore.DefaultConfiguredModelTemplate{
+		{Name: "update-model", ProviderModelSlug: "example/new", ContextWindowTokens: 16384, MaxOutputTokens: 2048},
+		{Name: "add-model", ProviderModelSlug: "example/add", ContextWindowTokens: 8192, MaxOutputTokens: 1024},
+	}
+	input := orglifecycle.ReconcileDefaultsInput{
+		DefaultMachinePools:  []executionstore.DefaultMachinePoolTemplate{desiredPool},
+		DefaultModelProvider: &desiredProvider,
+	}
+	result, err := store.Organizations().ReconcileDefaults(ctx, input)
+	if err != nil {
+		t.Fatalf("plan defaults: %v", err)
+	}
+	if len(result.Changes) == 0 {
+		t.Fatal("plan reported no changes")
+	}
+
+	input.Apply = true
+	if _, err := store.Organizations().ReconcileDefaults(ctx, input); err != nil {
+		t.Fatalf("apply defaults: %v", err)
+	}
+	poolRecord, err := testQueries(store).GetMachinePoolByName(ctx, dbsqlc.GetMachinePoolByNameParams{
+		OrgID: created.Org.ID, Name: desiredPool.Name,
+	})
+	if err != nil {
+		t.Fatalf("get machine pool: %v", err)
+	}
+	if poolRecord.Description != desiredPool.Description ||
+		poolRecord.MaxTotalMachines != 8 ||
+		poolRecord.MaxTotalCpu == nil || *poolRecord.MaxTotalCpu != 16 ||
+		poolRecord.MaxTotalMemoryMb == nil || *poolRecord.MaxTotalMemoryMb != 8192 ||
+		poolRecord.MaxMachineCpu == nil || *poolRecord.MaxMachineCpu != 4 ||
+		poolRecord.MaxMachineMemoryMb == nil || *poolRecord.MaxMachineMemoryMb != 2048 {
+		t.Fatalf("unexpected reconciled pool: %+v", poolRecord)
+	}
+	assertJSONRawEqual(t, poolRecord.DefaultMachineEnv, string(desiredPool.DefaultMachineEnv))
+	assertJSONRawEqual(t, poolRecord.DefaultMachineProviderOptions, string(desiredPool.DefaultMachineProviderOptions))
+
+	reconciledProvider, err := store.Models().GetModelProviderConfigByName(ctx, created.Org.ID, desiredProvider.Name)
+	if err != nil {
+		t.Fatalf("get reconciled provider: %v", err)
+	}
+	if reconciledProvider.BaseURL != desiredProvider.BaseURL || reconciledProvider.RequestTimeoutMS != 120000 ||
+		reconciledProvider.CredentialSecretID != provider.CredentialSecretID {
+		t.Fatalf("unexpected reconciled provider: %+v", reconciledProvider)
+	}
+	updatedModel, err := store.Models().GetConfiguredModelByName(ctx, created.Org.ID, provider.ID, "update-model")
+	if err != nil || updatedModel.ProviderModelSlug != "example/new" || updatedModel.MaxOutputTokens != 2048 {
+		t.Fatalf("unexpected updated model: %+v, err %v", updatedModel, err)
+	}
+	if _, err := store.Models().GetActiveProjectModelGrantForConfiguredModel(
+		ctx, created.Org.ID, created.Project.ID, updatedModel.ID,
+	); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("get update model default grant error = %v, want no rows", err)
+	}
+	addedModel, err := store.Models().GetConfiguredModelByName(ctx, created.Org.ID, provider.ID, "add-model")
+	if err != nil {
+		t.Fatalf("get added model: %v", err)
+	}
+	if _, err := store.Models().GetActiveProjectModelGrantForConfiguredModel(
+		ctx, created.Org.ID, created.Project.ID, addedModel.ID,
+	); err != nil {
+		t.Fatalf("get added model default grant: %v", err)
+	}
+	if _, err := store.Models().GetConfiguredModelByName(ctx, created.Org.ID, provider.ID, "remove-model"); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("get removed model error = %v, want no rows", err)
+	}
+	if _, err := store.Models().GetActiveProjectModelGrantForConfiguredModel(
+		ctx, created.Org.ID, created.Project.ID, retainedModel.ID,
+	); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("get retained model default grant error = %v, want no rows", err)
+	}
+	if _, err := store.Models().GetActiveProjectModelGrantForConfiguredModel(
+		ctx, created.Org.ID, manualProject.ID, retainedModel.ID,
+	); err != nil {
+		t.Fatalf("get retained model manual grant: %v", err)
+	}
+
+	result, err = store.Organizations().ReconcileDefaults(ctx, input)
+	if err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	if len(result.Changes) != 0 || len(result.Warnings) != 1 {
+		t.Fatalf("second apply result = %+v, want only retained-model warning", result)
+	}
+	if _, err := store.Organizations().DeleteProject(
+		ctx,
+		created.Org.ID,
+		created.Project.ID,
+		userPrincipal(user.ID),
+	); err != nil {
+		t.Fatalf("delete default project: %v", err)
+	}
+	desiredPool.Description = "pool without default project"
+	input.DefaultMachinePools = []executionstore.DefaultMachinePoolTemplate{desiredPool}
+	result, err = store.Organizations().ReconcileDefaults(ctx, input)
+	if err != nil {
+		t.Fatalf("apply without default project: %v", err)
+	}
+	if len(result.Changes) != 1 || len(result.Warnings) != 1 {
+		t.Fatalf("apply without default project result = %+v, want pool change and warning", result)
+	}
+	poolRecord, err = testQueries(store).GetMachinePoolByName(ctx, dbsqlc.GetMachinePoolByNameParams{
+		OrgID: created.Org.ID, Name: desiredPool.Name,
+	})
+	if err != nil {
+		t.Fatalf("get machine pool after default project deletion: %v", err)
+	}
+	if poolRecord.Description != desiredPool.Description {
+		t.Fatalf("machine pool description = %q, want %q", poolRecord.Description, desiredPool.Description)
+	}
+}

--- a/internal/storage/executionstore/default_reconciliation.go
+++ b/internal/storage/executionstore/default_reconciliation.go
@@ -12,26 +12,17 @@ func (s *Store) ReconcileDefaultMachinePoolsTx(
 	ctx context.Context,
 	tx pgx.Tx,
 	templates []DefaultMachinePoolTemplate,
+	rows []dbsqlc.MachinePool,
 	apply bool,
 ) ([]string, error) {
 	qtx := s.q.WithTx(tx)
 	var changes []string
 	for _, template := range templates {
-		if err := ValidateDefaultMachinePoolTemplate(template); err != nil {
-			return nil, fmt.Errorf("default machine pool: %w", err)
-		}
 		name := template.createInput(NilID).Name
-		rows, err := qtx.ListClusterManagedMachinePoolsByName(
-			ctx,
-			dbsqlc.ListClusterManagedMachinePoolsByNameParams{Name: name},
-		)
-		if err != nil {
-			return nil, fmt.Errorf("list default machine pools %q: %w", name, err)
-		}
-		if len(rows) == 0 {
-			return nil, fmt.Errorf("no cluster-managed machine pools named %q", name)
-		}
 		for _, row := range rows {
+			if row.Name != name {
+				continue
+			}
 			current := machinePoolRecordFromSQLC(row)
 			if apply {
 				locked, err := qtx.LockMachinePoolForUpdate(
@@ -51,17 +42,16 @@ func (s *Store) ReconcileDefaultMachinePoolsTx(
 			desired.MaxMachineMemoryMB = current.MaxMachineMemoryMB
 			if current.Provider != desired.Provider || current.ProviderAuthEnvVar != desired.ProviderAuthEnvVar {
 				return nil, fmt.Errorf(
-					"org %s: default machine pool %q cannot change provider or provider_auth_env_var",
-					current.OrgID,
+					"default machine pool %q cannot change provider or provider_auth_env_var",
 					name,
 				)
 			}
 			poolDefaults, err := prepareMachinePoolCreateInput(&desired)
 			if err != nil {
-				return nil, fmt.Errorf("org %s: default machine pool %q: %w", current.OrgID, name, err)
+				return nil, fmt.Errorf("default machine pool %q: %w", name, err)
 			}
 			if err := s.validatePoolDefaultsTx(ctx, qtx, desired, poolDefaults); err != nil {
-				return nil, fmt.Errorf("org %s: default machine pool %q: %w", current.OrgID, name, err)
+				return nil, fmt.Errorf("default machine pool %q: %w", name, err)
 			}
 			if sameMachinePoolIntent(current, desired) {
 				continue
@@ -70,6 +60,16 @@ func (s *Store) ReconcileDefaultMachinePoolsTx(
 			if apply {
 				if _, err := updateMachinePoolRow(ctx, qtx, current.ID, desired); err != nil {
 					return nil, fmt.Errorf("update default machine pool %q: %w", name, err)
+				}
+				if current.RuntimeProtectionEnabled != desired.RuntimeProtectionEnabled {
+					if err := qtx.ClearMachinePoolRuntimeMismatch(
+						ctx,
+						dbsqlc.ClearMachinePoolRuntimeMismatchParams{
+							OrgID: current.OrgID, MachinePoolID: current.ID,
+						},
+					); err != nil {
+						return nil, fmt.Errorf("clear machine pool runtime mismatch: %w", err)
+					}
 				}
 			}
 		}

--- a/internal/storage/executionstore/default_reconciliation.go
+++ b/internal/storage/executionstore/default_reconciliation.go
@@ -1,0 +1,78 @@
+package executionstore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
+)
+
+func (s *Store) ReconcileDefaultMachinePoolsTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	templates []DefaultMachinePoolTemplate,
+	apply bool,
+) ([]string, error) {
+	qtx := s.q.WithTx(tx)
+	var changes []string
+	for _, template := range templates {
+		if err := ValidateDefaultMachinePoolTemplate(template); err != nil {
+			return nil, fmt.Errorf("default machine pool: %w", err)
+		}
+		name := template.createInput(NilID).Name
+		rows, err := qtx.ListClusterManagedMachinePoolsByName(
+			ctx,
+			dbsqlc.ListClusterManagedMachinePoolsByNameParams{Name: name},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("list default machine pools %q: %w", name, err)
+		}
+		if len(rows) == 0 {
+			return nil, fmt.Errorf("no cluster-managed machine pools named %q", name)
+		}
+		for _, row := range rows {
+			current := machinePoolRecordFromSQLC(row)
+			if apply {
+				locked, err := qtx.LockMachinePoolForUpdate(
+					ctx,
+					dbsqlc.LockMachinePoolForUpdateParams{OrgID: current.OrgID, ID: current.ID},
+				)
+				if err != nil {
+					return nil, fmt.Errorf("lock default machine pool %q: %w", name, err)
+				}
+				current = machinePoolRecordFromSQLC(locked)
+			}
+			desired := template.createInput(current.OrgID)
+			desired.MaxTotalMachines = current.MaxTotalMachines
+			desired.MaxTotalCPU = current.MaxTotalCPU
+			desired.MaxTotalMemoryMB = current.MaxTotalMemoryMB
+			desired.MaxMachineCPU = current.MaxMachineCPU
+			desired.MaxMachineMemoryMB = current.MaxMachineMemoryMB
+			if current.Provider != desired.Provider || current.ProviderAuthEnvVar != desired.ProviderAuthEnvVar {
+				return nil, fmt.Errorf(
+					"org %s: default machine pool %q cannot change provider or provider_auth_env_var",
+					current.OrgID,
+					name,
+				)
+			}
+			poolDefaults, err := prepareMachinePoolCreateInput(&desired)
+			if err != nil {
+				return nil, fmt.Errorf("org %s: default machine pool %q: %w", current.OrgID, name, err)
+			}
+			if err := s.validatePoolDefaultsTx(ctx, qtx, desired, poolDefaults); err != nil {
+				return nil, fmt.Errorf("org %s: default machine pool %q: %w", current.OrgID, name, err)
+			}
+			if sameMachinePoolIntent(current, desired) {
+				continue
+			}
+			changes = append(changes, fmt.Sprintf("org %s: update machine pool %q", current.OrgID, name))
+			if apply {
+				if _, err := updateMachinePoolRow(ctx, qtx, current.ID, desired); err != nil {
+					return nil, fmt.Errorf("update default machine pool %q: %w", name, err)
+				}
+			}
+		}
+	}
+	return changes, nil
+}

--- a/internal/storage/executionstore/machine_pools_store.go
+++ b/internal/storage/executionstore/machine_pools_store.go
@@ -325,34 +325,38 @@ func (s *Store) CreateMachinePool(
 	if record.DeletedAt != nil {
 		return MachinePoolRecord{}, storeerr.ErrIdempotencyConflict
 	}
-	if record.Name != input.Name ||
-		record.ManagementKind != input.ManagementKind ||
-		record.Description != input.Description ||
-		record.Provider != input.Provider ||
-		!sameIntPtr(record.DefaultMachineCPU, input.DefaultMachineCPU) ||
-		!sameIntPtr(record.DefaultMachineMemoryMB, input.DefaultMachineMemoryMB) ||
-		!sameJSON(record.DefaultMachineEnv, input.DefaultMachineEnv) ||
-		!sameJSON(record.DefaultMachineSecretEnv, input.DefaultMachineSecretEnv) ||
-		!sameJSON(record.DefaultMachineProviderOptions, input.DefaultMachineProviderOptions) ||
-		record.DefaultCwd != input.DefaultCwd ||
-		!sameJSON(record.ProviderConfig, input.ProviderConfig) ||
-		record.ProviderAuthSecretID != input.ProviderAuthSecretID ||
-		record.ProviderAuthEnvVar != input.ProviderAuthEnvVar ||
-		record.RuntimeProtectionEnabled != input.RuntimeProtectionEnabled ||
-		record.MaxTotalMachines != input.MaxTotalMachines ||
-		!sameIntPtr(record.MaxTotalCPU, input.MaxTotalCPU) ||
-		!sameIntPtr(record.MaxTotalMemoryMB, input.MaxTotalMemoryMB) ||
-		!sameIntPtr(record.MinMachineCPU, input.MinMachineCPU) ||
-		!sameIntPtr(record.MinMachineMemoryMB, input.MinMachineMemoryMB) ||
-		!sameIntPtr(record.MaxMachineCPU, input.MaxMachineCPU) ||
-		!sameIntPtr(record.MaxMachineMemoryMB, input.MaxMachineMemoryMB) ||
-		!sameJSON(record.Metadata, input.Metadata) {
+	if !sameMachinePoolIntent(record, input) {
 		return MachinePoolRecord{}, storeerr.ErrIdempotencyConflict
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return MachinePoolRecord{}, fmt.Errorf("commit replay create machine pool: %w", err)
 	}
 	return record, nil
+}
+
+func sameMachinePoolIntent(record MachinePoolRecord, input CreateMachinePoolInput) bool {
+	return record.Name == input.Name &&
+		record.ManagementKind == input.ManagementKind &&
+		record.Description == input.Description &&
+		record.Provider == input.Provider &&
+		sameIntPtr(record.DefaultMachineCPU, input.DefaultMachineCPU) &&
+		sameIntPtr(record.DefaultMachineMemoryMB, input.DefaultMachineMemoryMB) &&
+		sameJSON(record.DefaultMachineEnv, input.DefaultMachineEnv) &&
+		sameJSON(record.DefaultMachineSecretEnv, input.DefaultMachineSecretEnv) &&
+		sameJSON(record.DefaultMachineProviderOptions, input.DefaultMachineProviderOptions) &&
+		record.DefaultCwd == input.DefaultCwd &&
+		sameJSON(record.ProviderConfig, input.ProviderConfig) &&
+		record.ProviderAuthSecretID == input.ProviderAuthSecretID &&
+		record.ProviderAuthEnvVar == input.ProviderAuthEnvVar &&
+		record.RuntimeProtectionEnabled == input.RuntimeProtectionEnabled &&
+		record.MaxTotalMachines == input.MaxTotalMachines &&
+		sameIntPtr(record.MaxTotalCPU, input.MaxTotalCPU) &&
+		sameIntPtr(record.MaxTotalMemoryMB, input.MaxTotalMemoryMB) &&
+		sameIntPtr(record.MinMachineCPU, input.MinMachineCPU) &&
+		sameIntPtr(record.MinMachineMemoryMB, input.MinMachineMemoryMB) &&
+		sameIntPtr(record.MaxMachineCPU, input.MaxMachineCPU) &&
+		sameIntPtr(record.MaxMachineMemoryMB, input.MaxMachineMemoryMB) &&
+		sameJSON(record.Metadata, input.Metadata)
 }
 
 func prepareMachinePoolCreateInput(
@@ -685,29 +689,7 @@ func (s *Store) UpdateMachinePool(
 	if err := s.validatePoolDefaultsTx(ctx, qtx, merged, poolDefaults); err != nil {
 		return MachinePoolRecord{}, err
 	}
-	row, err := qtx.UpdateMachinePool(ctx, dbsqlc.UpdateMachinePoolParams{
-		OrgID:                         input.OrgID,
-		ID:                            input.ID,
-		Name:                          merged.Name,
-		Description:                   merged.Description,
-		DefaultMachineCpu:             sqlcInt32Ptr(merged.DefaultMachineCPU),
-		DefaultMachineMemoryMb:        sqlcInt32Ptr(merged.DefaultMachineMemoryMB),
-		DefaultMachineEnv:             merged.DefaultMachineEnv,
-		DefaultMachineSecretEnv:       merged.DefaultMachineSecretEnv,
-		DefaultMachineProviderOptions: merged.DefaultMachineProviderOptions,
-		DefaultCwd:                    merged.DefaultCwd,
-		ProviderConfig:                merged.ProviderConfig,
-		ProviderAuthSecretID:          sqlcIDFromNil(merged.ProviderAuthSecretID),
-		RuntimeProtectionEnabled:      merged.RuntimeProtectionEnabled,
-		MaxTotalMachines:              merged.MaxTotalMachines,
-		MaxTotalCpu:                   sqlcInt32Ptr(merged.MaxTotalCPU),
-		MaxTotalMemoryMb:              sqlcInt32Ptr(merged.MaxTotalMemoryMB),
-		MinMachineCpu:                 sqlcInt32Ptr(merged.MinMachineCPU),
-		MinMachineMemoryMb:            sqlcInt32Ptr(merged.MinMachineMemoryMB),
-		MaxMachineCpu:                 sqlcInt32Ptr(merged.MaxMachineCPU),
-		MaxMachineMemoryMb:            sqlcInt32Ptr(merged.MaxMachineMemoryMB),
-		Metadata:                      merged.Metadata,
-	})
+	row, err := updateMachinePoolRow(ctx, qtx, input.ID, merged)
 	if err != nil {
 		if storeutil.IsUniqueViolation(err) {
 			return MachinePoolRecord{}, storeerr.ErrConflict
@@ -727,6 +709,38 @@ func (s *Store) UpdateMachinePool(
 		return MachinePoolRecord{}, fmt.Errorf("commit update machine pool: %w", err)
 	}
 	return record, nil
+}
+
+func updateMachinePoolRow(
+	ctx context.Context,
+	qtx *dbsqlc.Queries,
+	id ID,
+	input CreateMachinePoolInput,
+) (dbsqlc.MachinePool, error) {
+	return qtx.UpdateMachinePool(ctx, dbsqlc.UpdateMachinePoolParams{
+		OrgID:                         input.OrgID,
+		ID:                            id,
+		ManagementKind:                string(input.ManagementKind),
+		Name:                          input.Name,
+		Description:                   input.Description,
+		DefaultMachineCpu:             sqlcInt32Ptr(input.DefaultMachineCPU),
+		DefaultMachineMemoryMb:        sqlcInt32Ptr(input.DefaultMachineMemoryMB),
+		DefaultMachineEnv:             input.DefaultMachineEnv,
+		DefaultMachineSecretEnv:       input.DefaultMachineSecretEnv,
+		DefaultMachineProviderOptions: input.DefaultMachineProviderOptions,
+		DefaultCwd:                    input.DefaultCwd,
+		ProviderConfig:                input.ProviderConfig,
+		ProviderAuthSecretID:          sqlcIDFromNil(input.ProviderAuthSecretID),
+		RuntimeProtectionEnabled:      input.RuntimeProtectionEnabled,
+		MaxTotalMachines:              input.MaxTotalMachines,
+		MaxTotalCpu:                   sqlcInt32Ptr(input.MaxTotalCPU),
+		MaxTotalMemoryMb:              sqlcInt32Ptr(input.MaxTotalMemoryMB),
+		MinMachineCpu:                 sqlcInt32Ptr(input.MinMachineCPU),
+		MinMachineMemoryMb:            sqlcInt32Ptr(input.MinMachineMemoryMB),
+		MaxMachineCpu:                 sqlcInt32Ptr(input.MaxMachineCPU),
+		MaxMachineMemoryMb:            sqlcInt32Ptr(input.MaxMachineMemoryMB),
+		Metadata:                      input.Metadata,
+	})
 }
 
 func (s *Store) GetMachinePool(ctx context.Context, orgID, id ID) (MachinePoolRecord, error) {

--- a/internal/storage/executionstore/machine_pools_store.go
+++ b/internal/storage/executionstore/machine_pools_store.go
@@ -253,13 +253,35 @@ func (defaultPoolTemplate DefaultMachinePoolTemplate) createInput(orgID ID) Crea
 	}
 }
 
-func ValidateDefaultMachinePoolTemplate(defaultPoolTemplate DefaultMachinePoolTemplate) error {
+func ValidateDefaultMachinePoolTemplate(
+	defaultPoolTemplate DefaultMachinePoolTemplate,
+	machinePoolProviders MachinePoolProviders,
+) error {
 	input := defaultPoolTemplate.createInput(NilID)
 	if input.Name == "" {
 		return errors.New("name is required")
 	}
-	_, err := prepareMachinePoolConfigInput(&input)
-	return err
+	defaults, err := prepareMachinePoolConfigInput(&input)
+	if err != nil {
+		return err
+	}
+	return machinePoolProviders.ValidatePool(input.Provider, MachinePoolProviderPolicy{
+		DefaultProvisioning:      defaults.Provisioning,
+		RuntimeProtectionEnabled: input.RuntimeProtectionEnabled,
+		ResourceLimits: MachineResourceLimits{
+			MaxTotalCPU:        input.MaxTotalCPU,
+			MaxTotalMemoryMB:   input.MaxTotalMemoryMB,
+			MinMachineCPU:      input.MinMachineCPU,
+			MinMachineMemoryMB: input.MinMachineMemoryMB,
+			MaxMachineCPU:      input.MaxMachineCPU,
+			MaxMachineMemoryMB: input.MaxMachineMemoryMB,
+		},
+		ProviderConfig: input.ProviderConfig,
+	})
+}
+
+func (s *Store) ValidateDefaultMachinePoolTemplate(template DefaultMachinePoolTemplate) error {
+	return ValidateDefaultMachinePoolTemplate(template, s.machinePoolProviders)
 }
 
 func (s *Store) CreateMachinePool(

--- a/internal/storage/identitystore/orgs_projects_store.go
+++ b/internal/storage/identitystore/orgs_projects_store.go
@@ -18,7 +18,7 @@ const (
 	MaxOwnedOrgsPerUser      = 100
 	MaxOrgMembershipsPerUser = 1000
 	defaultProjectName       = "Default"
-	defaultProjectKey        = "default"
+	DefaultProjectKey        = "default"
 	resourceProjects         = "projects"
 	MaxActiveProjectsPerOrg  = int64(100)
 )
@@ -149,7 +149,7 @@ func (s *Store) ProvisionOrganizationTx(
 	projectRow, err := qtx.CreateProject(ctx, dbsqlc.CreateProjectParams{
 		OrgID:          org.ID,
 		Name:           defaultProjectName,
-		IdempotencyKey: storeutil.TextFromEmpty(defaultProjectKey),
+		IdempotencyKey: storeutil.TextFromEmpty(DefaultProjectKey),
 	})
 	var project ProjectRecord
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -157,7 +157,7 @@ func (s *Store) ProvisionOrganizationTx(
 			ctx,
 			dbsqlc.GetProjectByIdempotencyKeyParams{
 				OrgID:          org.ID,
-				IdempotencyKey: defaultProjectKey,
+				IdempotencyKey: DefaultProjectKey,
 			},
 		)
 		if errors.Is(loadErr, pgx.ErrNoRows) {

--- a/internal/storage/internal/dbsqlc/execution_resources.sql.go
+++ b/internal/storage/internal/dbsqlc/execution_resources.sql.go
@@ -1583,6 +1583,65 @@ func (q *Queries) ListClusterManagedMachinePools(ctx context.Context, arg ListCl
 	return items, nil
 }
 
+const listClusterManagedMachinePoolsByName = `-- name: ListClusterManagedMachinePoolsByName :many
+SELECT id, org_id, name, management_kind, description, provider, default_machine_cpu, default_machine_memory_mb, default_machine_env, default_machine_secret_env, default_machine_provider_options, default_cwd, provider_config, provider_auth_secret_id, provider_auth_env_var, max_total_machines, max_total_cpu, max_total_memory_mb, max_machine_cpu, max_machine_memory_mb, metadata, deleted_at, created_at, updated_at, runtime_protection_enabled, min_machine_cpu, min_machine_memory_mb
+FROM machine_pools
+WHERE name = $1 AND management_kind = 'cluster' AND deleted_at IS NULL
+ORDER BY org_id, id
+`
+
+type ListClusterManagedMachinePoolsByNameParams struct {
+	Name string
+}
+
+func (q *Queries) ListClusterManagedMachinePoolsByName(ctx context.Context, arg ListClusterManagedMachinePoolsByNameParams) ([]MachinePool, error) {
+	rows, err := q.db.Query(ctx, listClusterManagedMachinePoolsByName, arg.Name)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []MachinePool{}
+	for rows.Next() {
+		var i MachinePool
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrgID,
+			&i.Name,
+			&i.ManagementKind,
+			&i.Description,
+			&i.Provider,
+			&i.DefaultMachineCpu,
+			&i.DefaultMachineMemoryMb,
+			&i.DefaultMachineEnv,
+			&i.DefaultMachineSecretEnv,
+			&i.DefaultMachineProviderOptions,
+			&i.DefaultCwd,
+			&i.ProviderConfig,
+			&i.ProviderAuthSecretID,
+			&i.ProviderAuthEnvVar,
+			&i.MaxTotalMachines,
+			&i.MaxTotalCpu,
+			&i.MaxTotalMemoryMb,
+			&i.MaxMachineCpu,
+			&i.MaxMachineMemoryMb,
+			&i.Metadata,
+			&i.DeletedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.RuntimeProtectionEnabled,
+			&i.MinMachineCpu,
+			&i.MinMachineMemoryMb,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listMachinePools = `-- name: ListMachinePools :many
 SELECT id, org_id, name, management_kind, description, provider, default_machine_cpu,
        default_machine_memory_mb, default_machine_env, default_machine_secret_env,
@@ -2642,7 +2701,7 @@ SET name = $1,
     updated_at = statement_timestamp()
 WHERE org_id = $20
   AND id = $21
-  AND management_kind = 'tenant'
+  AND management_kind = $22
   AND deleted_at IS NULL
 RETURNING id, org_id, name, management_kind, description, provider, default_machine_cpu, default_machine_memory_mb, default_machine_env, default_machine_secret_env, default_machine_provider_options, default_cwd, provider_config, provider_auth_secret_id, provider_auth_env_var, max_total_machines, max_total_cpu, max_total_memory_mb, max_machine_cpu, max_machine_memory_mb, metadata, deleted_at, created_at, updated_at, runtime_protection_enabled, min_machine_cpu, min_machine_memory_mb
 `
@@ -2669,6 +2728,7 @@ type UpdateMachinePoolParams struct {
 	Metadata                      json.RawMessage
 	OrgID                         uuid.UUID
 	ID                            uuid.UUID
+	ManagementKind                string
 }
 
 func (q *Queries) UpdateMachinePool(ctx context.Context, arg UpdateMachinePoolParams) (MachinePool, error) {
@@ -2694,6 +2754,7 @@ func (q *Queries) UpdateMachinePool(ctx context.Context, arg UpdateMachinePoolPa
 		arg.Metadata,
 		arg.OrgID,
 		arg.ID,
+		arg.ManagementKind,
 	)
 	var i MachinePool
 	err := row.Scan(

--- a/internal/storage/internal/dbsqlc/model_provider_configs.sql.go
+++ b/internal/storage/internal/dbsqlc/model_provider_configs.sql.go
@@ -46,19 +46,20 @@ WHERE configured_models.org_id = $1
     FROM model_provider_configs provider_config
     WHERE provider_config.org_id = configured_models.org_id
       AND provider_config.id = configured_models.model_provider_config_id
-      AND provider_config.management_kind = 'tenant'
+      AND provider_config.management_kind = $3
   )
 RETURNING id, org_id, model_provider_config_id, name, current_revision_id,
           deleted_at, created_at, updated_at
 `
 
 type DeleteConfiguredModelParams struct {
-	OrgID uuid.UUID
-	ID    uuid.UUID
+	OrgID          uuid.UUID
+	ID             uuid.UUID
+	ManagementKind string
 }
 
 func (q *Queries) DeleteConfiguredModel(ctx context.Context, arg DeleteConfiguredModelParams) (ConfiguredModel, error) {
-	row := q.db.QueryRow(ctx, deleteConfiguredModel, arg.OrgID, arg.ID)
+	row := q.db.QueryRow(ctx, deleteConfiguredModel, arg.OrgID, arg.ID, arg.ManagementKind)
 	var i ConfiguredModel
 	err := row.Scan(
 		&i.ID,
@@ -594,6 +595,36 @@ func (q *Queries) GetConfiguredModelRevisionForUse(ctx context.Context, arg GetC
 	return i, err
 }
 
+const getDefaultConfiguredModelRemovalState = `-- name: GetDefaultConfiguredModelRemovalState :one
+SELECT EXISTS (
+         SELECT 1 FROM project_model_grants model_grant
+         WHERE model_grant.configured_model_id = $1
+           AND model_grant.project_id = $2
+       ) AS granted_to_default_project,
+       EXISTS (
+         SELECT 1 FROM project_model_grants model_grant
+         WHERE model_grant.configured_model_id = $1
+           AND model_grant.project_id <> $2
+       ) AS granted_to_other_project
+`
+
+type GetDefaultConfiguredModelRemovalStateParams struct {
+	TargetConfiguredModelID uuid.UUID
+	DefaultProjectID        uuid.UUID
+}
+
+type GetDefaultConfiguredModelRemovalStateRow struct {
+	GrantedToDefaultProject bool
+	GrantedToOtherProject   bool
+}
+
+func (q *Queries) GetDefaultConfiguredModelRemovalState(ctx context.Context, arg GetDefaultConfiguredModelRemovalStateParams) (GetDefaultConfiguredModelRemovalStateRow, error) {
+	row := q.db.QueryRow(ctx, getDefaultConfiguredModelRemovalState, arg.TargetConfiguredModelID, arg.DefaultProjectID)
+	var i GetDefaultConfiguredModelRemovalStateRow
+	err := row.Scan(&i.GrantedToDefaultProject, &i.GrantedToOtherProject)
+	return i, err
+}
+
 const getModelProviderConfig = `-- name: GetModelProviderConfig :one
 SELECT id, org_id, management_kind, name, api_format, api_variant, base_url, endpoint_path,
        request_timeout_ms, auth_kind, auth_options,
@@ -956,6 +987,57 @@ func (q *Queries) InsertModelProviderConfig(ctx context.Context, arg InsertModel
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const listClusterManagedModelProviderConfigsByName = `-- name: ListClusterManagedModelProviderConfigsByName :many
+SELECT id, org_id, management_kind, name, api_format, api_variant, base_url, endpoint_path,
+       request_timeout_ms, auth_kind, auth_options,
+       credential_secret_id, deleted_at, created_at, updated_at
+FROM model_provider_configs
+WHERE name = $1
+  AND management_kind = 'cluster'
+  AND deleted_at IS NULL
+ORDER BY org_id, id
+`
+
+type ListClusterManagedModelProviderConfigsByNameParams struct {
+	Name string
+}
+
+func (q *Queries) ListClusterManagedModelProviderConfigsByName(ctx context.Context, arg ListClusterManagedModelProviderConfigsByNameParams) ([]ModelProviderConfig, error) {
+	rows, err := q.db.Query(ctx, listClusterManagedModelProviderConfigsByName, arg.Name)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ModelProviderConfig{}
+	for rows.Next() {
+		var i ModelProviderConfig
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrgID,
+			&i.ManagementKind,
+			&i.Name,
+			&i.ApiFormat,
+			&i.ApiVariant,
+			&i.BaseUrl,
+			&i.EndpointPath,
+			&i.RequestTimeoutMs,
+			&i.AuthKind,
+			&i.AuthOptions,
+			&i.CredentialSecretID,
+			&i.DeletedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listConfiguredModels = `-- name: ListConfiguredModels :many
@@ -1647,11 +1729,11 @@ WITH target_configured_model AS (
   FROM configured_models configured_model
   JOIN model_provider_configs provider_config ON provider_config.org_id = configured_model.org_id
     AND provider_config.id = configured_model.model_provider_config_id
-    AND provider_config.management_kind = 'tenant'
+    AND provider_config.management_kind = $1
     AND provider_config.deleted_at IS NULL
-  WHERE configured_model.org_id = $1
-    AND configured_model.model_provider_config_id = $2
-    AND configured_model.id = $3
+  WHERE configured_model.org_id = $2
+    AND configured_model.model_provider_config_id = $3
+    AND configured_model.id = $4
     AND configured_model.deleted_at IS NULL
 ),
 revision AS (
@@ -1663,14 +1745,14 @@ revision AS (
         api_variant_options, created_at
   )
   SELECT target_configured_model.org_id, target_configured_model.id,
-         target_configured_model.model_provider_config_id, $4,
-         $5, $6,
-         $7,
-         $8, $9::bool,
-         $10::bool, $11::text,
-             $12::text[],
-             $13::text[], $14::text[],
-             $15, statement_timestamp()
+         target_configured_model.model_provider_config_id, $5,
+         $6, $7,
+         $8,
+         $9, $10::bool,
+         $11::bool, $12::text,
+             $13::text[],
+             $14::text[], $15::text[],
+             $16, statement_timestamp()
   FROM target_configured_model
   RETURNING id, org_id, configured_model_id, model_provider_config_id,
             provider_model_slug, context_window_tokens, max_output_tokens,
@@ -1681,7 +1763,7 @@ revision AS (
 ),
 configured_model AS (
   UPDATE configured_models
-  SET name = $16,
+  SET name = $17,
       current_revision_id = revision.id,
       updated_at = revision.created_at
   FROM revision
@@ -1706,6 +1788,7 @@ JOIN revision ON revision.configured_model_id = configured_model.id
 `
 
 type UpdateConfiguredModelParams struct {
+	ManagementKind            string
 	OrgID                     uuid.UUID
 	ModelProviderConfigID     uuid.UUID
 	ID                        uuid.UUID
@@ -1750,6 +1833,7 @@ type UpdateConfiguredModelRow struct {
 
 func (q *Queries) UpdateConfiguredModel(ctx context.Context, arg UpdateConfiguredModelParams) (UpdateConfiguredModelRow, error) {
 	row := q.db.QueryRow(ctx, updateConfiguredModel,
+		arg.ManagementKind,
 		arg.OrgID,
 		arg.ModelProviderConfigID,
 		arg.ID,
@@ -1807,7 +1891,7 @@ FROM secrets credential
 WHERE config.org_id = $7
   AND config.id = $8
   AND config.deleted_at IS NULL
-  AND config.management_kind = 'tenant'
+  AND config.management_kind = $9
   AND credential.org_id = config.org_id
   AND credential.id = $6
   AND credential.management_kind = config.management_kind
@@ -1830,6 +1914,7 @@ type UpdateModelProviderConfigParams struct {
 	CredentialSecretID *uuid.UUID
 	OrgID              uuid.UUID
 	ID                 uuid.UUID
+	ManagementKind     string
 }
 
 func (q *Queries) UpdateModelProviderConfig(ctx context.Context, arg UpdateModelProviderConfigParams) (ModelProviderConfig, error) {
@@ -1842,6 +1927,7 @@ func (q *Queries) UpdateModelProviderConfig(ctx context.Context, arg UpdateModel
 		arg.CredentialSecretID,
 		arg.OrgID,
 		arg.ID,
+		arg.ManagementKind,
 	)
 	var i ModelProviderConfig
 	err := row.Scan(

--- a/internal/storage/modelstore/configured_models_store.go
+++ b/internal/storage/modelstore/configured_models_store.go
@@ -226,7 +226,7 @@ func (s *Store) PatchConfiguredModel(
 		}
 		return record, nil
 	}
-	record, err := updateConfiguredModelTx(ctx, qtx, update)
+	record, err := updateConfiguredModelTx(ctx, qtx, update, management.Tenant)
 	if err != nil {
 		return ConfiguredModelRecord{}, err
 	}
@@ -306,6 +306,7 @@ func updateConfiguredModelTx(
 	ctx context.Context,
 	qtx *dbsqlc.Queries,
 	input configuredModelUpdate,
+	managementKind management.Kind,
 ) (ConfiguredModelRecord, error) {
 	input = normalizeConfiguredModelUpdate(input)
 	if input.Name == "" {
@@ -333,6 +334,7 @@ func updateConfiguredModelTx(
 	row, err := qtx.UpdateConfiguredModel(
 		ctx,
 		dbsqlc.UpdateConfiguredModelParams{
+			ManagementKind:            string(managementKind),
 			OrgID:                     input.OrgID,
 			ModelProviderConfigID:     input.ModelProviderConfigID,
 			ID:                        input.ID,
@@ -632,7 +634,9 @@ func (s *Store) DeleteConfiguredModel(
 	if hasGrants {
 		return ConfiguredModelRecord{}, fmt.Errorf("configured model has active project grants: %w", storeerr.ErrConflict)
 	}
-	deleted, err := qtx.DeleteConfiguredModel(ctx, dbsqlc.DeleteConfiguredModelParams{OrgID: orgID, ID: id})
+	deleted, err := qtx.DeleteConfiguredModel(ctx, dbsqlc.DeleteConfiguredModelParams{
+		OrgID: orgID, ID: id, ManagementKind: string(management.Tenant),
+	})
 	if err != nil {
 		return ConfiguredModelRecord{}, fmt.Errorf("delete configured model: %w", err)
 	}

--- a/internal/storage/modelstore/default_reconciliation.go
+++ b/internal/storage/modelstore/default_reconciliation.go
@@ -7,36 +7,22 @@ import (
 	"math"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/omnara-ai/omnara/internal/storage/identitystore"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
 	"github.com/omnara-ai/omnara/internal/storage/management"
 )
 
-const defaultProjectIdempotencyKey = "default"
-
 func (s *Store) ReconcileDefaultModelProviderTx(
 	ctx context.Context,
 	tx pgx.Tx,
-	template *DefaultModelProviderTemplate,
+	prepared *DefaultModelProviderTemplate,
+	rows []dbsqlc.ModelProviderConfig,
 	apply bool,
 ) ([]string, []string, error) {
-	if template == nil {
+	if prepared == nil {
 		return nil, nil, nil
 	}
-	prepared, err := PrepareDefaultModelProviderTemplate(*template)
-	if err != nil {
-		return nil, nil, fmt.Errorf("default model provider %q: %w", template.Name, err)
-	}
 	qtx := s.q.WithTx(tx)
-	rows, err := qtx.ListClusterManagedModelProviderConfigsByName(
-		ctx,
-		dbsqlc.ListClusterManagedModelProviderConfigsByNameParams{Name: prepared.Name},
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("list default model providers %q: %w", prepared.Name, err)
-	}
-	if len(rows) == 0 {
-		return nil, nil, fmt.Errorf("no cluster-managed model providers named %q", prepared.Name)
-	}
 	var changes []string
 	var warnings []string
 	for _, row := range rows {
@@ -53,8 +39,7 @@ func (s *Store) ReconcileDefaultModelProviderTx(
 		}
 		if current.APIFormat != prepared.APIFormat || current.APIVariant != prepared.APIVariant {
 			return nil, nil, fmt.Errorf(
-				"org %s: default model provider %q cannot change api_format or api_variant",
-				current.OrgID,
+				"default model provider %q cannot change api_format or api_variant",
 				prepared.Name,
 			)
 		}
@@ -99,21 +84,17 @@ func (s *Store) ReconcileDefaultModelProviderTx(
 				}
 			}
 		}
+		defaultProjectID := NilID
 		project, err := qtx.GetProjectByIdempotencyKey(
 			ctx,
 			dbsqlc.GetProjectByIdempotencyKeyParams{
-				OrgID: current.OrgID, IdempotencyKey: defaultProjectIdempotencyKey,
+				OrgID: current.OrgID, IdempotencyKey: identitystore.DefaultProjectKey,
 			},
 		)
-		if errors.Is(err, pgx.ErrNoRows) {
-			warnings = append(warnings, fmt.Sprintf(
-				"org %s: skip configured models because the default project is missing",
-				current.OrgID,
-			))
-			continue
-		}
-		if err != nil {
-			return nil, nil, fmt.Errorf("load default project for org %s: %w", current.OrgID, err)
+		if err == nil {
+			defaultProjectID = project.ID
+		} else if !errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil, fmt.Errorf("load default project: %w", err)
 		}
 		modelRows, err := qtx.ListConfiguredModels(ctx, dbsqlc.ListConfiguredModelsParams{
 			OrgID: current.OrgID, ModelProviderConfigID: current.ID, RowLimit: math.MaxInt64,
@@ -144,15 +125,17 @@ func (s *Store) ReconcileDefaultModelProviderTx(
 					if err != nil {
 						return nil, nil, fmt.Errorf("add default configured model %q: %w", modelTemplate.Name, err)
 					}
-					if err := grantDefaultConfiguredModelToProjectTx(
-						ctx,
-						qtx,
-						current.OrgID,
-						project.ID,
-						current.APIFormat,
-						created,
-					); err != nil {
-						return nil, nil, err
+					if !isNilID(defaultProjectID) {
+						if err := grantDefaultConfiguredModelToProjectTx(
+							ctx,
+							qtx,
+							current.OrgID,
+							defaultProjectID,
+							current.APIFormat,
+							created,
+						); err != nil {
+							return nil, nil, err
+						}
 					}
 				}
 				continue
@@ -196,13 +179,21 @@ func (s *Store) ReconcileDefaultModelProviderTx(
 				}
 				model = locked
 			}
-			state, err := qtx.GetDefaultConfiguredModelRemovalState(
-				ctx,
-				dbsqlc.GetDefaultConfiguredModelRemovalStateParams{
-					TargetConfiguredModelID: model.ID,
-					DefaultProjectID:        project.ID,
-				},
-			)
+			var state dbsqlc.GetDefaultConfiguredModelRemovalStateRow
+			if isNilID(defaultProjectID) {
+				state.GrantedToOtherProject, err = qtx.ConfiguredModelHasActiveGrants(
+					ctx,
+					dbsqlc.ConfiguredModelHasActiveGrantsParams{OrgID: current.OrgID, ID: model.ID},
+				)
+			} else {
+				state, err = qtx.GetDefaultConfiguredModelRemovalState(
+					ctx,
+					dbsqlc.GetDefaultConfiguredModelRemovalStateParams{
+						TargetConfiguredModelID: model.ID,
+						DefaultProjectID:        defaultProjectID,
+					},
+				)
+			}
 			if err != nil {
 				return nil, nil, fmt.Errorf("check removed configured model %q: %w", name, err)
 			}
@@ -214,7 +205,7 @@ func (s *Store) ReconcileDefaultModelProviderTx(
 						name,
 					))
 					if apply {
-						if err := deleteDefaultProjectModelGrantTx(ctx, qtx, current.OrgID, project.ID, model.ID); err != nil {
+						if err := deleteDefaultProjectModelGrantTx(ctx, qtx, current.OrgID, defaultProjectID, model.ID); err != nil {
 							return nil, nil, fmt.Errorf("remove default grant for configured model %q: %w", name, err)
 						}
 					}
@@ -233,7 +224,7 @@ func (s *Store) ReconcileDefaultModelProviderTx(
 			))
 			if apply {
 				if state.GrantedToDefaultProject {
-					if err := deleteDefaultProjectModelGrantTx(ctx, qtx, current.OrgID, project.ID, model.ID); err != nil {
+					if err := deleteDefaultProjectModelGrantTx(ctx, qtx, current.OrgID, defaultProjectID, model.ID); err != nil {
 						return nil, nil, fmt.Errorf("remove default grant for configured model %q: %w", name, err)
 					}
 				}

--- a/internal/storage/modelstore/default_reconciliation.go
+++ b/internal/storage/modelstore/default_reconciliation.go
@@ -1,0 +1,290 @@
+package modelstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
+	"github.com/omnara-ai/omnara/internal/storage/management"
+)
+
+const defaultProjectIdempotencyKey = "default"
+
+func (s *Store) ReconcileDefaultModelProviderTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	template *DefaultModelProviderTemplate,
+	apply bool,
+) ([]string, []string, error) {
+	if template == nil {
+		return nil, nil, nil
+	}
+	prepared, err := PrepareDefaultModelProviderTemplate(*template)
+	if err != nil {
+		return nil, nil, fmt.Errorf("default model provider %q: %w", template.Name, err)
+	}
+	qtx := s.q.WithTx(tx)
+	rows, err := qtx.ListClusterManagedModelProviderConfigsByName(
+		ctx,
+		dbsqlc.ListClusterManagedModelProviderConfigsByNameParams{Name: prepared.Name},
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list default model providers %q: %w", prepared.Name, err)
+	}
+	if len(rows) == 0 {
+		return nil, nil, fmt.Errorf("no cluster-managed model providers named %q", prepared.Name)
+	}
+	var changes []string
+	var warnings []string
+	for _, row := range rows {
+		current := modelProviderConfigRecordFromSQLC(row)
+		if apply {
+			locked, err := qtx.LockModelProviderConfigForMutation(
+				ctx,
+				dbsqlc.LockModelProviderConfigForMutationParams{OrgID: current.OrgID, ID: current.ID},
+			)
+			if err != nil {
+				return nil, nil, fmt.Errorf("lock default model provider %q: %w", prepared.Name, err)
+			}
+			current = modelProviderConfigRecordFromSQLC(locked)
+		}
+		if current.APIFormat != prepared.APIFormat || current.APIVariant != prepared.APIVariant {
+			return nil, nil, fmt.Errorf(
+				"org %s: default model provider %q cannot change api_format or api_variant",
+				current.OrgID,
+				prepared.Name,
+			)
+		}
+		desiredProvider := CreateModelProviderConfigInput{
+			OrgID:              current.OrgID,
+			Name:               prepared.Name,
+			APIFormat:          prepared.APIFormat,
+			APIVariant:         prepared.APIVariant,
+			BaseURL:            prepared.BaseURL,
+			EndpointPath:       prepared.EndpointPath,
+			RequestTimeoutMS:   prepared.RequestTimeoutMS,
+			AuthKind:           prepared.AuthKind,
+			AuthOptions:        prepared.AuthOptions,
+			CredentialSecretID: current.CredentialSecretID,
+			managementKind:     management.Cluster,
+		}
+		if !sameModelProviderConfigIntent(current, desiredProvider) {
+			changes = append(changes, fmt.Sprintf(
+				"org %s: update model provider %q",
+				current.OrgID,
+				prepared.Name,
+			))
+			if apply {
+				if _, err := updateModelProviderConfigTx(
+					ctx,
+					qtx,
+					modelProviderConfigUpdate{
+						OrgID:              current.OrgID,
+						ID:                 current.ID,
+						BaseURL:            prepared.BaseURL,
+						EndpointPath:       prepared.EndpointPath,
+						RequestTimeoutMS:   prepared.RequestTimeoutMS,
+						AuthKind:           prepared.AuthKind,
+						AuthOptions:        prepared.AuthOptions,
+						CredentialSecretID: current.CredentialSecretID,
+						APIFormat:          current.APIFormat,
+						APIVariant:         current.APIVariant,
+					},
+					management.Cluster,
+				); err != nil {
+					return nil, nil, fmt.Errorf("update default model provider %q: %w", prepared.Name, err)
+				}
+			}
+		}
+		project, err := qtx.GetProjectByIdempotencyKey(
+			ctx,
+			dbsqlc.GetProjectByIdempotencyKeyParams{
+				OrgID: current.OrgID, IdempotencyKey: defaultProjectIdempotencyKey,
+			},
+		)
+		if errors.Is(err, pgx.ErrNoRows) {
+			warnings = append(warnings, fmt.Sprintf(
+				"org %s: skip configured models because the default project is missing",
+				current.OrgID,
+			))
+			continue
+		}
+		if err != nil {
+			return nil, nil, fmt.Errorf("load default project for org %s: %w", current.OrgID, err)
+		}
+		modelRows, err := qtx.ListConfiguredModels(ctx, dbsqlc.ListConfiguredModelsParams{
+			OrgID: current.OrgID, ModelProviderConfigID: current.ID, RowLimit: math.MaxInt64,
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("list configured models for %q: %w", prepared.Name, err)
+		}
+		existing := make(map[string]ConfiguredModelRecord, len(modelRows))
+		for _, modelRow := range modelRows {
+			model := configuredModelRecordFromListSQLC(modelRow)
+			existing[model.Name] = model
+		}
+		desiredNames := make(map[string]struct{}, len(prepared.Models))
+		for _, modelTemplate := range prepared.Models {
+			desiredNames[modelTemplate.Name] = struct{}{}
+			desired := configuredModelInputFromDefaultTemplate(modelTemplate)
+			desired.OrgID = current.OrgID
+			desired.ModelProviderConfigID = current.ID
+			model, found := existing[modelTemplate.Name]
+			if !found {
+				changes = append(changes, fmt.Sprintf(
+					"org %s: add configured model %q",
+					current.OrgID,
+					modelTemplate.Name,
+				))
+				if apply {
+					created, err := s.createConfiguredModelTx(ctx, qtx, desired, management.Cluster)
+					if err != nil {
+						return nil, nil, fmt.Errorf("add default configured model %q: %w", modelTemplate.Name, err)
+					}
+					if err := grantDefaultConfiguredModelToProjectTx(
+						ctx,
+						qtx,
+						current.OrgID,
+						project.ID,
+						current.APIFormat,
+						created,
+					); err != nil {
+						return nil, nil, err
+					}
+				}
+				continue
+			}
+			if apply {
+				locked, err := lockConfiguredModelCurrentRevisionForMutationTx(ctx, qtx, current.OrgID, model.ID)
+				if err != nil {
+					return nil, nil, fmt.Errorf("lock default configured model %q: %w", model.Name, err)
+				}
+				model = locked
+			}
+			if sameConfiguredModelIntent(model, desired) {
+				continue
+			}
+			changes = append(changes, fmt.Sprintf(
+				"org %s: update configured model %q",
+				current.OrgID,
+				modelTemplate.Name,
+			))
+			if apply {
+				if _, err := updateConfiguredModelTx(
+					ctx,
+					qtx,
+					configuredModelUpdateFromDefault(model.ID, desired),
+					management.Cluster,
+				); err != nil {
+					return nil, nil, fmt.Errorf("update default configured model %q: %w", modelTemplate.Name, err)
+				}
+			}
+		}
+		for _, modelRow := range modelRows {
+			model := configuredModelRecordFromListSQLC(modelRow)
+			name := model.Name
+			if _, desired := desiredNames[name]; desired {
+				continue
+			}
+			if apply {
+				locked, err := lockConfiguredModelCurrentRevisionForDeleteTx(ctx, qtx, current.OrgID, model.ID)
+				if err != nil {
+					return nil, nil, fmt.Errorf("lock removed configured model %q: %w", name, err)
+				}
+				model = locked
+			}
+			state, err := qtx.GetDefaultConfiguredModelRemovalState(
+				ctx,
+				dbsqlc.GetDefaultConfiguredModelRemovalStateParams{
+					TargetConfiguredModelID: model.ID,
+					DefaultProjectID:        project.ID,
+				},
+			)
+			if err != nil {
+				return nil, nil, fmt.Errorf("check removed configured model %q: %w", name, err)
+			}
+			if state.GrantedToOtherProject {
+				if state.GrantedToDefaultProject {
+					changes = append(changes, fmt.Sprintf(
+						"org %s: remove configured model %q from the default project",
+						current.OrgID,
+						name,
+					))
+					if apply {
+						if err := deleteDefaultProjectModelGrantTx(ctx, qtx, current.OrgID, project.ID, model.ID); err != nil {
+							return nil, nil, fmt.Errorf("remove default grant for configured model %q: %w", name, err)
+						}
+					}
+				}
+				warnings = append(warnings, fmt.Sprintf(
+					"org %s: keep configured model %q because another project grants it",
+					current.OrgID,
+					name,
+				))
+				continue
+			}
+			changes = append(changes, fmt.Sprintf(
+				"org %s: remove configured model %q",
+				current.OrgID,
+				name,
+			))
+			if apply {
+				if state.GrantedToDefaultProject {
+					if err := deleteDefaultProjectModelGrantTx(ctx, qtx, current.OrgID, project.ID, model.ID); err != nil {
+						return nil, nil, fmt.Errorf("remove default grant for configured model %q: %w", name, err)
+					}
+				}
+				if _, err := qtx.DeleteConfiguredModel(ctx, dbsqlc.DeleteConfiguredModelParams{
+					OrgID: current.OrgID, ID: model.ID, ManagementKind: string(management.Cluster),
+				}); err != nil {
+					return nil, nil, fmt.Errorf("remove default configured model %q: %w", name, err)
+				}
+			}
+		}
+	}
+	return changes, warnings, nil
+}
+
+func configuredModelUpdateFromDefault(id ID, input CreateConfiguredModelInput) configuredModelUpdate {
+	return configuredModelUpdate{
+		OrgID:                     input.OrgID,
+		ModelProviderConfigID:     input.ModelProviderConfigID,
+		ID:                        id,
+		Name:                      input.Name,
+		ProviderModelSlug:         input.ProviderModelSlug,
+		ContextWindowTokens:       input.ContextWindowTokens,
+		MaxOutputTokens:           input.MaxOutputTokens,
+		DefaultMaxOutputTokens:    input.DefaultMaxOutputTokens,
+		DefaultCacheRetention:     input.DefaultCacheRetention,
+		SupportsTools:             input.SupportsTools,
+		SupportsReasoning:         input.SupportsReasoning,
+		DefaultReasoningEffort:    input.DefaultReasoningEffort,
+		SupportedReasoningEfforts: input.SupportedReasoningEfforts,
+		InputModalities:           input.InputModalities,
+		OutputModalities:          input.OutputModalities,
+		APIVariantOptions:         input.APIVariantOptions,
+	}
+}
+
+func deleteDefaultProjectModelGrantTx(
+	ctx context.Context,
+	qtx *dbsqlc.Queries,
+	orgID, projectID, configuredModelID ID,
+) error {
+	grant, err := qtx.GetActiveProjectModelGrantForConfiguredModel(
+		ctx,
+		dbsqlc.GetActiveProjectModelGrantForConfiguredModelParams{
+			OrgID: orgID, ProjectID: projectID, ConfiguredModelID: configuredModelID,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	_, err = qtx.DeleteProjectModelGrant(ctx, dbsqlc.DeleteProjectModelGrantParams{
+		OrgID: orgID, ProjectID: projectID, ID: grant.ID,
+	})
+	return err
+}

--- a/internal/storage/modelstore/model_provider_configs_store.go
+++ b/internal/storage/modelstore/model_provider_configs_store.go
@@ -304,17 +304,27 @@ func (s *Store) PatchModelProviderConfig(
 	}
 	update := updateModelProviderConfigInputFromCurrent(current)
 	applyModelProviderConfigPatch(&update, current, input)
-	update, err = normalizeModelProviderConfigUpdate(
+	record, err := updateModelProviderConfigTx(ctx, qtx, update, management.Tenant)
+	if err != nil {
+		return ModelProviderConfigRecord{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ModelProviderConfigRecord{}, err
+	}
+	return record, nil
+}
+
+func updateModelProviderConfigTx(
+	ctx context.Context,
+	qtx *dbsqlc.Queries,
+	input modelProviderConfigUpdate,
+	managementKind management.Kind,
+) (ModelProviderConfigRecord, error) {
+	update, err := normalizeModelProviderConfigUpdate(
 		ctx,
-		update,
+		input,
 		func(ctx context.Context, orgID, credentialSecretID ID) error {
-			return validateModelProviderCredentialTx(
-				ctx,
-				qtx,
-				orgID,
-				credentialSecretID,
-				management.Tenant,
-			)
+			return validateModelProviderCredentialTx(ctx, qtx, orgID, credentialSecretID, managementKind)
 		},
 	)
 	if err != nil {
@@ -323,6 +333,7 @@ func (s *Store) PatchModelProviderConfig(
 	row, err := qtx.UpdateModelProviderConfig(
 		ctx,
 		dbsqlc.UpdateModelProviderConfigParams{
+			ManagementKind:     string(managementKind),
 			OrgID:              update.OrgID,
 			ID:                 update.ID,
 			BaseUrl:            update.BaseURL,
@@ -341,9 +352,6 @@ func (s *Store) PatchModelProviderConfig(
 	}
 	if err != nil {
 		return ModelProviderConfigRecord{}, fmt.Errorf("update model provider config: %w", err)
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return ModelProviderConfigRecord{}, err
 	}
 	return modelProviderConfigRecordFromSQLC(row), nil
 }

--- a/internal/storage/orglifecycle/default_reconciliation.go
+++ b/internal/storage/orglifecycle/default_reconciliation.go
@@ -2,10 +2,13 @@ package orglifecycle
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
+	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
 	"github.com/omnara-ai/omnara/internal/storage/modelstore"
 )
 
@@ -24,6 +27,81 @@ func (s *Service) ReconcileDefaults(
 	ctx context.Context,
 	input ReconcileDefaultsInput,
 ) (ReconcileDefaultsResult, error) {
+	var orgIDs []ID
+	seen := make(map[ID]bool)
+	pools := make(map[ID][]dbsqlc.MachinePool)
+	providers := make(map[ID][]dbsqlc.ModelProviderConfig)
+	addOrg := func(orgID ID) {
+		if !seen[orgID] {
+			seen[orgID] = true
+			orgIDs = append(orgIDs, orgID)
+		}
+	}
+	for _, template := range input.DefaultMachinePools {
+		if err := s.execution.ValidateDefaultMachinePoolTemplate(template); err != nil {
+			return ReconcileDefaultsResult{}, fmt.Errorf("default machine pool: %w", err)
+		}
+		name := strings.TrimSpace(template.Name)
+		rows, err := s.q.ListClusterManagedMachinePoolsByName(
+			ctx,
+			dbsqlc.ListClusterManagedMachinePoolsByNameParams{Name: name},
+		)
+		if err != nil {
+			return ReconcileDefaultsResult{}, fmt.Errorf("list default machine pools %q: %w", name, err)
+		}
+		if len(rows) == 0 {
+			return ReconcileDefaultsResult{}, fmt.Errorf("no cluster-managed machine pools named %q", name)
+		}
+		for _, row := range rows {
+			addOrg(row.OrgID)
+			pools[row.OrgID] = append(pools[row.OrgID], row)
+		}
+	}
+	if input.DefaultModelProvider != nil {
+		prepared, err := modelstore.PrepareDefaultModelProviderTemplate(*input.DefaultModelProvider)
+		if err != nil {
+			return ReconcileDefaultsResult{}, fmt.Errorf("default model provider %q: %w", input.DefaultModelProvider.Name, err)
+		}
+		rows, err := s.q.ListClusterManagedModelProviderConfigsByName(
+			ctx,
+			dbsqlc.ListClusterManagedModelProviderConfigsByNameParams{Name: prepared.Name},
+		)
+		if err != nil {
+			return ReconcileDefaultsResult{}, fmt.Errorf("list default model providers %q: %w", prepared.Name, err)
+		}
+		if len(rows) == 0 {
+			return ReconcileDefaultsResult{}, fmt.Errorf("no cluster-managed model providers named %q", prepared.Name)
+		}
+		input.DefaultModelProvider = &prepared
+		for _, row := range rows {
+			addOrg(row.OrgID)
+			providers[row.OrgID] = append(providers[row.OrgID], row)
+		}
+	}
+
+	var result ReconcileDefaultsResult
+	var reconcileErrs []error
+	for _, orgID := range orgIDs {
+		orgResult, err := s.reconcileOrgDefaults(ctx, input, pools[orgID], providers[orgID])
+		if err != nil {
+			reconcileErrs = append(reconcileErrs, fmt.Errorf("org %s: %w", orgID, err))
+			if ctx.Err() != nil {
+				break
+			}
+			continue
+		}
+		result.Changes = append(result.Changes, orgResult.Changes...)
+		result.Warnings = append(result.Warnings, orgResult.Warnings...)
+	}
+	return result, errors.Join(reconcileErrs...)
+}
+
+func (s *Service) reconcileOrgDefaults(
+	ctx context.Context,
+	input ReconcileDefaultsInput,
+	pools []dbsqlc.MachinePool,
+	providers []dbsqlc.ModelProviderConfig,
+) (ReconcileDefaultsResult, error) {
 	txOptions := pgx.TxOptions{}
 	if !input.Apply {
 		txOptions.AccessMode = pgx.ReadOnly
@@ -37,6 +115,7 @@ func (s *Service) ReconcileDefaults(
 		ctx,
 		tx,
 		input.DefaultMachinePools,
+		pools,
 		input.Apply,
 	)
 	if err != nil {
@@ -46,6 +125,7 @@ func (s *Service) ReconcileDefaults(
 		ctx,
 		tx,
 		input.DefaultModelProvider,
+		providers,
 		input.Apply,
 	)
 	if err != nil {

--- a/internal/storage/orglifecycle/default_reconciliation.go
+++ b/internal/storage/orglifecycle/default_reconciliation.go
@@ -1,0 +1,59 @@
+package orglifecycle
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/omnara-ai/omnara/internal/storage/executionstore"
+	"github.com/omnara-ai/omnara/internal/storage/modelstore"
+)
+
+type ReconcileDefaultsInput struct {
+	Apply                bool
+	DefaultMachinePools  []executionstore.DefaultMachinePoolTemplate
+	DefaultModelProvider *modelstore.DefaultModelProviderTemplate
+}
+
+type ReconcileDefaultsResult struct {
+	Changes  []string
+	Warnings []string
+}
+
+func (s *Service) ReconcileDefaults(
+	ctx context.Context,
+	input ReconcileDefaultsInput,
+) (ReconcileDefaultsResult, error) {
+	txOptions := pgx.TxOptions{}
+	if !input.Apply {
+		txOptions.AccessMode = pgx.ReadOnly
+	}
+	tx, err := s.pool.BeginTx(ctx, txOptions)
+	if err != nil {
+		return ReconcileDefaultsResult{}, fmt.Errorf("begin default reconciliation: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	changes, err := s.execution.ReconcileDefaultMachinePoolsTx(
+		ctx,
+		tx,
+		input.DefaultMachinePools,
+		input.Apply,
+	)
+	if err != nil {
+		return ReconcileDefaultsResult{}, err
+	}
+	modelChanges, warnings, err := s.models.ReconcileDefaultModelProviderTx(
+		ctx,
+		tx,
+		input.DefaultModelProvider,
+		input.Apply,
+	)
+	if err != nil {
+		return ReconcileDefaultsResult{}, err
+	}
+	changes = append(changes, modelChanges...)
+	if err := tx.Commit(ctx); err != nil {
+		return ReconcileDefaultsResult{}, fmt.Errorf("commit default reconciliation: %w", err)
+	}
+	return ReconcileDefaultsResult{Changes: changes, Warnings: warnings}, nil
+}

--- a/internal/storage/queries/execution_resources.sql
+++ b/internal/storage/queries/execution_resources.sql
@@ -50,7 +50,7 @@ SET name = sqlc.arg(name),
     updated_at = statement_timestamp()
 WHERE org_id = sqlc.arg(org_id)
   AND id = sqlc.arg(id)
-  AND management_kind = 'tenant'
+  AND management_kind = sqlc.arg(management_kind)
   AND deleted_at IS NULL
 RETURNING id, org_id, name, management_kind, description, provider, default_machine_cpu, default_machine_memory_mb, default_machine_env, default_machine_secret_env, default_machine_provider_options, default_cwd, provider_config, provider_auth_secret_id, provider_auth_env_var, max_total_machines, max_total_cpu, max_total_memory_mb, max_machine_cpu, max_machine_memory_mb, metadata, deleted_at, created_at, updated_at, runtime_protection_enabled, min_machine_cpu, min_machine_memory_mb;
 
@@ -226,6 +226,12 @@ SELECT id, org_id, name, management_kind, description, provider, default_machine
 FROM machine_pools
 WHERE org_id = sqlc.arg(org_id) AND management_kind = 'cluster' AND deleted_at IS NULL
 ORDER BY name, id;
+
+-- name: ListClusterManagedMachinePoolsByName :many
+SELECT id, org_id, name, management_kind, description, provider, default_machine_cpu, default_machine_memory_mb, default_machine_env, default_machine_secret_env, default_machine_provider_options, default_cwd, provider_config, provider_auth_secret_id, provider_auth_env_var, max_total_machines, max_total_cpu, max_total_memory_mb, max_machine_cpu, max_machine_memory_mb, metadata, deleted_at, created_at, updated_at, runtime_protection_enabled, min_machine_cpu, min_machine_memory_mb
+FROM machine_pools
+WHERE name = sqlc.arg(name) AND management_kind = 'cluster' AND deleted_at IS NULL
+ORDER BY org_id, id;
 
 -- name: GetPoolGrantConfigValidationContext :one
 SELECT pool.provider,

--- a/internal/storage/queries/model_provider_configs.sql
+++ b/internal/storage/queries/model_provider_configs.sql
@@ -98,6 +98,16 @@ ORDER BY CASE WHEN NOT sqlc.arg(sort_desc)::boolean THEN sort_key END ASC,
          CASE WHEN sqlc.arg(sort_desc)::boolean THEN id END DESC
 LIMIT sqlc.arg(row_limit)::bigint;
 
+-- name: ListClusterManagedModelProviderConfigsByName :many
+SELECT id, org_id, management_kind, name, api_format, api_variant, base_url, endpoint_path,
+       request_timeout_ms, auth_kind, auth_options,
+       credential_secret_id, deleted_at, created_at, updated_at
+FROM model_provider_configs
+WHERE name = sqlc.arg(name)
+  AND management_kind = 'cluster'
+  AND deleted_at IS NULL
+ORDER BY org_id, id;
+
 -- name: UpdateModelProviderConfig :one
 UPDATE model_provider_configs config
 SET base_url = sqlc.arg(base_url),
@@ -111,7 +121,7 @@ FROM secrets credential
 WHERE config.org_id = sqlc.arg(org_id)
   AND config.id = sqlc.arg(id)
   AND config.deleted_at IS NULL
-  AND config.management_kind = 'tenant'
+  AND config.management_kind = sqlc.arg(management_kind)
   AND credential.org_id = config.org_id
   AND credential.id = sqlc.arg(credential_secret_id)
   AND credential.management_kind = config.management_kind
@@ -355,7 +365,7 @@ WITH target_configured_model AS (
   FROM configured_models configured_model
   JOIN model_provider_configs provider_config ON provider_config.org_id = configured_model.org_id
     AND provider_config.id = configured_model.model_provider_config_id
-    AND provider_config.management_kind = 'tenant'
+    AND provider_config.management_kind = sqlc.arg(management_kind)
     AND provider_config.deleted_at IS NULL
   WHERE configured_model.org_id = sqlc.arg(org_id)
     AND configured_model.model_provider_config_id = sqlc.arg(model_provider_config_id)
@@ -456,10 +466,22 @@ WHERE configured_models.org_id = sqlc.arg(org_id)
     FROM model_provider_configs provider_config
     WHERE provider_config.org_id = configured_models.org_id
       AND provider_config.id = configured_models.model_provider_config_id
-      AND provider_config.management_kind = 'tenant'
+      AND provider_config.management_kind = sqlc.arg(management_kind)
   )
 RETURNING id, org_id, model_provider_config_id, name, current_revision_id,
           deleted_at, created_at, updated_at;
+
+-- name: GetDefaultConfiguredModelRemovalState :one
+SELECT EXISTS (
+         SELECT 1 FROM project_model_grants model_grant
+         WHERE model_grant.configured_model_id = sqlc.arg(target_configured_model_id)
+           AND model_grant.project_id = sqlc.arg(default_project_id)
+       ) AS granted_to_default_project,
+       EXISTS (
+         SELECT 1 FROM project_model_grants model_grant
+         WHERE model_grant.configured_model_id = sqlc.arg(target_configured_model_id)
+           AND model_grant.project_id <> sqlc.arg(default_project_id)
+       ) AS granted_to_other_project;
 
 -- name: ConfiguredModelHasActiveGrants :one
 SELECT EXISTS (


### PR DESCRIPTION
- add `omnara-api reconcile-defaults plan|apply` so operators can preview or apply configured defaults across existing organizations
- update cluster-managed machine pool defaults while preserving every organization's existing capacity limits and leaving existing machines unchanged
- reconcile default model provider settings and configured models while retaining provider credentials, explicit project opt-outs, and customized grants