### PR TITLE
feat: reset navigation when switching organizations

### DIFF
--- a/frontend/apps/web/e2e/web.spec.ts
+++ b/frontend/apps/web/e2e/web.spec.ts
@@ -7,6 +7,9 @@ function requiredEnvironmentVariable(name: string): string {
 }
 
 const projectID = requiredEnvironmentVariable('OMNARA_WEB_E2E_PROJECT_ID')
+const orgName = requiredEnvironmentVariable('OMNARA_WEB_E2E_ORG_NAME')
+const switchOrgName = requiredEnvironmentVariable('OMNARA_WEB_E2E_SWITCH_ORG_NAME')
+const createdOrgName = 'zz web created organization'
 const adminEmail = requiredEnvironmentVariable('OMNARA_WEB_E2E_ADMIN_EMAIL')
 const viewerEmail = requiredEnvironmentVariable('OMNARA_WEB_E2E_VIEWER_EMAIL')
 const password = requiredEnvironmentVariable('OMNARA_WEB_E2E_PASSWORD')
@@ -54,6 +57,34 @@ test('returns to a protected deep link after login', async ({ page }) => {
   const failures = installFailureTracking(page)
   await signIn(page, adminEmail, `${createAgentPath}?source=e2e#yaml`)
   await expect(page.getByRole('button', { name: 'Create agent' })).toBeVisible()
+  expect(failures).toEqual([])
+})
+
+test('switches organizations from a project page', async ({ page }) => {
+  const failures = installFailureTracking(page)
+  await signIn(page, adminEmail, `/projects/${projectID}/agents`)
+
+  await page.getByRole('button', { name: orgName }).click()
+  await page.getByRole('menuitem', { name: switchOrgName }).click()
+
+  await expect(page).toHaveURL('/')
+  await expect(page.getByRole('button', { name: switchOrgName })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Project not found' })).toHaveCount(0)
+  expect(failures).toEqual([])
+})
+
+test('creates an organization from a project page', async ({ page }) => {
+  const failures = installFailureTracking(page)
+  await signIn(page, adminEmail, `/projects/${projectID}/agents`)
+
+  await page.getByRole('button', { name: orgName }).click()
+  await page.getByRole('menuitem', { name: 'New organization' }).click()
+  await page.getByRole('textbox', { name: 'Name', exact: true }).fill(createdOrgName)
+  await page.getByRole('button', { name: 'Create organization' }).click()
+
+  await expect(page).toHaveURL('/')
+  await expect(page.getByRole('button', { name: createdOrgName })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Project not found' })).toHaveCount(0)
   expect(failures).toEqual([])
 })
 

--- a/frontend/apps/web/src/components/app-shell/OrgSwitcher.tsx
+++ b/frontend/apps/web/src/components/app-shell/OrgSwitcher.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from '@tanstack/react-router'
 import { Check, ChevronsUpDown, Plus, UserPlus } from 'lucide-react'
 import { useState } from 'react'
 
@@ -17,10 +18,17 @@ import { canManageOrg } from '@/lib/permissions'
 import { useActiveOrg } from '@/lib/use-active-org'
 
 export function OrgSwitcher() {
+  const navigate = useNavigate()
   const { orgs, activeOrg, setActiveOrgId } = useActiveOrg()
   const canManage = canManageOrg(activeOrg.role)
   const [newOrgOpen, setNewOrgOpen] = useState(false)
   const [inviteOpen, setInviteOpen] = useState(false)
+
+  async function switchOrganization(id: string) {
+    if (id === activeOrg.id) return
+    await navigate({ to: '/', replace: true })
+    setActiveOrgId(id)
+  }
 
   return (
     <>
@@ -56,7 +64,7 @@ export function OrgSwitcher() {
                   key={org.id}
                   className="gap-2"
                   onClick={() => {
-                    setActiveOrgId(org.id)
+                    void switchOrganization(org.id)
                   }}
                 >
                   <span className="flex-1 truncate">{org.name}</span>

--- a/frontend/apps/web/src/components/org/CreateOrgDialog.tsx
+++ b/frontend/apps/web/src/components/org/CreateOrgDialog.tsx
@@ -1,4 +1,5 @@
 import { useCreateOrganization } from '@omnara/react'
+import { useNavigate } from '@tanstack/react-router'
 import { type SyntheticEvent, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
@@ -35,6 +36,7 @@ export function CreateOrgDialog({
   onOpenChange: (open: boolean) => void
 }) {
   const createOrganization = useCreateOrganization()
+  const navigate = useNavigate()
   const { setActiveOrgId } = useActiveOrg()
   const [state, setState] = useState<CreateOrgState>(initialState)
   const errorMessage = statusError(state.status)
@@ -47,6 +49,7 @@ export function CreateOrgDialog({
         body: { name: state.name },
         idempotencyKey: state.idempotencyKey,
       })
+      await navigate({ to: '/', replace: true })
       setActiveOrgId(result.org.id)
       setState(initialState())
       onOpenChange(false)

--- a/internal/e2e/web_e2e_test.go
+++ b/internal/e2e/web_e2e_test.go
@@ -15,12 +15,15 @@ import (
 	"github.com/omnara-ai/omnara/internal/publicid"
 	"github.com/omnara-ai/omnara/internal/storage"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
+	"github.com/omnara-ai/omnara/internal/storage/orglifecycle"
 )
 
 const (
 	webE2EPassword       = "Correct horse battery staple 1!"
 	webE2EProviderConfig = "openai-prod"
 	webE2EModelName      = "service-e2e-local"
+	webE2EOrgName        = "web Org"
+	webE2ESwitchOrgName  = "zz web switch target"
 )
 
 func TestWebE2E(t *testing.T) {
@@ -50,7 +53,7 @@ func TestWebE2E(t *testing.T) {
 	store := storage.NewStore(env.db)
 	adminEmail := "web-admin-" + env.seed + "@example.com"
 	viewerEmail := "web-viewer-" + env.seed + "@example.com"
-	createWebE2EUser(
+	adminUserID := createWebE2EUser(
 		t,
 		ctx,
 		store,
@@ -68,6 +71,13 @@ func TestWebE2E(t *testing.T) {
 		viewerEmail,
 		authz.ProjectRoleViewer,
 	)
+	if _, err := store.Organizations().CreateOrgForUser(ctx, orglifecycle.CreateOrgForUserInput{
+		UserID:         adminUserID,
+		Name:           webE2ESwitchOrgName,
+		IdempotencyKey: "web-switch-target-org",
+	}); err != nil {
+		t.Fatalf("create web e2e switch target organization: %v", err)
+	}
 
 	cmd := exec.CommandContext(ctx, "pnpm", "--filter", "@omnara/web", "run", "test:e2e")
 	cmd.WaitDelay = 5 * time.Second
@@ -75,6 +85,8 @@ func TestWebE2E(t *testing.T) {
 	cmd.Env = serviceProcessEnv(
 		"OMNARA_WEB_E2E_BASE_URL="+env.apiURL,
 		"OMNARA_WEB_E2E_PROJECT_ID="+project.projectID,
+		"OMNARA_WEB_E2E_ORG_NAME="+webE2EOrgName,
+		"OMNARA_WEB_E2E_SWITCH_ORG_NAME="+webE2ESwitchOrgName,
 		"OMNARA_WEB_E2E_ADMIN_EMAIL="+adminEmail,
 		"OMNARA_WEB_E2E_VIEWER_EMAIL="+viewerEmail,
 		"OMNARA_WEB_E2E_PASSWORD="+webE2EPassword,
@@ -94,7 +106,7 @@ func createWebE2EUser(
 	store *storage.Store,
 	orgID, projectID storage.ID,
 	email, projectRole string,
-) {
+) storage.ID {
 	t.Helper()
 	start, err := store.Identity().StartPasswordSignup(
 		ctx,
@@ -142,4 +154,5 @@ func createWebE2EUser(
 	); err != nil {
 		t.Fatalf("add project membership for %s: %v", email, err)
 	}
+	return completed.User.ID
 }


### PR DESCRIPTION
small fix for a small bug - when switching orgs while viewing a project, the URL path persists when viewing the new org, resulting in the following error:

<img width="1728" height="854" alt="image" src="https://github.com/user-attachments/assets/12b76aed-5a0a-4a2b-b2f3-0c31eaa17aba" />

the fix:
- Navigate home before changing the active organization so project-scoped URLs are never queried under the new organization.
- Apply the same route-safe transition after creating an organization while preserving the current page for no-op selections.
- Add browser coverage for switching and creating organizations from project pages.