### PR TITLE
feat: support live MCP config changes

### DIFF
--- a/internal/e2e/service_e2e_mcp_test.go
+++ b/internal/e2e/service_e2e_mcp_test.go
@@ -293,3 +293,187 @@ WHERE call.project_id = $1
 		t.Fatalf("completed mcp__docs__greet tool calls = %d, want 1", toolCalls)
 	}
 }
+
+func TestServiceE2ELiveMCPConfigChanges(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	env := newDaemonOnlyServiceE2EEnvironment(t, ctx, "live-mcp-config-changes")
+	mcpServer := mcptest.NewJSONServer(t)
+
+	var requestCount atomic.Int64
+	const callID = "call_live_mcp_greet"
+	const initialText = "initial turn completed without MCP"
+	const addedText = "live MCP tool call completed"
+	const removedText = "live MCP removal completed"
+	openai := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			http.NotFound(w, r)
+			return
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer service-e2e-test-key" {
+			t.Errorf("unexpected OpenAI auth header %q", auth)
+			http.Error(w, "bad auth", http.StatusUnauthorized)
+			return
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode OpenAI request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch requestCount.Add(1) {
+		case 1:
+			if requestContainsTool(body, "mcp__docs__greet") {
+				t.Errorf("initial model request unexpectedly exposed mcp__docs__greet: %+v", body["tools"])
+				http.Error(w, "unexpected mcp tool", http.StatusServiceUnavailable)
+				return
+			}
+			_, _ = w.Write([]byte(
+				`{"id":"resp_live_mcp_initial","status":"completed","output":[` +
+					`{"id":"msg_live_mcp_initial","type":"message",` +
+					`"content":[{"type":"output_text","text":"` + initialText +
+					`"}]}],"usage":{"input_tokens":7,"output_tokens":5}}`,
+			))
+		case 2:
+			if !requestContainsTool(body, "mcp__docs__greet") {
+				t.Errorf("model request after live add did not expose mcp__docs__greet: %+v", body["tools"])
+				http.Error(w, "missing mcp tool", http.StatusServiceUnavailable)
+				return
+			}
+			_, _ = fmt.Fprintf(
+				w,
+				`{"id":"resp_live_mcp_added","status":"completed","output":[`+
+					`{"id":"fc_live_mcp_added","type":"function_call",`+
+					`"call_id":%q,"name":"mcp__docs__greet","arguments":"{\"name\":\"Ada\"}"}],`+
+					`"usage":{"input_tokens":11,"output_tokens":4}}`,
+				callID,
+			)
+		case 3:
+			if !requestContainsToolResult(body, callID, "Hi Ada") {
+				t.Errorf("model continuation did not include live MCP result for %s: %+v", callID, body["input"])
+				http.Error(w, "missing mcp result", http.StatusServiceUnavailable)
+				return
+			}
+			_, _ = w.Write([]byte(
+				`{"id":"resp_live_mcp_result","status":"completed","output":[` +
+					`{"id":"msg_live_mcp_result","type":"message",` +
+					`"content":[{"type":"output_text","text":"` + addedText +
+					`"}]}],"usage":{"input_tokens":13,"output_tokens":5}}`,
+			))
+		case 4:
+			if requestContainsTool(body, "mcp__docs__greet") {
+				t.Errorf("model request after live removal exposed mcp__docs__greet: %+v", body["tools"])
+				http.Error(w, "stale mcp tool", http.StatusServiceUnavailable)
+				return
+			}
+			_, _ = w.Write([]byte(
+				`{"id":"resp_live_mcp_removed","status":"completed","output":[` +
+					`{"id":"msg_live_mcp_removed","type":"message",` +
+					`"content":[{"type":"output_text","text":"` + removedText +
+					`"}]}],"usage":{"input_tokens":7,"output_tokens":5}}`,
+			))
+		default:
+			t.Errorf("unexpected extra OpenAI request: %+v", body)
+			http.Error(w, "too many requests", http.StatusInternalServerError)
+		}
+	}))
+	defer openai.Close()
+
+	initialYAML := strings.Join([]string{
+		"name: Live MCP Config Changes",
+		"instruction: Follow the current MCP configuration.",
+		"model:",
+		"  provider_config: openai-prod",
+		"  name: service-e2e-local",
+	}, "\n") + "\n"
+	env.startAPI(t, ctx)
+	project := env.bootstrapProjectViaAPIWithSource(t, ctx, "live-mcp-config-changes", initialYAML)
+	agentID := project.createAgent(t, ctx)
+	projectUUID := mustDecodeServiceE2EPublicID(t, publicid.KindProject, project.projectID)
+	agentUUID := mustDecodeServiceE2EPublicID(t, publicid.KindAgent, agentID)
+	waitForOutput := func(text string, worker serviceProcess) {
+		t.Helper()
+		waitForServiceE2ECondition(t, ctx, func() (bool, string) {
+			var outputs, locks, wakeups int
+			if err := env.db.QueryRow(ctx, `SELECT count(*) FROM agent_events event JOIN agents agent ON agent.id = event.agent_id JOIN content_blocks block ON block.agent_id = event.agent_id AND block.owner_model_output_id = event.model_output_id WHERE agent.project_id = $1 AND event.agent_id = $2 AND event.event_kind = 'model_output' AND block.block_kind = 'text' AND block.text_content = $3`, projectUUID, agentUUID, text).
+				Scan(&outputs); err != nil {
+				return false, err.Error()
+			}
+			if err := env.db.QueryRow(ctx, scopedAgentRuntimeLockCountSQL, projectUUID, agentUUID).Scan(&locks); err != nil {
+				return false, err.Error()
+			}
+			if err := env.db.QueryRow(ctx, `SELECT count(*) FROM agent_wakeups wake JOIN agents agent ON agent.id = wake.agent_id WHERE agent.project_id = $1 AND wake.agent_id = $2`, projectUUID, agentUUID).
+				Scan(&wakeups); err != nil {
+				return false, err.Error()
+			}
+			return outputs == 1 && locks == 0 && wakeups == 0,
+				fmt.Sprintf("output=%q count=%d locks=%d wakeups=%d worker_logs=%s", text, outputs, locks, wakeups, worker.logExcerpt())
+		})
+	}
+
+	project.createInput(t, ctx, agentID, "complete a turn without MCP")
+	worker := env.startWorker(
+		t,
+		ctx,
+		project.projectID,
+		serviceWorkerOptions{ProviderConfig: "openai-prod", BaseURL: openai.URL, LogLevel: "info"},
+	)
+	waitForOutput(initialText, worker)
+	worker.stop()
+
+	project.updateConfig(t, ctx, agentID, strings.Join([]string{
+		"name: Live MCP Config Changes",
+		"instruction: Follow the current MCP configuration.",
+		"model:",
+		"  provider_config: openai-prod",
+		"  name: service-e2e-local",
+		"mcp:",
+		"  docs:",
+		"    url: " + mcpServer.URL,
+		"    permission:",
+		"      mode: always_allow",
+		"      parameters: {}",
+	}, "\n")+"\n")
+	project.createInput(t, ctx, agentID, "use the newly added docs greet MCP tool for Ada")
+	worker = env.startWorker(
+		t,
+		ctx,
+		project.projectID,
+		serviceWorkerOptions{ProviderConfig: "openai-prod", BaseURL: openai.URL, LogLevel: "info"},
+	)
+	waitForOutput(addedText, worker)
+	worker.stop()
+
+	project.updateConfig(t, ctx, agentID, initialYAML)
+	project.createInput(t, ctx, agentID, "complete a turn after MCP removal")
+	worker = env.startWorker(
+		t,
+		ctx,
+		project.projectID,
+		serviceWorkerOptions{ProviderConfig: "openai-prod", BaseURL: openai.URL, LogLevel: "info"},
+	)
+	waitForOutput(removedText, worker)
+
+	if got := requestCount.Load(); got != 4 {
+		t.Fatalf("OpenAI server saw %d requests, want 4", got)
+	}
+	var toolCalls int
+	if err := env.db.QueryRow(ctx, `SELECT count(*) FROM tool_call_read_projection WHERE project_id = $1 AND agent_id = $2 AND name = 'mcp__docs__greet' AND type = 'mcp' AND state = 'completed'`, projectUUID, agentUUID).
+		Scan(&toolCalls); err != nil {
+		t.Fatalf("query live MCP tool calls: %v", err)
+	}
+	if toolCalls != 1 {
+		t.Fatalf("completed live mcp__docs__greet tool calls = %d, want 1", toolCalls)
+	}
+	var state executionstore.MCPConnectionState
+	var protocolVersion, sessionID, capabilities, serverInfo, tools string
+	if err := env.db.QueryRow(ctx, `SELECT connection.state, connection.protocol_version, connection.mcp_session_id, connection.server_capabilities::text, connection.server_info::text, connection.tools_snapshot::text FROM agent_mcp_connections connection JOIN agents agent ON agent.id = connection.agent_id WHERE agent.project_id = $1 AND connection.agent_id = $2 AND connection.server_key = 'docs'`, projectUUID, agentUUID).
+		Scan(&state, &protocolVersion, &sessionID, &capabilities, &serverInfo, &tools); err != nil {
+		t.Fatalf("query removed MCP connection: %v", err)
+	}
+	if state != executionstore.MCPConnectionStateExpired || protocolVersion != "" || sessionID != "" ||
+		capabilities != "{}" || serverInfo != "{}" || tools != "[]" {
+		t.Fatalf("removed MCP connection state=%q protocol=%q session=%q capabilities=%s server_info=%s tools=%s", state, protocolVersion, sessionID, capabilities, serverInfo, tools)
+	}
+}

