### PR TITLE
feat: initialize hosted managed work admission

### DIFF
--- a/internal/httpapi/default_model_provider_org_integration_test.go
+++ b/internal/httpapi/default_model_provider_org_integration_test.go
@@ -265,6 +265,61 @@ func createOrgRouteUser(
 	return user, pat.Token
 }
 
+func TestCreateOrganizationPersistsHostedManagedWorkAdmission(t *testing.T) {
+	for _, allowed := range []bool{false, true} {
+		t.Run(fmt.Sprintf("allowed_%t", allowed), func(t *testing.T) {
+			ctx := context.Background()
+			pool := openIntegrationDB(t, ctx)
+			template := testDefaultOpenRouterTemplate()
+			provisioner := hostedCredentialProvisionerFunc(func(
+				_ context.Context,
+				request modelprovider.HostedCredentialRequest,
+			) (modelprovider.ProvisionHostedCredentialResponse, error) {
+				return modelprovider.ProvisionHostedCredentialResponse{
+					CredentialValue:       "sk-admission-" + request.OrgID,
+					NewManagedWorkAllowed: allowed,
+				}, nil
+			})
+			handler := newIntegrationServer(
+				pool,
+				WithDefaultModelProvider(&template),
+				WithHostedCredentialProvisioner(provisioner),
+			)
+			store := integrationStoreForHandler(t, handler)
+			_, token := createOrgRouteUser(t, pool, store, fmt.Sprintf("hosted-admission-%t", allowed))
+
+			created := requestJSONWithHeaders(
+				t,
+				handler,
+				http.MethodPost,
+				"/api/v1/orgs",
+				fmt.Sprintf(`{"name":"Hosted Admission %t"}`, allowed),
+				fmt.Sprintf("hosted-admission-%t", allowed),
+				http.StatusCreated,
+				authHeaders(token),
+			)
+			orgID, err := publicid.Decode(
+				publicid.KindOrganization,
+				created["org"].(map[string]any)["id"].(string),
+			)
+			if err != nil {
+				t.Fatalf("decode organization ID: %v", err)
+			}
+			var stored bool
+			if err := pool.QueryRow(ctx, `
+				SELECT new_managed_work_allowed
+				FROM org_managed_work_admission
+				WHERE org_id = $1
+			`, orgID).Scan(&stored); err != nil {
+				t.Fatalf("read managed-work admission: %v", err)
+			}
+			if stored != allowed {
+				t.Fatalf("managed-work admission = %t, want %t", stored, allowed)
+			}
+		})
+	}
+}
+
 func TestCreateOrganizationProvisionsHostedCredentialBeforeAtomicLocalCreation(t *testing.T) {
 	ctx := context.Background()
 	pool := openIntegrationDB(t, ctx)
@@ -275,7 +330,10 @@ func TestCreateOrganizationProvisionsHostedCredentialBeforeAtomicLocalCreation(t
 		request modelprovider.HostedCredentialRequest,
 	) (modelprovider.ProvisionHostedCredentialResponse, error) {
 		provisionRequest = request
-		return modelprovider.ProvisionHostedCredentialResponse{CredentialValue: "sk-cluster-openrouter"}, nil
+		return modelprovider.ProvisionHostedCredentialResponse{
+			CredentialValue:       "sk-cluster-openrouter",
+			NewManagedWorkAllowed: true,
+		}, nil
 	})
 	handler := newIntegrationServer(
 		pool,

--- a/internal/httpapi/org_routes.go
+++ b/internal/httpapi/org_routes.go
@@ -99,6 +99,7 @@ func (s strictOpenAPIServer) CreateOrganization(
 		return nil, err
 	}
 	var provisionedProvider *modelstore.ProvisionedDefaultModelProvider
+	var initialManagedWorkAllowed *bool
 	if s.server.defaultModelProvider != nil {
 		if err := s.server.store.Identity().PreflightOrgCreationCapacity(ctx, principal.ID); err != nil {
 			return nil, s.createOrganizationStorageError("check organization creation capacity", err)
@@ -106,23 +107,28 @@ func (s strictOpenAPIServer) CreateOrganization(
 		if s.server.hostedCredentialProvisioner == nil {
 			return nil, apierror.FromCode(openapi.ErrorCodeServiceUnavailable, "hosted credential provisioner unavailable")
 		}
-		provisionedProvider, err = s.provisionDefaultModelProvider(
+		var managedWorkAllowed bool
+		provisionedProvider, managedWorkAllowed, err = s.provisionDefaultModelProvider(
 			ctx,
 			publicOrgID,
 			publicCreatorUserID,
 			*s.server.defaultModelProvider,
 		)
+		if err == nil {
+			initialManagedWorkAllowed = &managedWorkAllowed
+		}
 	}
 	if err != nil {
 		return nil, hostedCredentialProvisioningAPIError(err)
 	}
 	input := orglifecycle.CreateOrgForUserInput{
-		OrgID:                orgID,
-		UserID:               principal.ID,
-		Name:                 request.Body.Name,
-		IdempotencyKey:       idempotencyKey,
-		DefaultMachinePools:  s.server.defaultPools,
-		DefaultModelProvider: provisionedProvider,
+		OrgID:                     orgID,
+		UserID:                    principal.ID,
+		Name:                      request.Body.Name,
+		IdempotencyKey:            idempotencyKey,
+		DefaultMachinePools:       s.server.defaultPools,
+		DefaultModelProvider:      provisionedProvider,
+		InitialManagedWorkAllowed: initialManagedWorkAllowed,
 	}
 	record, err := s.server.store.Organizations().CreateOrgForUser(ctx, input)
 	if err != nil {
@@ -189,9 +195,9 @@ func (s strictOpenAPIServer) provisionDefaultModelProvider(
 	publicOrgID string,
 	publicCreatorUserID string,
 	template modelstore.DefaultModelProviderTemplate,
-) (*modelstore.ProvisionedDefaultModelProvider, error) {
+) (*modelstore.ProvisionedDefaultModelProvider, bool, error) {
 	if s.server.hostedCredentialProvisioner == nil {
-		return nil, apierror.FromCode(openapi.ErrorCodeServiceUnavailable, "hosted credential provisioner unavailable")
+		return nil, false, apierror.FromCode(openapi.ErrorCodeServiceUnavailable, "hosted credential provisioner unavailable")
 	}
 	provisionCtx, cancel := context.WithTimeout(ctx, modelprovider.HostedCredentialProvisionTimeout)
 	response, provisionErr := s.server.hostedCredentialProvisioner.ProvisionHostedCredential(
@@ -211,12 +217,12 @@ func (s strictOpenAPIServer) provisionDefaultModelProvider(
 			"provisioner", template.Provisioner,
 			"error", provisionErr,
 		)
-		return nil, provisionErr
+		return nil, false, provisionErr
 	}
 	return &modelstore.ProvisionedDefaultModelProvider{
 		Template:        template,
 		CredentialValue: response.CredentialValue,
-	}, nil
+	}, response.NewManagedWorkAllowed, nil
 }
 
 func hostedCredentialProvisioningAPIError(err error) error {

--- a/internal/modelprovider/hosted_credentials.go
+++ b/internal/modelprovider/hosted_credentials.go
@@ -43,7 +43,8 @@ type HostedCredentialRequest struct {
 }
 
 type ProvisionHostedCredentialResponse struct {
-	CredentialValue string `json:"credential_value"`
+	CredentialValue       string `json:"credential_value"`
+	NewManagedWorkAllowed bool   `json:"new_managed_work_allowed"`
 }
 
 var ErrHostedCredentialConflict = errors.New("hosted credential setup is blocked by an unresolved attempt")

--- a/internal/modelprovider/hosted_credentials_test.go
+++ b/internal/modelprovider/hosted_credentials_test.go
@@ -57,14 +57,12 @@ func TestHTTPHostedCredentialProvisionerBuildsAuthenticatedRoute(t *testing.T) {
 	}
 }
 
-func TestHTTPHostedCredentialProvisionerAcceptsAdditiveResponseFields(t *testing.T) {
+func TestHTTPHostedCredentialProvisionerDeniesMissingAdmissionAndAcceptsAdditiveFields(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(
-			`{"credential_value":"secret","new_managed_work_allowed":false,"private_policy":{"version":2}}`,
-		))
+		_, _ = w.Write([]byte(`{"credential_value":"secret","private_policy":{"version":2}}`))
 	}))
 	defer server.Close()
 

--- a/internal/modelprovider/hosted_credentials_test.go
+++ b/internal/modelprovider/hosted_credentials_test.go
@@ -36,7 +36,7 @@ func TestHTTPHostedCredentialProvisionerBuildsAuthenticatedRoute(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(`{"credential_value":"sk-provisioned"}`))
+		_, _ = w.Write([]byte(`{"credential_value":"sk-provisioned","new_managed_work_allowed":true}`))
 	}))
 	defer server.Close()
 
