### PR TITLE
feat: isolate cluster-managed provider secrets

### DIFF
--- a/internal/httpapi/default_model_provider_org_integration_test.go
+++ b/internal/httpapi/default_model_provider_org_integration_test.go
@@ -334,13 +334,24 @@ func TestCreateOrganizationProvisionsHostedCredentialBeforeAtomicLocalCreation(t
 		t.Fatalf("unexpected cluster credential: %+v", credential)
 	}
 	payload, err := store.Secrets().ReadOrgOwnedSecretPayload(ctx, secretstore.ReadOrgOwnedSecretPayloadInput{
-		OrgID: orgID, SecretID: credential.ID, Kind: secretstore.SecretKindGeneric,
+		OrgID:          orgID,
+		SecretID:       credential.ID,
+		ManagementKind: management.Cluster,
+		Kind:           secretstore.SecretKindGeneric,
 	})
 	if err != nil {
 		t.Fatalf("read cluster credential payload: %v", err)
 	}
 	if payload.Payload[secrets.KeyValue] != "sk-cluster-openrouter" {
 		t.Fatalf("cluster credential value = %q", payload.Payload[secrets.KeyValue])
+	}
+	if _, err := store.Secrets().ReadOrgOwnedSecretPayload(ctx, secretstore.ReadOrgOwnedSecretPayloadInput{
+		OrgID:          orgID,
+		SecretID:       credential.ID,
+		ManagementKind: management.Tenant,
+		Kind:           secretstore.SecretKindGeneric,
+	}); !errors.Is(err, storeerr.ErrNotFound) {
+		t.Fatalf("read cluster credential as tenant-managed error = %v, want not found", err)
 	}
 	models, err := store.Models().ListConfiguredModels(ctx, modelstore.ListConfiguredModelsInput{
 		OrgID: orgID, ProviderConfigID: provider.ID, Limit: 10,
@@ -367,6 +378,15 @@ func TestCreateOrganizationProvisionsHostedCredentialBeforeAtomicLocalCreation(t
 	publicSecretID, err := publicid.Encode(publicid.KindSecret, credential.ID)
 	if err != nil {
 		t.Fatalf("encode credential secret id: %v", err)
+	}
+	if _, err := store.Execution().ResolveEnvironmentSecrets(
+		ctx,
+		orgID,
+		storage.NilID,
+		[]byte(`{}`),
+		[]byte(`{"OPENROUTER_API_KEY":"`+publicSecretID+`"}`),
+	); err == nil || !errors.Is(err, storeerr.ErrPermanentEnvironment) {
+		t.Fatalf("resolve cluster credential in org-scoped environment error = %v, want permanent environment error", err)
 	}
 	requestJSONWithHeaders(
 		t,
@@ -396,6 +416,59 @@ func TestCreateOrganizationProvisionsHostedCredentialBeforeAtomicLocalCreation(t
 		`{"name":"tenant-renamed"}`,
 		"",
 		http.StatusConflict,
+		authHeaders(token),
+	)
+	requestJSONWithHeaders(
+		t,
+		handler,
+		http.MethodPost,
+		"/api/v1/orgs/"+publicOrgID+"/model-provider-configs",
+		`{"name":"reused-hosted-key","preset":"openrouter","credential_secret_id":"`+publicSecretID+`"}`,
+		"",
+		http.StatusBadRequest,
+		authHeaders(token),
+	)
+	requestJSONWithHeaders(
+		t,
+		handler,
+		http.MethodPost,
+		"/api/v1/orgs/"+publicOrgID+"/secrets/"+publicSecretID+"/grants",
+		`{"target_project_id":"`+projectResponse["id"].(string)+`"}`,
+		"",
+		http.StatusConflict,
+		authHeaders(token),
+	)
+	grantList := requestJSONWithHeaders(
+		t,
+		handler,
+		http.MethodGet,
+		"/api/v1/orgs/"+publicOrgID+"/secrets/"+publicSecretID+"/grants",
+		"",
+		"",
+		http.StatusOK,
+		authHeaders(token),
+	)["data"].([]any)
+	if len(grantList) != 0 {
+		t.Fatalf("cluster credential grants = %+v, want empty", grantList)
+	}
+	poolCredential := requestJSONWithHeaders(
+		t,
+		handler,
+		http.MethodPost,
+		"/api/v1/orgs/"+publicOrgID+"/secrets",
+		`{"owner":{"kind":"org"},"name":"tenant-pool-key","material":{"kind":"generic","value":"pool-key"}}`,
+		"",
+		http.StatusCreated,
+		authHeaders(token),
+	)
+	requestJSONWithHeaders(
+		t,
+		handler,
+		http.MethodPost,
+		"/api/v1/orgs/"+publicOrgID+"/machine-pools",
+		`{"name":"hosted-key-env","provider":"unikraft","default_machine_memory_mb":1024,"default_machine_cpu":1,"default_machine_env":{},"default_machine_secret_env":{"OPENROUTER_API_KEY":"`+publicSecretID+`"},"default_machine_provider_options":{"image":"test","metro":"sfo"},"default_cwd":"/workspace","provider_config":{},"provider_auth_secret_id":"`+poolCredential["id"].(string)+`","max_total_machines":1,"max_total_cpu":2,"max_total_memory_mb":4096,"max_machine_cpu":2,"max_machine_memory_mb":4096}`,
+		"",
+		http.StatusNotFound,
 		authHeaders(token),
 	)
 	requestJSONWithHeaders(

--- a/internal/httpapi/model_provider_config_routes.go
+++ b/internal/httpapi/model_provider_config_routes.go
@@ -347,9 +347,10 @@ func (s strictOpenAPIServer) discoverProviderModels(
 		}
 	}
 	credential, err := s.server.store.Secrets().ReadOrgOwnedSecretPayload(ctx, secretstore.ReadOrgOwnedSecretPayloadInput{
-		OrgID:    orgID,
-		SecretID: record.CredentialSecretID,
-		Kind:     secretstore.SecretKindGeneric,
+		OrgID:          orgID,
+		SecretID:       record.CredentialSecretID,
+		ManagementKind: record.ManagementKind,
+		Kind:           secretstore.SecretKindGeneric,
 	})
 	if err != nil {
 		return failed("could not read the credential secret")

--- a/internal/modelprovider/resolver.go
+++ b/internal/modelprovider/resolver.go
@@ -153,9 +153,10 @@ func (r Resolver) Resolve(ctx context.Context, selection model.Selection) (model
 	credential, err := r.Secrets.ReadOrgOwnedSecretPayload(
 		ctx,
 		secretstore.ReadOrgOwnedSecretPayloadInput{
-			OrgID:    orgID,
-			SecretID: providerConfig.CredentialSecretID,
-			Kind:     secretstore.SecretKindGeneric,
+			OrgID:          orgID,
+			SecretID:       providerConfig.CredentialSecretID,
+			ManagementKind: providerConfig.ManagementKind,
+			Kind:           secretstore.SecretKindGeneric,
 		},
 	)
 	if err != nil {

--- a/internal/storage/executionstore/machine_config.go
+++ b/internal/storage/executionstore/machine_config.go
@@ -275,9 +275,10 @@ func (s *Store) ResolveMachineProviderCredential(
 			return MachineProviderCredential{}, errors.New("provider_auth_secret_id is required")
 		}
 		credential, err := s.secrets.ReadOrgOwnedSecretPayload(ctx, secretstore.ReadOrgOwnedSecretPayloadInput{
-			OrgID:    orgID,
-			SecretID: providerAuthSecretID,
-			Kind:     secretstore.SecretKindGeneric,
+			OrgID:          orgID,
+			SecretID:       providerAuthSecretID,
+			ManagementKind: management.Tenant,
+			Kind:           secretstore.SecretKindGeneric,
 		})
 		if err != nil {
 			if errors.Is(err, storeerr.ErrNotFound) {
@@ -828,9 +829,10 @@ func (s *Store) readEnvironmentSecretPayload(
 ) (secretstore.SecretPayloadRecord, error) {
 	if isNilID(projectID) {
 		return s.secrets.ReadOrgOwnedSecretPayload(ctx, secretstore.ReadOrgOwnedSecretPayloadInput{
-			OrgID:    orgID,
-			SecretID: secretID,
-			Kind:     secretstore.SecretKindGeneric,
+			OrgID:          orgID,
+			SecretID:       secretID,
+			ManagementKind: management.Tenant,
+			Kind:           secretstore.SecretKindGeneric,
 		})
 	}
 	return s.secrets.ReadProjectAvailableSecretPayload(ctx, secretstore.ReadProjectAvailableSecretPayloadInput{

--- a/internal/storage/identity_integration_test.go
+++ b/internal/storage/identity_integration_test.go
@@ -665,7 +665,10 @@ func TestCreateOrgForUserCreatesClusterManagedModelProviderAtomically(t *testing
 		t.Fatalf("tenant machine environment with cluster credential error = %v, want not found", err)
 	}
 	payload, err := store.Secrets().ReadOrgOwnedSecretPayload(ctx, secretstore.ReadOrgOwnedSecretPayloadInput{
-		OrgID: created.Org.ID, SecretID: credential.ID, Kind: secretstore.SecretKindGeneric,
+		OrgID:          created.Org.ID,
+		SecretID:       credential.ID,
+		ManagementKind: management.Cluster,
+		Kind:           secretstore.SecretKindGeneric,
 	})
 	if err != nil {
 		t.Fatalf("read default model provider credential: %v", err)

--- a/internal/storage/secretstore/secret_payload_store.go
+++ b/internal/storage/secretstore/secret_payload_store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/omnara-ai/omnara/internal/secrets"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
+	"github.com/omnara-ai/omnara/internal/storage/management"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
 )
 
@@ -205,13 +206,16 @@ func (s *Store) ReadOrgOwnedSecretPayload(
 		return SecretPayloadRecord{}, errors.New("secret key wrapper is required")
 	}
 	if isNilID(input.OrgID) || isNilID(input.SecretID) || input.Kind == "" {
-		return SecretPayloadRecord{}, invalidSecretRequest("org, secret, and kind are required")
+		return SecretPayloadRecord{}, invalidSecretRequest("org, secret, management kind, and kind are required")
+	}
+	if err := management.Validate(input.ManagementKind); err != nil {
+		return SecretPayloadRecord{}, invalidSecretRequest("%v", err)
 	}
 	record, err := s.GetSecret(ctx, input.OrgID, input.SecretID)
 	if err != nil {
 		return SecretPayloadRecord{}, err
 	}
-	if record.OwnerKind != SecretOwnerOrg {
+	if record.OwnerKind != SecretOwnerOrg || record.ManagementKind != input.ManagementKind {
 		return SecretPayloadRecord{}, storeerr.ErrNotFound
 	}
 	if record.Kind != input.Kind {

--- a/internal/storage/secretstore/types.go
+++ b/internal/storage/secretstore/types.go
@@ -215,9 +215,10 @@ type ReadProjectAvailableSecretPayloadInput struct {
 }
 
 type ReadOrgOwnedSecretPayloadInput struct {
-	OrgID    ID
-	SecretID ID
-	Kind     secrets.Kind
+	OrgID          ID
+	SecretID       ID
+	ManagementKind management.Kind
+	Kind           secrets.Kind
 }
 
 type RotateProjectAvailableOAuthSecretInput struct {


### PR DESCRIPTION
- Keep cluster-managed credential metadata visible through tenant secret GET and list APIs without exposing plaintext payloads.
- Require organization-owned payload reads to declare and match the expected management kind, preventing cross-boundary decryption.
- Prevent cluster-managed credentials from being reused by tenant model providers, machine pools, machine secret environments, project grants, or tenant-controlled discovery endpoints.
- Preserve default-provider inference by allowing the cluster-managed provider to decrypt only its matching cluster-managed credential.
- Expand regression coverage for visibility, attachment attempts, grant access, environment resolution, and valid default-provider usage.