--- a/internal/harness/kernel/agent_executor_mcp.go
+++ b/internal/harness/kernel/agent_executor_mcp.go
@@ -26,16 +26,6 @@ const (
 	mcpInitializationResume
 )
 
-func mcpInitializationForExecution(toolRounds int, continuationContextID storage.ID) mcpInitializationMode {
-	if toolRounds != 0 {
-		return mcpInitializationNone
-	}
-	if continuationContextID == storage.NilID {
-		return mcpInitializationOpening
-	}
-	return mcpInitializationResume
-}
-
 func shouldInitializeMCPConnection(mode mcpInitializationMode, state executionstore.MCPConnectionState) bool {
 	switch mode {
 	case mcpInitializationOpening:
@@ -55,9 +45,20 @@ func (e AgentExecutor) ensureMCPConnections(
 	mode mcpInitializationMode,
 ) error {
 	if len(contract.MCPServers) == 0 {
-		return nil
+		connections, err := e.Store.Execution().ListAgentMCPConnections(ctx, input.ProjectID, input.AgentID)
+		if err != nil {
+			return err
+		}
+		if len(connections) == 0 {
+			return nil
+		}
 	}
-	connections, err := e.Store.Execution().ListAgentMCPConnections(ctx, input.ProjectID, input.AgentID)
+	connections, err := e.Store.Execution().ReconcileAgentMCPConnections(
+		ctx,
+		input.ProjectID,
+		input.AgentID,
+		contract.MCPServers,
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/harness/kernel/agent_executor_mcp.go
+++ b/internal/harness/kernel/agent_executor_mcp.go
@@ -31,7 +31,8 @@ func shouldInitializeMCPConnection(mode mcpInitializationMode, state executionst
 	case mcpInitializationOpening:
 		return mcp.ShouldInitialize(state)
 	case mcpInitializationResume:
-		return state == executionstore.MCPConnectionStateInitializing
+		return state == executionstore.MCPConnectionStateInitializing ||
+			state == executionstore.MCPConnectionStateExpired
 	default:
 		return false
 	}

--- a/internal/harness/kernel/agent_executor_mcp_integration_test.go
+++ b/internal/harness/kernel/agent_executor_mcp_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/omnara-ai/omnara/internal/agentconfig"
 	"github.com/omnara-ai/omnara/internal/harness/tools"
 	"github.com/omnara-ai/omnara/internal/mcp"
 	"github.com/omnara-ai/omnara/internal/model"
@@ -64,7 +65,10 @@ mcp:
 	input := fixture.admitContentInputTurn(t, ctx, launch.Agent.ID, kernelTestUserID, "hello", now.Add(2*time.Millisecond))
 	modelClient := &sequenceKernelModel{
 		providerModelSlug: "test-model",
-		responses:         []model.Response{{ID: "resp-mcp", Content: []model.ResponsePart{{Type: "text", Text: "done"}}, StopReason: model.StopReasonEndTurn}},
+		responses: []model.Response{
+			{ID: "resp-mcp", Content: []model.ResponsePart{{Type: "text", Text: "done"}}, StopReason: model.StopReasonEndTurn},
+			{ID: "resp-mcp-removed", Content: []model.ResponsePart{{Type: "text", Text: "done without mcp"}}, StopReason: model.StopReasonEndTurn},
+		},
 	}
 	mcpClient := &fakeKernelMCPClient{
 		agentID:         "remote-session",
@@ -128,6 +132,71 @@ mcp:
 	}
 	if len(snapshot) != 1 || snapshot[0].Name != "greet" || snapshot[0].Description != "say hi" {
 		t.Fatalf("unexpected tools snapshot: %s", conn.ToolsSnapshot)
+	}
+	if err := fixture.Store.Execution().ReleaseAgentRuntimeLock(
+		ctx,
+		kernelTestProjectID,
+		launch.Agent.ID,
+		input.RuntimeLockID,
+	); err != nil {
+		t.Fatalf("release runtime before mcp config removal: %v", err)
+	}
+	nextConfig := fixture.kernelAgentConfigInput(t, ctx, "Kernel MCP Without MCP", "test-model")
+	if _, err := fixture.Store.Execution().ChangeAgentConfig(ctx, executionstore.ChangeAgentConfigInput{
+		CreateAgentConfigInput: nextConfig,
+		AgentID:                launch.Agent.ID,
+		Reason:                 "test_remove_mcp",
+		IdempotencyKey:         "kernel-mcp-remove-live",
+	}); err != nil {
+		t.Fatalf("remove mcp config: %v", err)
+	}
+	if _, _, _, err := fixture.Store.Execution().CreateAgentContentInput(
+		ctx,
+		executionstore.CreateAgentContentInputInput{
+			ProjectID:      kernelTestProjectID,
+			AgentID:        launch.Agent.ID,
+			Actor:          kernelTestOmnaraActorParams(t, kernelTestUserID),
+			ContentBlocks:  mustKernelJSON([]map[string]string{{"type": "text", "text": "continue"}}),
+			IdempotencyKey: "kernel-mcp-remove-input",
+		},
+	); err != nil {
+		t.Fatalf("create input after mcp config removal: %v", err)
+	}
+	claim, found, err := fixture.Store.Execution().ClaimNextAgentWork(
+		ctx,
+		kernelTestClaimInput(input.Now.Add(3*time.Second)),
+	)
+	if err != nil {
+		t.Fatalf("claim mcp config removal work: %v", err)
+	}
+	if !found || claim.AgentID != launch.Agent.ID || claim.Kind != executionstore.AgentWorkModel {
+		t.Fatalf("unexpected mcp config removal work: found=%t claim=%+v", found, claim)
+	}
+	next := modelWorkExecutionFromClaimForKernelTest(claim, input.Now.Add(4*time.Second))
+	if err := executor.ExecuteModelWork(ctx, next); err != nil {
+		t.Fatalf("execute mcp config removal work: %v", err)
+	}
+	if modelClient.preparedCount() != 2 || len(modelClient.prepared[1].ToolSpecs) != 0 {
+		t.Fatalf("expected second model prepare without mcp tools, got %+v", modelClient.prepared)
+	}
+	if mcpClient.initializeCount != 3 {
+		t.Fatalf("initialize count after mcp removal = %d, want 3", mcpClient.initializeCount)
+	}
+	removed, found, err := fixture.Store.Execution().GetMCPConnection(
+		ctx,
+		kernelTestProjectID,
+		launch.Agent.ID,
+		"docs",
+	)
+	if err != nil {
+		t.Fatalf("load removed mcp connection: %v", err)
+	}
+	if !found {
+		t.Fatal("expected removed mcp connection history")
+	}
+	if removed.State != executionstore.MCPConnectionStateExpired || removed.MCPSessionID != "" ||
+		string(removed.ToolsSnapshot) != "[]" || removed.Generation != conn.Generation+1 {
+		t.Fatalf("unexpected removed mcp connection: %+v", removed)
 	}
 }
 
@@ -457,6 +526,135 @@ mcp:
 	if conn.State != executionstore.MCPConnectionStateReady || conn.MCPSessionID != "remote-session-2" ||
 		conn.InitializeError != "" {
 		t.Fatalf("unexpected refreshed mcp connection: %+v", conn)
+	}
+}
+
+func TestAgentExecutorAppliesMCPConfigChangeAfterPendingTool(t *testing.T) {
+	ctx := context.Background()
+	fixture := newKernelFixture(t, ctx)
+	now := fixture.Now
+	oldSource := `
+name: Kernel MCP Config Change
+instruction: Use MCP tools.
+model:
+  provider_config: openai-prod
+  name: test-model
+mcp:
+  docs:
+    url: https://old.example.com/mcp
+    permission:
+      mode: always_allow
+`
+	profile := fixture.createConfigAndProfileBookmark(
+		t,
+		ctx,
+		"Kernel MCP Config Change",
+		"kernel-mcp-config-change",
+		oldSource,
+		now,
+	)
+	launch, err := fixture.Store.Execution().LaunchAgent(ctx, executionstore.LaunchAgentInput{
+		ProjectID:      kernelTestProjectID,
+		ProfileID:      profile.ID,
+		AgentConfigID:  profile.CurrentConfigID,
+		LaunchedBy:     kernelTestUserPrincipal(kernelTestUserID),
+		IdempotencyKey: "kernel-mcp-config-change-launch",
+	})
+	if err != nil {
+		t.Fatalf("launch agent: %v", err)
+	}
+	newSource := strings.Replace(oldSource, "https://old.example.com/mcp", "https://new.example.com/mcp", 1)
+	compiled := fixture.compileAgentYAMLResolved(t, ctx, newSource, now.Add(time.Second))
+	nextConfig := executionstore.CreateAgentConfigInput{
+		ProjectID:               kernelTestProjectID,
+		Definition:              json.RawMessage(compiled.CanonicalJSON),
+		Source:                  newSource,
+		SourceFormat:            "yaml",
+		ConfiguredModelID:       parseConfiguredModelID(t, compiled),
+		CompiledDefinition:      json.RawMessage(compiled.CanonicalJSON),
+		CompilerVersion:         agentconfig.CompilerVersion,
+		EffectiveDefinitionHash: compiled.Hash,
+	}
+	var changeErr error
+	modelClient := &sequenceKernelModel{
+		providerModelSlug: "test-model",
+		responses: []model.Response{
+			{
+				ID:         "resp-mcp-config-change-tool",
+				StopReason: model.StopReasonToolUse,
+				Content: modeltest.ResponsePartsForToolCalls([]model.ToolCall{{
+					ID:    "call_mcp_config_change",
+					Name:  toolcatalog.MCPRuntimeToolName("docs", "greet"),
+					Input: json.RawMessage(`{"name":"Ada"}`),
+				}}),
+			},
+			{ID: "resp-mcp-config-change-final", Content: []model.ResponsePart{{Type: "text", Text: "done"}}, StopReason: model.StopReasonEndTurn},
+		},
+		afterRespond: func(response model.Response) {
+			if response.ID != "resp-mcp-config-change-tool" {
+				return
+			}
+			_, changeErr = fixture.Store.Execution().ChangeAgentConfig(ctx, executionstore.ChangeAgentConfigInput{
+				CreateAgentConfigInput: nextConfig,
+				AgentID:                launch.Agent.ID,
+				Reason:                 "test_mcp_config_change",
+				IdempotencyKey:         "kernel-mcp-config-change-live",
+			})
+		},
+	}
+	mcpClient := &fakeKernelMCPClient{
+		protocolVersion:    mcp.ProtocolVersion,
+		initializeAgentIDs: []string{"remote-session-1", "remote-session-2"},
+		tools: []*sdkmcp.Tool{
+			{Name: "greet", Description: "say hi", InputSchema: map[string]any{"type": "object"}},
+		},
+		callToolResult: &sdkmcp.CallToolResult{
+			Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: "hello"}},
+		},
+	}
+	executor := AgentExecutor{
+		Store:         fixture.Store,
+		ModelResolver: liveTestModelResolver(fixture.Store, modelClient),
+		MCP:           mcpClient,
+		ToolExecutor:  tools.Executor{Store: fixture.Store, MCP: mcpClient},
+		Now:           func() time.Time { return now.Add(3 * time.Millisecond) },
+	}
+	input := fixture.admitContentInputTurn(
+		t,
+		ctx,
+		launch.Agent.ID,
+		kernelTestUserID,
+		"use mcp while its config changes",
+		now.Add(2*time.Millisecond),
+	)
+	executeAsyncToolTurn(t, ctx, fixture, executor, input)
+	if changeErr != nil {
+		t.Fatalf("change mcp config: %v", changeErr)
+	}
+	if mcpClient.initializeCount != 2 || mcpClient.callToolCount != 1 || len(mcpClient.callToolConns) != 1 {
+		t.Fatalf(
+			"unexpected mcp calls: initialize=%d call=%d conns=%+v",
+			mcpClient.initializeCount,
+			mcpClient.callToolCount,
+			mcpClient.callToolConns,
+		)
+	}
+	called := mcpClient.callToolConns[0]
+	if called.EndpointURL != "https://old.example.com/mcp" || called.MCPSessionID != "remote-session-1" {
+		t.Fatalf("pending tool used changed mcp connection: %+v", called)
+	}
+	conn, found, err := fixture.Store.Execution().GetMCPConnection(
+		ctx,
+		kernelTestProjectID,
+		launch.Agent.ID,
+		"docs",
+	)
+	if err != nil || !found {
+		t.Fatalf("load changed mcp connection: found=%t err=%v", found, err)
+	}
+	if conn.EndpointURL != "https://new.example.com/mcp" || conn.State != executionstore.MCPConnectionStateReady ||
+		conn.MCPSessionID != "remote-session-2" {
+		t.Fatalf("new model round did not initialize changed mcp connection: %+v", conn)
 	}
 }
 

