### PR TITLE
fix: wait for machine bindings before tool dispatch

### DIFF
--- a/internal/harness/tools/executor.go
+++ b/internal/harness/tools/executor.go
@@ -54,6 +54,26 @@ func (e Executor) Dispatch(ctx context.Context, turn Turn, call model.ToolCall) 
 			proposal.State == executionstore.ToolCallStateAwaitingPermission) {
 		return Result{}, ErrActionRequired
 	}
+	if execErr == nil && call.Name == toolcatalog.ToolNameRunCommand {
+		resolved, resolveErr := resolveRunCommandRequest(call.Input)
+		if resolveErr != nil {
+			return Result{}, resolveErr
+		}
+		_, resolveErr = e.waitForMachineExecutionTarget(ctx, turn, resolved.MachineRef)
+		if resolveErr != nil {
+			if !errors.Is(resolveErr, ErrNoActiveAgentMachineBinding) &&
+				!errors.Is(resolveErr, ErrMachineRefUnavailable) &&
+				!errors.Is(resolveErr, ErrMachineSelectionRequired) {
+				return Result{}, resolveErr
+			}
+			unavailable, unavailableErr := machineUnavailableToolResult(resolveErr)
+			if unavailableErr != nil {
+				return Result{}, unavailableErr
+			}
+			content = unavailable.Content
+			execErr = unavailable.Cause
+		}
+	}
 	if execErr == nil {
 		dispatchResult, err = e.dispatchToolHandler(
 			ctx,

--- a/internal/harness/tools/machine_execution_target.go
+++ b/internal/harness/tools/machine_execution_target.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 )
@@ -10,6 +11,11 @@ import (
 var ErrNoActiveAgentMachineBinding = errors.New("no_active_agent_machine_binding")
 var ErrMachineSelectionRequired = errors.New("machine_selection_required")
 var ErrMachineRefUnavailable = errors.New("machine_ref_unavailable")
+
+const (
+	defaultMachineBindingWaitTimeout  = 30 * time.Second
+	defaultMachineBindingPollInterval = 250 * time.Millisecond
+)
 
 func (e Executor) ResolveMachineExecutionTarget(
 	ctx context.Context,
@@ -24,6 +30,52 @@ func (e Executor) ResolveMachineExecutionTarget(
 		return executionstore.AgentMachineBindingRecord{}, err
 	}
 	return selectMachineExecutionTarget(bindings, machineRef)
+}
+
+func (e Executor) waitForMachineExecutionTarget(
+	ctx context.Context,
+	turn Turn,
+	machineRef string,
+) (executionstore.AgentMachineBindingRecord, error) {
+	if e.Store == nil {
+		return executionstore.AgentMachineBindingRecord{}, errors.New("tool executor store is required")
+	}
+	timeout := e.MachineBindingWaitTimeout
+	if timeout <= 0 {
+		timeout = defaultMachineBindingWaitTimeout
+	}
+	interval := e.MachineBindingPollInterval
+	if interval <= 0 {
+		interval = defaultMachineBindingPollInterval
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	for {
+		bindings, err := e.Store.Execution().ListExecutableAgentMachineBindings(
+			waitCtx,
+			turn.ProjectID,
+			turn.AgentID,
+		)
+		if err != nil {
+			if waitCtx.Err() != nil && ctx.Err() == nil {
+				return executionstore.AgentMachineBindingRecord{}, ErrNoActiveAgentMachineBinding
+			}
+			return executionstore.AgentMachineBindingRecord{}, err
+		}
+		if len(bindings) > 0 {
+			return selectMachineExecutionTarget(bindings, machineRef)
+		}
+		timer := time.NewTimer(interval)
+		select {
+		case <-waitCtx.Done():
+			timer.Stop()
+			if ctx.Err() != nil {
+				return executionstore.AgentMachineBindingRecord{}, ctx.Err()
+			}
+			return executionstore.AgentMachineBindingRecord{}, ErrNoActiveAgentMachineBinding
+		case <-timer.C:
+		}
+	}
 }
 
 func resolveMachineExecutionTargetForToolCall(

--- a/internal/harness/tools/machine_execution_target_integration_test.go
+++ b/internal/harness/tools/machine_execution_target_integration_test.go
@@ -191,6 +191,55 @@ func TestResolveMachineExecutionTargetUsesMachineRefSelection(t *testing.T) {
 	_ = secondAgentBinding
 }
 
+func TestWaitForMachineExecutionTargetPollsUntilBindingIsActive(t *testing.T) {
+	ctx := context.Background()
+	fixture := newMachineDispatchFixture(t, ctx, "wait-for-binding")
+	machine := createExecutableBinding(
+		t,
+		ctx,
+		fixture.Store,
+		fixture.UserID,
+		"wait-for-binding",
+		fixture.Now.Add(5*time.Second),
+	)
+	insertDone := make(chan error, 1)
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		_, err := fixture.Pool.Exec(
+			ctx,
+			`INSERT INTO agent_machine_bindings(
+			   org_id, project_id, agent_id, machine_id, machine_ref, binding_kind, state, created_at, updated_at
+			 )
+			 VALUES ($1, $2, $3, $4, 'mchr-waited', 'explicit', 'attached', $5, $5)`,
+			toolsTestOrgID,
+			toolsTestProjectID,
+			fixture.Launch.Agent.ID,
+			machine.MachineID,
+			fixture.Now.Add(6*time.Second),
+		)
+		insertDone <- err
+	}()
+	executor := Executor{
+		Store:                      fixture.Store,
+		MachineBindingWaitTimeout:  time.Second,
+		MachineBindingPollInterval: 10 * time.Millisecond,
+	}
+	binding, err := executor.waitForMachineExecutionTarget(
+		ctx,
+		Turn{ProjectID: toolsTestProjectID, AgentID: fixture.Launch.Agent.ID},
+		"mchr-waited",
+	)
+	if err != nil {
+		t.Fatalf("wait for machine target: %v", err)
+	}
+	if err := <-insertDone; err != nil {
+		t.Fatalf("attach delayed machine: %v", err)
+	}
+	if binding.MachineID != machine.MachineID || binding.MachineRef != "mchr-waited" {
+		t.Fatalf("resolved delayed binding = %+v", binding)
+	}
+}
+
 func TestApprovedImplicitMachineTargetChangeFailsTerminally(t *testing.T) {
 	ctx := context.Background()
 	fixture := newMachineDispatchFixture(t, ctx, "approved-machine-target-change")

--- a/internal/harness/tools/permission_modes.go
+++ b/internal/harness/tools/permission_modes.go
@@ -379,7 +379,7 @@ func runCommandPermissionChallenge(
 	if err != nil {
 		return toolpermission.Request{}, err
 	}
-	binding, err := executor.ResolveMachineExecutionTarget(ctx, turn, resolved.MachineRef)
+	binding, err := executor.waitForMachineExecutionTarget(ctx, turn, resolved.MachineRef)
 	if err != nil {
 		return toolpermission.Request{}, executor.machinePreparationError(err)
 	}

--- a/internal/harness/tools/types.go
+++ b/internal/harness/tools/types.go
@@ -51,18 +51,20 @@ type ToolSpec struct {
 }
 
 type Executor struct {
-	Store                    *storage.Store
-	Skills                   SkillStore
-	MCP                      mcp.Client
-	IntegrationHTTPClient    *http.Client
-	MCPAuthHTTPClient        *http.Client
-	WebSearch                webaccess.SearchProvider
-	WebFetcher               *webaccess.Fetcher
-	MachinePoolManager       machinePoolManager
-	BackgroundRunner         BackgroundRunner
-	Now                      func() time.Time
-	MCPInitializationBackoff func(attempt int) time.Duration
-	SkillBroadcaster         SkillBroadcaster
+	Store                      *storage.Store
+	Skills                     SkillStore
+	MCP                        mcp.Client
+	IntegrationHTTPClient      *http.Client
+	MCPAuthHTTPClient          *http.Client
+	WebSearch                  webaccess.SearchProvider
+	WebFetcher                 *webaccess.Fetcher
+	MachinePoolManager         machinePoolManager
+	BackgroundRunner           BackgroundRunner
+	Now                        func() time.Time
+	MachineBindingWaitTimeout  time.Duration
+	MachineBindingPollInterval time.Duration
+	MCPInitializationBackoff   func(attempt int) time.Duration
+	SkillBroadcaster           SkillBroadcaster
 }
 
 func (e Executor) skillStore() SkillStore {

--- a/internal/harness/worker/worker_integration_test.go
+++ b/internal/harness/worker/worker_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/omnara-ai/omnara/internal/agentconfig"
 	"github.com/omnara-ai/omnara/internal/harness/kernel"
+	"github.com/omnara-ai/omnara/internal/harness/tools"
 	"github.com/omnara-ai/omnara/internal/interactionform"
 	"github.com/omnara-ai/omnara/internal/model"
 	"github.com/omnara-ai/omnara/internal/modelcontext"
@@ -1233,7 +1234,11 @@ func TestWorkerKernelMachineToolWithoutBindingFailsBeforeApproval(t *testing.T) 
 		Store:          store,
 		ContextBuilder: modelcontext.Builder{Store: modelcontext.NewStore(store.Execution(), store.Artifacts(), store.Integrations())},
 		ModelResolver:  liveWorkerTestModelResolver(store, modelClient),
-		Now:            func() time.Time { return now.Add(2 * time.Second) },
+		ToolExecutor: tools.Executor{
+			MachineBindingWaitTimeout:  time.Millisecond,
+			MachineBindingPollInterval: time.Millisecond,
+		},
+		Now: func() time.Time { return now.Add(2 * time.Second) },
 	}
 	worker := NewWorker(store.Execution(), executor, Options{RuntimeLockLeaseDuration: 15 * time.Second, Capacity: 1})
 	requireWorkerClaim(t, ctx, worker, "persist no-machine command output")


### PR DESCRIPTION
## Summary
- poll for an executable machine binding before preparing run command permissions
- poll again before dispatch so always-allowed commands also wait for startup
- preserve the existing terminal error after the bounded wait expires
- cover delayed binding availability and retain fast timeout coverage

## Testing
- `git diff --check`
- Go test compilation attempted with Go 1.26.5; the compiler was killed by the constrained runner before tests executed