@@ -49,8 +49,8 @@ func TestHTTPHostedCredentialProvisionerBuildsAuthenticatedRoute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("provision hosted credential: %v", err)
 	}
-	if response.CredentialValue != "sk-provisioned" {
-		t.Fatalf("credential value = %q, want provisioned value", response.CredentialValue)
+	if response.CredentialValue != "sk-provisioned" || !response.NewManagedWorkAllowed {
+		t.Fatalf("provisioning response = %+v", response)
 	}
 	if !reflect.DeepEqual(gotRequest, validHostedCredentialRequest()) {
 		t.Fatalf("unexpected provision request: %+v", gotRequest)
@@ -62,7 +62,9 @@ func TestHTTPHostedCredentialProvisionerAcceptsAdditiveResponseFields(t *testing
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(`{"credential_value":"secret","private_policy":{"version":2}}`))
+		_, _ = w.Write([]byte(
+			`{"credential_value":"secret","new_managed_work_allowed":false,"private_policy":{"version":2}}`,
+		))
 	}))
 	defer server.Close()
 
@@ -75,8 +77,8 @@ func TestHTTPHostedCredentialProvisionerAcceptsAdditiveResponseFields(t *testing
 	if err != nil {
 		t.Fatalf("provision credential: %v", err)
 	}
-	if response.CredentialValue != "secret" {
-		t.Fatalf("credential value = %q, want secret", response.CredentialValue)
+	if response.CredentialValue != "secret" || response.NewManagedWorkAllowed {
+		t.Fatalf("provisioning response = %+v", response)
 	}
 }
 

--- a/internal/storage/internal/dbsqlc/identity.sql.go
+++ b/internal/storage/internal/dbsqlc/identity.sql.go
@@ -642,6 +642,21 @@ func (q *Queries) CreateOrgInvitation(ctx context.Context, arg CreateOrgInvitati
 	return i, err
 }
 
+const createOrgManagedWorkAdmission = `-- name: CreateOrgManagedWorkAdmission :exec
+INSERT INTO org_managed_work_admission(org_id, new_managed_work_allowed)
+VALUES ($1, $2)
+`
+
+type CreateOrgManagedWorkAdmissionParams struct {
+	OrgID                 uuid.UUID
+	NewManagedWorkAllowed bool
+}
+
+func (q *Queries) CreateOrgManagedWorkAdmission(ctx context.Context, arg CreateOrgManagedWorkAdmissionParams) error {
+	_, err := q.db.Exec(ctx, createOrgManagedWorkAdmission, arg.OrgID, arg.NewManagedWorkAllowed)
+	return err
+}
+
 const createPersonalAccessToken = `-- name: CreatePersonalAccessToken :one
 INSERT INTO personal_access_tokens(user_id, name, token_id, token_hash, created_at)
 VALUES ($1, $2, $3, $4, statement_timestamp())

--- a/internal/storage/orglifecycle/orgs_projects.go
+++ b/internal/storage/orglifecycle/orgs_projects.go
@@ -20,12 +20,13 @@ import (
 )
 
 type CreateOrgForUserInput struct {
-	OrgID                ID
-	UserID               ID
-	Name                 string
-	IdempotencyKey       string
-	DefaultMachinePools  []executionstore.DefaultMachinePoolTemplate
-	DefaultModelProvider *modelstore.ProvisionedDefaultModelProvider
+	OrgID                     ID
+	UserID                    ID
+	Name                      string
+	IdempotencyKey            string
+	DefaultMachinePools       []executionstore.DefaultMachinePoolTemplate
+	DefaultModelProvider      *modelstore.ProvisionedDefaultModelProvider
+	InitialManagedWorkAllowed *bool
 }
 
 func (s *Service) CreateOrgForUser(
@@ -60,6 +61,20 @@ func (s *Service) CreateOrgForUser(
 		return identitystore.CreateOrgForUserRecord{}, err
 	}
 	if record.Created {
+		if input.InitialManagedWorkAllowed != nil {
+			if err := s.q.WithTx(tx).CreateOrgManagedWorkAdmission(
+				ctx,
+				dbsqlc.CreateOrgManagedWorkAdmissionParams{
+					OrgID:                 record.Org.ID,
+					NewManagedWorkAllowed: *input.InitialManagedWorkAllowed,
+				},
+			); err != nil {
+				return identitystore.CreateOrgForUserRecord{}, fmt.Errorf(
+					"create organization managed-work admission: %w",
+					err,
+				)
+			}
+		}
 		if err := s.execution.ProvisionOrganizationDefaultsTx(
 			ctx,
 			tx,

--- a/internal/storage/queries/identity.sql
+++ b/internal/storage/queries/identity.sql
@@ -9,6 +9,10 @@ VALUES (sqlc.arg(id), sqlc.arg(name), sqlc.narg(idempotency_key), transaction_ti
 ON CONFLICT (idempotency_key) DO NOTHING
 RETURNING id, name, coalesce(idempotency_key, '') AS idempotency_key, created_at, updated_at;
 
+-- name: CreateOrgManagedWorkAdmission :exec
+INSERT INTO org_managed_work_admission(org_id, new_managed_work_allowed)
+VALUES (sqlc.arg(org_id), sqlc.arg(new_managed_work_allowed));
+
 -- name: GetOrgByIdempotencyKey :one
 SELECT id, name, coalesce(idempotency_key, '') AS idempotency_key, created_at, updated_at
 FROM orgs


### PR DESCRIPTION
## Summary

- extend hosted credential provisioning with the initial managed-work admission decision
- persist that decision atomically with newly created hosted organizations
- preserve existing self-hosted organization behavior

## Verification

- `make verify`
- `make test-integration`