--- a/internal/harness/kernel/agent_executor_unit_test.go
+++ b/internal/harness/kernel/agent_executor_unit_test.go
@@ -182,16 +182,12 @@ func TestShouldInitializeMCPConnectionPreservesRetryRecoveryWithoutRevivingFailu
 			t.Fatalf("opening mode excluded %q connection", state)
 		}
 	}
-	if !shouldInitializeMCPConnection(mcpInitializationResume, executionstore.MCPConnectionStateInitializing) {
-		t.Fatal("resume mode excluded interrupted initializing connection")
+	if !shouldInitializeMCPConnection(mcpInitializationResume, executionstore.MCPConnectionStateInitializing) ||
+		!shouldInitializeMCPConnection(mcpInitializationResume, executionstore.MCPConnectionStateExpired) {
+		t.Fatal("resume mode excluded recoverable connection")
 	}
-	for _, state := range []executionstore.MCPConnectionState{
-		executionstore.MCPConnectionStateFailed,
-		executionstore.MCPConnectionStateExpired,
-	} {
-		if shouldInitializeMCPConnection(mcpInitializationResume, state) {
-			t.Fatalf("resume mode revived %q connection", state)
-		}
+	if shouldInitializeMCPConnection(mcpInitializationResume, executionstore.MCPConnectionStateFailed) {
+		t.Fatal("resume mode revived failed connection")
 	}
 }
 

--- a/internal/harness/kernel/agent_executor_unit_test.go
+++ b/internal/harness/kernel/agent_executor_unit_test.go
@@ -172,18 +172,7 @@ func TestMCPInitializationRetryableFailureClassification(t *testing.T) {
 	}
 }
 
-func TestMCPInitializationModePreservesRetryRecoveryWithoutRevivingFailures(t *testing.T) {
-	contextID := unitKernelID("mcp-context")
-	if mode := mcpInitializationForExecution(0, storage.NilID); mode != mcpInitializationOpening {
-		t.Fatalf("fresh turn mode = %d, want opening", mode)
-	}
-	if mode := mcpInitializationForExecution(0, contextID); mode != mcpInitializationResume {
-		t.Fatalf("first-context retry mode = %d, want resume", mode)
-	}
-	if mode := mcpInitializationForExecution(1, contextID); mode != mcpInitializationNone {
-		t.Fatalf("tool continuation mode = %d, want none", mode)
-	}
-
+func TestShouldInitializeMCPConnectionPreservesRetryRecoveryWithoutRevivingFailures(t *testing.T) {
 	for _, state := range []executionstore.MCPConnectionState{
 		executionstore.MCPConnectionStateInitializing,
 		executionstore.MCPConnectionStateFailed,

--- a/internal/harness/tools/mcp_tool.go
+++ b/internal/harness/tools/mcp_tool.go
@@ -45,12 +45,6 @@ func (e Executor) dispatchMCPTool(
 	if !ok {
 		return toolResultContent{}, fmt.Errorf("invalid mcp tool name %q", call.Name)
 	}
-	// Dispatch resolves the connection by current server key. This is safe only
-	// because live config changes cannot alter MCP declarations yet
-	// (validateLiveAgentConfigChangeTx rejects MCP diffs), so the connection a
-	// pending call observes is always the one that produced it. When live MCP
-	// changes land, tool calls must record their producing MCP connection
-	// id/generation and dispatch must use that recorded identity instead.
 	conn, found, err := e.Store.Execution().GetMCPConnection(ctx, turn.ProjectID, turn.AgentID, serverKey)
 	if err != nil {
 		return toolResultContent{}, err

--- a/internal/httpapi/public_api_agent_launch_integration_test.go
+++ b/internal/httpapi/public_api_agent_launch_integration_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omnara-ai/omnara/internal/httpapi/openapi"
 	"github.com/omnara-ai/omnara/internal/publicid"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 )
@@ -386,7 +385,7 @@ func TestPublicAgentLaunchFlow(t *testing.T) {
 	}
 }
 
-func TestPublicAgentConfigChangeRejectsLiveMCPDiff(t *testing.T) {
+func TestPublicAgentConfigChangeAcceptsLiveMCPDiff(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	pool := openIntegrationDB(t, ctx)
@@ -443,14 +442,11 @@ mcp:
 		project.ProjectPath+"/agents/"+agentID+"/config",
 		`{"source_format":"yaml","source":`+quotedJSONString(changedYAML)+`}`,
 		"idem-config-policy-mcp-change",
-		http.StatusBadRequest,
+		http.StatusOK,
 		authHeaders(project.AdminToken),
 	)
-	if got := response["code"]; got != string(openapi.ErrorCodeInvalidRequest) {
-		t.Fatalf("unexpected config policy error code: %+v", response)
-	}
-	if got := response["error"]; got != "invalid request: live config changes cannot change mcp declarations yet" {
-		t.Fatalf("unexpected config policy error: %+v", response)
+	if response["agent_config"] == nil || response["agent_input"] == nil {
+		t.Fatalf("unexpected config change response: %+v", response)
 	}
 }
 

--- a/internal/storage/agent_mcp_connections_integration_test.go
+++ b/internal/storage/agent_mcp_connections_integration_test.go
@@ -245,6 +245,34 @@ mcp:
 	if _, found, err := store.Execution().GetMCPConnection(ctx, wrongProjectID, launch.Agent.ID, "docs"); err != nil || found {
 		t.Fatalf("wrong project lookup should not find connection, found=%t err=%v", found, err)
 	}
+	removed, err := store.Execution().ReconcileAgentMCPConnections(ctx, testProjectID, launch.Agent.ID, nil)
+	if err != nil {
+		t.Fatalf("reconcile removed server: %v", err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed reconciliation returned connections: %+v", removed)
+	}
+	expired, found, err = store.Execution().GetMCPConnection(ctx, testProjectID, launch.Agent.ID, "docs")
+	if err != nil || !found {
+		t.Fatalf("load removed connection: found=%t err=%v", found, err)
+	}
+	if expired.State != executionstore.MCPConnectionStateExpired || expired.Generation != current.Generation+1 {
+		t.Fatalf("removed connection was not expired: %+v", expired)
+	}
+
+	readded, err := store.Execution().ReconcileAgentMCPConnections(
+		ctx,
+		testProjectID,
+		launch.Agent.ID,
+		launch.MCPServers,
+	)
+	if err != nil {
+		t.Fatalf("reconcile re-added server: %v", err)
+	}
+	if len(readded) != 1 || readded[0].State != executionstore.MCPConnectionStateExpired ||
+		readded[0].MCPSessionID != "" || !readded[0].UpdatedAt.Equal(expired.UpdatedAt) {
+		t.Fatalf("re-added server reused stale connection: %+v", readded)
+	}
 }
 
 func TestRuntimeMCPServerResolveTool(t *testing.T) {

--- a/internal/storage/executionstore/agent_config_changes_store.go
+++ b/internal/storage/executionstore/agent_config_changes_store.go
@@ -221,12 +221,6 @@ func validateLiveAgentConfigChangeTx(
 			err,
 		)
 	}
-	if !reflect.DeepEqual(currentContract.MCPServers, nextContract.MCPServers) {
-		return agentconfig.RuntimeContract{}, agentconfig.RuntimeContract{}, storeerr.InvalidRequest(errors.New(
-			"live config changes cannot change mcp declarations yet",
-		))
-
-	}
 	return currentContract, nextContract, nil
 }
 

--- a/internal/storage/executionstore/agent_mcp_connections_store.go
+++ b/internal/storage/executionstore/agent_mcp_connections_store.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/omnara-ai/omnara/internal/agentconfig"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
 )
@@ -40,58 +41,89 @@ type MCPConnectionRecord struct {
 	UpdatedAt          time.Time          `json:"updated_at"`
 }
 
-type GetOrCreateMCPConnectionInput struct {
-	ProjectID   ID
-	AgentID     ID
-	ServerKey   string
-	EndpointURL string
-	ConfigHash  string
-}
-
-func (s *Store) GetOrCreateMCPConnection(
+func (s *Store) ReconcileAgentMCPConnections(
 	ctx context.Context,
-	input GetOrCreateMCPConnectionInput,
-) (MCPConnectionRecord, error) {
-	if isNilID(input.ProjectID) || isNilID(input.AgentID) {
-		return MCPConnectionRecord{}, errors.New("project and agent are required")
+	projectID, agentID ID,
+	servers []agentconfig.RuntimeMCPServer,
+) ([]MCPConnectionRecord, error) {
+	if isNilID(projectID) || isNilID(agentID) {
+		return nil, errors.New("project and agent are required")
 	}
-	if input.ServerKey == "" || input.EndpointURL == "" || input.ConfigHash == "" {
-		return MCPConnectionRecord{}, errors.New(
-			"server key, endpoint url, and config hash are required",
-		)
+	desired := make(map[string]string, len(servers))
+	for _, server := range servers {
+		configHash, err := mcpServerConfigHash(server)
+		if err != nil {
+			return nil, fmt.Errorf("hash mcp server %q config: %w", server.ServerKey, err)
+		}
+		desired[server.ServerKey] = configHash
+	}
+	current, err := s.ListAgentMCPConnections(ctx, projectID, agentID)
+	if err != nil {
+		return nil, err
+	}
+	connections := make([]MCPConnectionRecord, 0, len(servers))
+	reconciled := true
+	for _, connection := range current {
+		configHash, configured := desired[connection.ServerKey]
+		if configured {
+			if connection.ConfigHash == configHash {
+				connections = append(connections, connection)
+			} else {
+				reconciled = false
+			}
+			continue
+		}
+		if connection.State != MCPConnectionStateExpired {
+			reconciled = false
+		}
+	}
+	if reconciled && len(connections) == len(servers) && len(current) > 0 {
+		return connections, nil
 	}
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
-		return MCPConnectionRecord{}, fmt.Errorf("begin get or create mcp connection: %w", err)
+		return nil, fmt.Errorf("begin reconcile agent mcp connections: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 	qtx := dbsqlc.New(tx)
 	if _, err := qtx.LockAgentInProject(
 		ctx,
-		dbsqlc.LockAgentInProjectParams{ProjectID: input.ProjectID, ID: input.AgentID},
+		dbsqlc.LockAgentInProjectParams{ProjectID: projectID, ID: agentID},
 	); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return MCPConnectionRecord{}, storeerr.ErrNotFound
+			return nil, storeerr.ErrNotFound
 		}
-		return MCPConnectionRecord{}, fmt.Errorf("lock agent for mcp connection: %w", err)
+		return nil, fmt.Errorf("lock agent for mcp reconciliation: %w", err)
 	}
-	row, err := qtx.GetOrCreateMCPConnection(ctx, dbsqlc.GetOrCreateMCPConnectionParams{
-		ProjectID:   input.ProjectID,
-		AgentID:     input.AgentID,
-		ServerKey:   input.ServerKey,
-		EndpointUrl: input.EndpointURL,
-		ConfigHash:  input.ConfigHash,
-	})
-	if errors.Is(err, pgx.ErrNoRows) {
-		return MCPConnectionRecord{}, storeerr.ErrNotFound
-	}
+	connections, err = createAgentMCPConnectionsTx(ctx, qtx, projectID, agentID, servers)
 	if err != nil {
-		return MCPConnectionRecord{}, fmt.Errorf("get or create mcp connection: %w", err)
+		return nil, err
+	}
+	rows, err := qtx.ListAgentMCPConnections(
+		ctx,
+		dbsqlc.ListAgentMCPConnectionsParams{ProjectID: projectID, AgentID: agentID},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list agent mcp connections for reconciliation: %w", err)
+	}
+	for _, row := range rows {
+		if _, ok := desired[row.ServerKey]; ok || MCPConnectionState(row.State) == MCPConnectionStateExpired {
+			continue
+		}
+		_, err := qtx.MarkMCPConnectionExpired(ctx, dbsqlc.MarkMCPConnectionExpiredParams{
+			ProjectID:          projectID,
+			AgentID:            agentID,
+			ID:                 row.ID,
+			GenerationObserved: row.Generation,
+		})
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("expire removed mcp connection %q: %w", row.ServerKey, err)
+		}
 	}
 	if err := tx.Commit(ctx); err != nil {
-		return MCPConnectionRecord{}, fmt.Errorf("commit get or create mcp connection: %w", err)
+		return nil, fmt.Errorf("commit agent mcp reconciliation: %w", err)
 	}
-	return mcpConnectionRecordFromSQLC(row), nil
+	return connections, nil
 }
 
 func (s *Store) GetMCPConnection(

--- a/internal/storage/executionstore/agent_mcp_connections_store.go
+++ b/internal/storage/executionstore/agent_mcp_connections_store.go
@@ -50,12 +50,14 @@ func (s *Store) ReconcileAgentMCPConnections(
 		return nil, errors.New("project and agent are required")
 	}
 	desired := make(map[string]string, len(servers))
+	serverKeys := make([]string, 0, len(servers))
 	for _, server := range servers {
 		configHash, err := mcpServerConfigHash(server)
 		if err != nil {
 			return nil, fmt.Errorf("hash mcp server %q config: %w", server.ServerKey, err)
 		}
 		desired[server.ServerKey] = configHash
+		serverKeys = append(serverKeys, server.ServerKey)
 	}
 	current, err := s.ListAgentMCPConnections(ctx, projectID, agentID)
 	if err != nil {
@@ -99,26 +101,12 @@ func (s *Store) ReconcileAgentMCPConnections(
 	if err != nil {
 		return nil, err
 	}
-	rows, err := qtx.ListAgentMCPConnections(
-		ctx,
-		dbsqlc.ListAgentMCPConnectionsParams{ProjectID: projectID, AgentID: agentID},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("list agent mcp connections for reconciliation: %w", err)
-	}
-	for _, row := range rows {
-		if _, ok := desired[row.ServerKey]; ok || MCPConnectionState(row.State) == MCPConnectionStateExpired {
-			continue
-		}
-		_, err := qtx.MarkMCPConnectionExpired(ctx, dbsqlc.MarkMCPConnectionExpiredParams{
-			ProjectID:          projectID,
-			AgentID:            agentID,
-			ID:                 row.ID,
-			GenerationObserved: row.Generation,
-		})
-		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return nil, fmt.Errorf("expire removed mcp connection %q: %w", row.ServerKey, err)
-		}
+	if err := qtx.ExpireRemovedMCPConnections(ctx, dbsqlc.ExpireRemovedMCPConnectionsParams{
+		ProjectID:  projectID,
+		AgentID:    agentID,
+		ServerKeys: serverKeys,
+	}); err != nil {
+		return nil, fmt.Errorf("expire removed mcp connections: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return nil, fmt.Errorf("commit agent mcp reconciliation: %w", err)

--- a/internal/storage/executionstore/agents_integration_test.go
+++ b/internal/storage/executionstore/agents_integration_test.go
@@ -1185,7 +1185,7 @@ func isPgCode(err error, code string) bool {
 	return errors.As(err, &pgErr) && pgErr.Code == code
 }
 
-func TestChangeAgentConfigRejectsLiveMCPDiffs(t *testing.T) {
+func TestChangeAgentConfigAcceptsLiveMCPDiffs(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	pool := openIntegrationDB(t, ctx)
@@ -1214,14 +1214,6 @@ model:
 	if err != nil {
 		t.Fatalf("launch with config: %v", err)
 	}
-	initialAgent, err := store.Execution().GetAgentInProject(ctx, testProjectID, launch.Agent.ID)
-	if err != nil {
-		t.Fatalf("load initial agent: %v", err)
-	}
-	initialEvents, err := store.Execution().ListAgentEventsForRead(ctx, testProjectID, launch.Agent.ID, 0, 100)
-	if err != nil {
-		t.Fatalf("list initial events: %v", err)
-	}
 	yaml := `
 name: Policy Profile
 instruction: Add MCP.
@@ -1233,7 +1225,7 @@ mcp:
     url: https://mcp.example.com
 `
 	compiled := mustCompileAgentYAMLResolved(t, ctx, store, yaml, now.Add(2*time.Second))
-	_, err = store.Execution().ChangeAgentConfig(ctx, executionstore.ChangeAgentConfigInput{
+	changed, err := store.Execution().ChangeAgentConfig(ctx, executionstore.ChangeAgentConfigInput{
 		CreateAgentConfigInput: executionstore.CreateAgentConfigInput{
 			ProjectID:               testProjectID,
 			Definition:              json.RawMessage(compiled.CanonicalJSON),
@@ -1249,22 +1241,15 @@ mcp:
 		Reason:         "policy-test",
 		IdempotencyKey: "idem-config-policy-mcp",
 	})
-	if err == nil || !strings.Contains(err.Error(), "live config changes cannot change mcp declarations yet") {
-		t.Fatalf("change config error=%v, want live MCP rejection", err)
+	if err != nil {
+		t.Fatalf("change config: %v", err)
 	}
 	loaded, err := store.Execution().GetAgentInProject(ctx, testProjectID, launch.Agent.ID)
 	if err != nil {
-		t.Fatalf("load agent after rejected change: %v", err)
+		t.Fatalf("load agent after change: %v", err)
 	}
-	if loaded.CurrentConfigID != initialAgent.CurrentConfigID {
-		t.Fatalf("rejected change advanced current config: before=%+v after=%+v", initialAgent, loaded)
-	}
-	events, err := store.Execution().ListAgentEventsForRead(ctx, testProjectID, launch.Agent.ID, 0, 100)
-	if err != nil {
-		t.Fatalf("list events after rejected change: %v", err)
-	}
-	if len(events) != len(initialEvents) {
-		t.Fatalf("rejected change appended events: before=%d after=%d events=%+v", len(initialEvents), len(events), events)
+	if loaded.CurrentConfigID != changed.AgentConfig.ID {
+		t.Fatalf("current config = %s, want %s", loaded.CurrentConfigID, changed.AgentConfig.ID)
 	}
 }
 

--- a/internal/storage/executionstore/agents_integration_test.go
+++ b/internal/storage/executionstore/agents_integration_test.go
@@ -1251,6 +1251,25 @@ mcp:
 	if loaded.CurrentConfigID != changed.AgentConfig.ID {
 		t.Fatalf("current config = %s, want %s", loaded.CurrentConfigID, changed.AgentConfig.ID)
 	}
+	currentConfig, found, err := store.Execution().GetAgentConfig(ctx, testProjectID, loaded.CurrentConfigID)
+	if err != nil {
+		t.Fatalf("load current config: %v", err)
+	}
+	if !found {
+		t.Fatal("current config not found")
+	}
+	contract, err := agentconfig.RuntimeContractFromCompiled(
+		currentConfig.CompiledDefinition,
+		currentConfig.CompilerVersion,
+		currentConfig.EffectiveDefinitionHash,
+	)
+	if err != nil {
+		t.Fatalf("load current runtime contract: %v", err)
+	}
+	if len(contract.MCPServers) != 1 || contract.MCPServers[0].ServerKey != "docs" ||
+		contract.MCPServers[0].URL != "https://mcp.example.com" {
+		t.Fatalf("current MCP servers = %+v, want docs at https://mcp.example.com", contract.MCPServers)
+	}
 }
 
 func TestChangeAgentConfigReconcilesExplicitMachineSources(t *testing.T) {

--- a/internal/storage/internal/dbsqlc/agent_mcp_connections.sql.go
+++ b/internal/storage/internal/dbsqlc/agent_mcp_connections.sql.go
@@ -64,6 +64,35 @@ func (q *Queries) BeginMCPConnectionInitialization(ctx context.Context, arg Begi
 	return i, err
 }
 
+const expireRemovedMCPConnections = `-- name: ExpireRemovedMCPConnections :exec
+UPDATE agent_mcp_connections connection
+SET state = 'expired',
+    protocol_version = '',
+    mcp_session_id = '',
+    server_capabilities = '{}'::jsonb,
+    server_info = '{}'::jsonb,
+    tools_snapshot = '[]'::jsonb,
+    generation = connection.generation + 1,
+    updated_at = transaction_timestamp()
+FROM agents agent
+WHERE agent.project_id = $1
+  AND agent.id = connection.agent_id
+  AND connection.agent_id = $2
+  AND connection.server_key <> ALL($3::text[])
+  AND connection.state <> 'expired'
+`
+
+type ExpireRemovedMCPConnectionsParams struct {
+	ProjectID  uuid.UUID
+	AgentID    uuid.UUID
+	ServerKeys []string
+}
+
+func (q *Queries) ExpireRemovedMCPConnections(ctx context.Context, arg ExpireRemovedMCPConnectionsParams) error {
+	_, err := q.db.Exec(ctx, expireRemovedMCPConnections, arg.ProjectID, arg.AgentID, arg.ServerKeys)
+	return err
+}
+
 const getMCPConnection = `-- name: GetMCPConnection :one
 SELECT connection.id, connection.agent_id, connection.server_key,
        connection.endpoint_url, connection.config_hash, connection.state,

--- a/internal/storage/queries/agent_mcp_connections.sql
+++ b/internal/storage/queries/agent_mcp_connections.sql
@@ -163,6 +163,23 @@ RETURNING connection.id, connection.agent_id, connection.server_key,
           connection.generation, connection.request_sequence,
           connection.created_at, connection.updated_at;
 
+-- name: ExpireRemovedMCPConnections :exec
+UPDATE agent_mcp_connections connection
+SET state = 'expired',
+    protocol_version = '',
+    mcp_session_id = '',
+    server_capabilities = '{}'::jsonb,
+    server_info = '{}'::jsonb,
+    tools_snapshot = '[]'::jsonb,
+    generation = connection.generation + 1,
+    updated_at = transaction_timestamp()
+FROM agents agent
+WHERE agent.project_id = sqlc.arg(project_id)
+  AND agent.id = connection.agent_id
+  AND connection.agent_id = sqlc.arg(agent_id)
+  AND connection.server_key <> ALL(sqlc.arg(server_keys)::text[])
+  AND connection.state <> 'expired';
+
 -- name: MarkMCPConnectionExpired :one
 UPDATE agent_mcp_connections connection
 SET state = 'expired',


### PR DESCRIPTION
- Allows live agent config updates to add, change, or remove MCP declarations instead of rejecting the request.
- Reconciles MCP connection rows at model-work boundaries, reusing unchanged connections, reinitializing changed servers, and expiring removed servers without a steady-state lock transaction.
- Keeps pending tool calls pinned to their originating MCP config, then applies endpoint, authentication, permission, and tool-surface changes on the next model round.
