### PR TITLE
feat: cache SigV4 MCP role credentials

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -163,6 +163,7 @@ func main() {
 		log.Error("configure skill broadcaster", "error", err)
 		os.Exit(1)
 	}
+	sigV4CredentialCache := mcp.NewSigV4CredentialCache()
 	executor := workerpkg.AgentWorkExecutor(kernel.AgentExecutor{
 		Store: store,
 		ContextBuilder: modelcontext.Builder{
@@ -180,8 +181,9 @@ func main() {
 				AppCategories: cfg.OpenRouterAppCategories,
 			},
 		},
-		MCP:               mcp.New(mcp.Options{HTTPClient: mcpHTTPClient}),
-		MCPAuthHTTPClient: mcpHTTPClient,
+		MCP:                  mcp.New(mcp.Options{HTTPClient: mcpHTTPClient}),
+		MCPAuthHTTPClient:    mcpHTTPClient,
+		SigV4CredentialCache: sigV4CredentialCache,
 		ToolExecutor: tools.Executor{
 			Store:                 store,
 			Skills:                store.Skills(),

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -163,7 +163,11 @@ func main() {
 		log.Error("configure skill broadcaster", "error", err)
 		os.Exit(1)
 	}
-	sigV4CredentialCache := mcp.NewSigV4CredentialCache()
+	sigV4CredentialCache, err := mcp.NewSigV4CredentialCache()
+	if err != nil {
+		log.Error("configure SigV4 credential cache", "error", err)
+		os.Exit(1)
+	}
 	executor := workerpkg.AgentWorkExecutor(kernel.AgentExecutor{
 		Store: store,
 		ContextBuilder: modelcontext.Builder{

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-shiori/go-readability v0.0.0-20251205110129-5db1dc9836f0
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/kaptinlin/jsonschema v0.9.4
 	github.com/modelcontextprotocol/go-sdk v1.7.0

--- a/internal/harness/kernel/agent_executor.go
+++ b/internal/harness/kernel/agent_executor.go
@@ -19,13 +19,14 @@ import (
 )
 
 type AgentExecutor struct {
-	Store             *storage.Store
-	ContextBuilder    modelcontext.Builder
-	ModelResolver     model.Resolver
-	MCP               mcp.Client
-	MCPAuthHTTPClient *http.Client
-	ToolExecutor      tools.Executor
-	Now               func() time.Time
+	Store                *storage.Store
+	ContextBuilder       modelcontext.Builder
+	ModelResolver        model.Resolver
+	MCP                  mcp.Client
+	MCPAuthHTTPClient    *http.Client
+	SigV4CredentialCache *mcp.SigV4CredentialCache
+	ToolExecutor         tools.Executor
+	Now                  func() time.Time
 
 	StreamPublisher notifications.AgentStreamDeltaPublisher
 	StreamLog       *slog.Logger

--- a/internal/harness/kernel/agent_executor_helpers.go
+++ b/internal/harness/kernel/agent_executor_helpers.go
@@ -72,6 +72,9 @@ func (e AgentExecutor) configuredToolExecutor() tools.Executor {
 	if executor.MCPAuthHTTPClient == nil {
 		executor.MCPAuthHTTPClient = e.MCPAuthHTTPClient
 	}
+	if executor.SigV4CredentialCache == nil {
+		executor.SigV4CredentialCache = e.SigV4CredentialCache
+	}
 	if executor.Now == nil {
 		executor.Now = e.now
 	}

--- a/internal/harness/kernel/agent_executor_mcp.go
+++ b/internal/harness/kernel/agent_executor_mcp.go
@@ -80,11 +80,12 @@ func (e AgentExecutor) ensureMCPConnections(
 		servers[server.ServerKey] = server
 	}
 	manager := mcp.Manager{
-		Execution:       e.Store.Execution(),
-		Secrets:         e.Store.Secrets(),
-		Client:          e.MCP,
-		Backoff:         e.MCPInitializationBackoff,
-		OAuthHTTPClient: e.MCPAuthHTTPClient,
+		Execution:            e.Store.Execution(),
+		Secrets:              e.Store.Secrets(),
+		Client:               e.MCP,
+		Backoff:              e.MCPInitializationBackoff,
+		SigV4CredentialCache: e.SigV4CredentialCache,
+		OAuthHTTPClient:      e.MCPAuthHTTPClient,
 	}
 	errs := make(chan error, len(pending))
 	var wg sync.WaitGroup

--- a/internal/harness/kernel/agent_executor_unit_test.go
+++ b/internal/harness/kernel/agent_executor_unit_test.go
@@ -41,6 +41,7 @@ func (*kernelSkillStoreStub) GetSkillForDispatch(
 func TestAgentExecutorDependencyComposition(t *testing.T) {
 	aggregate := storage.NewStore(nil)
 	explicit := &kernelSkillStoreStub{}
+	sigV4CredentialCache := mcp.NewSigV4CredentialCache()
 
 	defaults := (AgentExecutor{Store: aggregate}).contextBuilder()
 	if defaults.Store == nil || defaults.Skills != aggregate.Skills() {
@@ -57,8 +58,12 @@ func TestAgentExecutorDependencyComposition(t *testing.T) {
 		t.Fatalf("empty context dependencies = %+v, want unresolved dependencies", empty)
 	}
 
-	toolDefaults := (AgentExecutor{Store: aggregate}).configuredToolExecutor()
-	if toolDefaults.Store != aggregate || toolDefaults.Skills != nil {
+	toolDefaults := (AgentExecutor{
+		Store:                aggregate,
+		SigV4CredentialCache: sigV4CredentialCache,
+	}).configuredToolExecutor()
+	if toolDefaults.Store != aggregate || toolDefaults.Skills != nil ||
+		toolDefaults.SigV4CredentialCache != sigV4CredentialCache {
 		t.Fatalf("default tool dependencies = %+v, want aggregate store with deferred skill resolution", toolDefaults)
 	}
 	toolOverride := (AgentExecutor{

--- a/internal/harness/kernel/agent_executor_unit_test.go
+++ b/internal/harness/kernel/agent_executor_unit_test.go
@@ -41,7 +41,10 @@ func (*kernelSkillStoreStub) GetSkillForDispatch(
 func TestAgentExecutorDependencyComposition(t *testing.T) {
 	aggregate := storage.NewStore(nil)
 	explicit := &kernelSkillStoreStub{}
-	sigV4CredentialCache := mcp.NewSigV4CredentialCache()
+	sigV4CredentialCache, err := mcp.NewSigV4CredentialCache()
+	if err != nil {
+		t.Fatalf("create SigV4 credential cache: %v", err)
+	}
 
 	defaults := (AgentExecutor{Store: aggregate}).contextBuilder()
 	if defaults.Store == nil || defaults.Skills != aggregate.Skills() {

--- a/internal/harness/tools/mcp_tool.go
+++ b/internal/harness/tools/mcp_tool.go
@@ -64,11 +64,12 @@ func (e Executor) dispatchMCPTool(
 		return toolResultContent{}, err
 	}
 	manager := mcp.Manager{
-		Execution:       e.Store.Execution(),
-		Secrets:         e.Store.Secrets(),
-		Client:          e.MCP,
-		Backoff:         e.MCPInitializationBackoff,
-		OAuthHTTPClient: e.MCPAuthHTTPClient,
+		Execution:            e.Store.Execution(),
+		Secrets:              e.Store.Secrets(),
+		Client:               e.MCP,
+		Backoff:              e.MCPInitializationBackoff,
+		SigV4CredentialCache: e.SigV4CredentialCache,
+		OAuthHTTPClient:      e.MCPAuthHTTPClient,
 	}
 	wireConn, err := manager.Connection(
 		ctx,

--- a/internal/harness/tools/types.go
+++ b/internal/harness/tools/types.go
@@ -56,6 +56,7 @@ type Executor struct {
 	MCP                      mcp.Client
 	IntegrationHTTPClient    *http.Client
 	MCPAuthHTTPClient        *http.Client
+	SigV4CredentialCache     *mcp.SigV4CredentialCache
 	WebSearch                webaccess.SearchProvider
 	WebFetcher               *webaccess.Fetcher
 	MachinePoolManager       machinePoolManager

--- a/internal/mcp/connection_manager.go
+++ b/internal/mcp/connection_manager.go
@@ -29,10 +29,11 @@ const (
 )
 
 type Manager struct {
-	Execution *executionstore.Store
-	Secrets   *secretstore.Store
-	Client    Client
-	Backoff   func(attempt int) time.Duration
+	Execution            *executionstore.Store
+	Secrets              *secretstore.Store
+	Client               Client
+	Backoff              func(attempt int) time.Duration
+	SigV4CredentialCache *SigV4CredentialCache
 
 	OAuthHTTPClient *http.Client
 
@@ -381,11 +382,20 @@ func (m Manager) Connection(
 		}
 		wireConn.BearerToken = token
 	case agentconfig.MCPAuthTypeSigV4:
-		wireConn.prepareRequest, err = newSigV4RequestPreparer(
-			ctx,
-			server.Auth.Service,
+		provider, providerErr := resolveAWSCredentialProvider(
+			m.SigV4CredentialCache,
+			secretID,
+			secretPayload.CurrentVersionID,
 			server.Auth.Region,
 			payload,
+		)
+		if providerErr != nil {
+			return Conn{}, fmt.Errorf("prepare SigV4 MCP auth for %q: %w", conn.ServerKey, providerErr)
+		}
+		wireConn.prepareRequest, err = newSigV4RequestPreparer(
+			server.Auth.Service,
+			server.Auth.Region,
+			provider,
 		)
 		if err != nil {
 			return Conn{}, fmt.Errorf("prepare SigV4 MCP auth for %q: %w", conn.ServerKey, err)

--- a/internal/mcp/sigv4.go
+++ b/internal/mcp/sigv4.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/omnara-ai/omnara/internal/secrets"
 	"github.com/omnara-ai/omnara/internal/storage"
 )
@@ -23,7 +24,7 @@ const maxSigV4CredentialCacheEntries = 1_024
 
 type SigV4CredentialCache struct {
 	mu      sync.Mutex
-	entries map[sigV4CredentialCacheKey]sigV4CredentialCacheEntry
+	entries *simplelru.LRU[sigV4CredentialCacheKey, sigV4CredentialCacheEntry]
 }
 
 type sigV4CredentialCacheKey struct {
@@ -36,10 +37,15 @@ type sigV4CredentialCacheEntry struct {
 	provider  *aws.CredentialsCache
 }
 
-func NewSigV4CredentialCache() *SigV4CredentialCache {
-	return &SigV4CredentialCache{
-		entries: make(map[sigV4CredentialCacheKey]sigV4CredentialCacheEntry),
+func NewSigV4CredentialCache() (*SigV4CredentialCache, error) {
+	entries, err := simplelru.NewLRU[sigV4CredentialCacheKey, sigV4CredentialCacheEntry](
+		maxSigV4CredentialCacheEntries,
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create SigV4 credential cache: %w", err)
 	}
+	return &SigV4CredentialCache{entries: entries}, nil
 }
 
 func (c *SigV4CredentialCache) provider(
@@ -54,15 +60,9 @@ func (c *SigV4CredentialCache) provider(
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	key := sigV4CredentialCacheKey{secretID: secretID, region: region}
-	entry, ok := c.entries[key]
+	entry, ok := c.entries.Get(key)
 	if ok && entry.versionID == versionID {
 		return entry.provider, nil
-	}
-	if !ok && len(c.entries) >= maxSigV4CredentialCacheEntries {
-		for existingKey := range c.entries {
-			delete(c.entries, existingKey)
-			break
-		}
 	}
 	staticProvider := staticAWSCredentialProvider(payload)
 	cfg := aws.Config{Region: region, Credentials: staticProvider}
@@ -76,10 +76,10 @@ func (c *SigV4CredentialCache) provider(
 			options.ExpiryWindow = 30 * time.Second
 		},
 	)
-	c.entries[key] = sigV4CredentialCacheEntry{
+	c.entries.Add(key, sigV4CredentialCacheEntry{
 		versionID: versionID,
 		provider:  provider,
-	}
+	})
 	return provider, nil
 }
 

--- a/internal/mcp/sigv4.go
+++ b/internal/mcp/sigv4.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -15,13 +16,77 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/omnara-ai/omnara/internal/secrets"
+	"github.com/omnara-ai/omnara/internal/storage"
 )
 
-func newSigV4RequestPreparer(
-	ctx context.Context,
-	service string,
+const maxSigV4CredentialCacheEntries = 1_024
+
+type SigV4CredentialCache struct {
+	mu      sync.Mutex
+	entries map[sigV4CredentialCacheKey]sigV4CredentialCacheEntry
+}
+
+type sigV4CredentialCacheKey struct {
+	secretID storage.ID
+	region   string
+}
+
+type sigV4CredentialCacheEntry struct {
+	versionID storage.ID
+	provider  *aws.CredentialsCache
+}
+
+func NewSigV4CredentialCache() *SigV4CredentialCache {
+	return &SigV4CredentialCache{
+		entries: make(map[sigV4CredentialCacheKey]sigV4CredentialCacheEntry),
+	}
+}
+
+func (c *SigV4CredentialCache) provider(
+	secretID storage.ID,
+	versionID storage.ID,
 	region string,
 	payload secrets.Payload,
+) (aws.CredentialsProvider, error) {
+	if c == nil {
+		return nil, fmt.Errorf("sigv4 credential cache is required for AWS role assumption")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := sigV4CredentialCacheKey{secretID: secretID, region: region}
+	entry, ok := c.entries[key]
+	if ok && entry.versionID == versionID {
+		return entry.provider, nil
+	}
+	if !ok && len(c.entries) >= maxSigV4CredentialCacheEntries {
+		for existingKey := range c.entries {
+			delete(c.entries, existingKey)
+			break
+		}
+	}
+	staticProvider := staticAWSCredentialProvider(payload)
+	cfg := aws.Config{Region: region, Credentials: staticProvider}
+	provider := aws.NewCredentialsCache(
+		newAssumeRoleCredentialProvider(
+			sts.NewFromConfig(cfg),
+			payload[secrets.KeyAWSRoleARN],
+			payload[secrets.KeyAWSExternalID],
+		),
+		func(options *aws.CredentialsCacheOptions) {
+			options.ExpiryWindow = 30 * time.Second
+		},
+	)
+	c.entries[key] = sigV4CredentialCacheEntry{
+		versionID: versionID,
+		provider:  provider,
+	}
+	return provider, nil
+}
+
+func newSigV4RequestPreparer(
+	service string,
+	region string,
+	provider aws.CredentialsProvider,
 ) (func(context.Context, *http.Request, []byte) error, error) {
 	service = strings.TrimSpace(service)
 	if service == "" {
@@ -31,12 +96,15 @@ func newSigV4RequestPreparer(
 	if region == "" {
 		return nil, fmt.Errorf("aws signing region is required")
 	}
-	resolved, err := resolveAWSCredentials(ctx, region, payload)
-	if err != nil {
-		return nil, err
+	if provider == nil {
+		return nil, fmt.Errorf("aws credential provider is required")
 	}
 	signer := v4.NewSigner()
 	return func(ctx context.Context, request *http.Request, body []byte) error {
+		resolved, err := provider.Retrieve(ctx)
+		if err != nil {
+			return err
+		}
 		hash := sha256.Sum256(body)
 		return signer.SignHTTP(
 			ctx,
@@ -50,51 +118,37 @@ func newSigV4RequestPreparer(
 	}, nil
 }
 
-func resolveAWSCredentials(
-	ctx context.Context,
+func resolveAWSCredentialProvider(
+	cache *SigV4CredentialCache,
+	secretID storage.ID,
+	versionID storage.ID,
 	region string,
 	payload secrets.Payload,
-) (aws.Credentials, error) {
-	resolved := aws.Credentials{
-		AccessKeyID:     payload[secrets.KeyAWSAccessKeyID],
-		SecretAccessKey: payload[secrets.KeyAWSSecretAccessKey],
-		SessionToken:    payload[secrets.KeyAWSSessionToken],
-	}
+) (aws.CredentialsProvider, error) {
 	roleARN := payload[secrets.KeyAWSRoleARN]
 	if roleARN == "" {
-		return resolved, nil
+		return staticAWSCredentialProvider(payload), nil
 	}
-	cfg := aws.Config{
-		Region: region,
-		Credentials: credentials.NewStaticCredentialsProvider(
-			resolved.AccessKeyID,
-			resolved.SecretAccessKey,
-			resolved.SessionToken,
-		),
-	}
-	return assumeRoleCredentials(
-		ctx,
-		sts.NewFromConfig(cfg),
-		roleARN,
-		payload[secrets.KeyAWSExternalID],
+	return cache.provider(secretID, versionID, region, payload)
+}
+
+func staticAWSCredentialProvider(payload secrets.Payload) aws.CredentialsProvider {
+	return credentials.NewStaticCredentialsProvider(
+		payload[secrets.KeyAWSAccessKeyID],
+		payload[secrets.KeyAWSSecretAccessKey],
+		payload[secrets.KeyAWSSessionToken],
 	)
 }
 
-func assumeRoleCredentials(
-	ctx context.Context,
+func newAssumeRoleCredentialProvider(
 	client stscreds.AssumeRoleAPIClient,
 	roleARN string,
 	externalID string,
-) (aws.Credentials, error) {
-	provider := stscreds.NewAssumeRoleProvider(client, roleARN, func(options *stscreds.AssumeRoleOptions) {
+) aws.CredentialsProvider {
+	return stscreds.NewAssumeRoleProvider(client, roleARN, func(options *stscreds.AssumeRoleOptions) {
 		options.RoleSessionName = "omnara"
 		if externalID != "" {
 			options.ExternalID = aws.String(externalID)
 		}
 	})
-	resolved, err := provider.Retrieve(ctx)
-	if err != nil {
-		return aws.Credentials{}, fmt.Errorf("assume AWS role: %w", err)
-	}
-	return resolved, nil
 }

--- a/internal/mcp/sigv4_test.go
+++ b/internal/mcp/sigv4_test.go
@@ -9,22 +9,19 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/google/uuid"
 	"github.com/omnara-ai/omnara/internal/secrets"
 )
 
 func TestBuildHTTPPreparesSigV4Request(t *testing.T) {
 	ctx := context.Background()
 	prepareRequest, err := newSigV4RequestPreparer(
-		ctx,
 		"execute-api",
 		"us-west-2",
-		secrets.Payload{
-			secrets.KeyAWSAccessKeyID:     "AKIAEXAMPLE",
-			secrets.KeyAWSSecretAccessKey: "secret",
-			secrets.KeyAWSSessionToken:    "session-token",
-		},
+		credentials.NewStaticCredentialsProvider("AKIAEXAMPLE", "secret", "session-token"),
 	)
 	if err != nil {
 		t.Fatalf("create SigV4 request signer: %v", err)
@@ -65,7 +62,7 @@ func TestBuildHTTPPreparesSigV4Request(t *testing.T) {
 	}
 }
 
-func TestAssumeRoleCredentials(t *testing.T) {
+func TestAssumeRoleCredentialProvider(t *testing.T) {
 	expires := time.Now().Add(time.Hour)
 	client := assumeRoleClientFunc(func(
 		_ context.Context,
@@ -88,12 +85,12 @@ func TestAssumeRoleCredentials(t *testing.T) {
 			Expiration:      &expires,
 		}}, nil
 	})
-	resolved, err := assumeRoleCredentials(
-		context.Background(),
+	provider := newAssumeRoleCredentialProvider(
 		client,
 		"arn:aws:iam::123456789012:role/ReadOnly",
 		"external",
 	)
+	resolved, err := provider.Retrieve(context.Background())
 	if err != nil {
 		t.Fatalf("assume role: %v", err)
 	}
@@ -103,6 +100,90 @@ func TestAssumeRoleCredentials(t *testing.T) {
 		!resolved.CanExpire ||
 		!resolved.Expires.Equal(expires) {
 		t.Fatalf("resolved credentials = %+v", resolved)
+	}
+}
+
+func TestResolveAWSCredentialProviderScopesSecretVersionByRegion(t *testing.T) {
+	cache := NewSigV4CredentialCache()
+	secretID := uuid.New()
+	versionID := uuid.New()
+	payload := testAssumeRolePayload()
+	first, err := resolveAWSCredentialProvider(cache, secretID, versionID, "us-west-2", payload)
+	if err != nil {
+		t.Fatalf("get first provider: %v", err)
+	}
+	sameRegion, err := resolveAWSCredentialProvider(cache, secretID, versionID, "us-west-2", payload)
+	if err != nil {
+		t.Fatalf("get same-region provider: %v", err)
+	}
+	if first != sameRegion {
+		t.Fatal("same secret version and region returned different providers")
+	}
+	differentRegion, err := resolveAWSCredentialProvider(cache, secretID, versionID, "us-east-1", payload)
+	if err != nil {
+		t.Fatalf("get different-region provider: %v", err)
+	}
+	if first == differentRegion {
+		t.Fatal("same secret version in different regions returned the same provider")
+	}
+}
+
+func TestResolveAWSCredentialProviderRequiresCacheForAssumeRole(t *testing.T) {
+	_, err := resolveAWSCredentialProvider(
+		nil,
+		uuid.New(),
+		uuid.New(),
+		"us-west-2",
+		testAssumeRolePayload(),
+	)
+	if err == nil || !strings.Contains(err.Error(), "credential cache is required") {
+		t.Fatalf("resolve role provider error = %v, want missing credential cache", err)
+	}
+}
+
+func TestResolveAWSCredentialProviderReplacesRotatedSecret(t *testing.T) {
+	cache := NewSigV4CredentialCache()
+	secretID := uuid.New()
+	payload := testAssumeRolePayload()
+	first, err := resolveAWSCredentialProvider(cache, secretID, uuid.New(), "us-west-2", payload)
+	if err != nil {
+		t.Fatalf("get first provider: %v", err)
+	}
+	second, err := resolveAWSCredentialProvider(cache, secretID, uuid.New(), "us-west-2", payload)
+	if err != nil {
+		t.Fatalf("get rotated provider: %v", err)
+	}
+	if first == second {
+		t.Fatal("rotated secret version reused the previous provider")
+	}
+}
+
+func TestResolveAWSCredentialProviderBoundsEntries(t *testing.T) {
+	cache := NewSigV4CredentialCache()
+	payload := testAssumeRolePayload()
+	for range maxSigV4CredentialCacheEntries + 1 {
+		_, err := resolveAWSCredentialProvider(
+			cache,
+			uuid.New(),
+			uuid.New(),
+			"us-west-2",
+			payload,
+		)
+		if err != nil {
+			t.Fatalf("resolve provider: %v", err)
+		}
+	}
+	if got := len(cache.entries); got != maxSigV4CredentialCacheEntries {
+		t.Fatalf("cache entries = %d, want %d", got, maxSigV4CredentialCacheEntries)
+	}
+}
+
+func testAssumeRolePayload() secrets.Payload {
+	return secrets.Payload{
+		secrets.KeyAWSAccessKeyID:     "AKIAEXAMPLE",
+		secrets.KeyAWSSecretAccessKey: "secret",
+		secrets.KeyAWSRoleARN:         "arn:aws:iam::123456789012:role/ReadOnly",
+		secrets.KeyAWSExternalID:      "external",
 	}
 }
 

--- a/internal/mcp/sigv4_test.go
+++ b/internal/mcp/sigv4_test.go
@@ -104,7 +104,7 @@ func TestAssumeRoleCredentialProvider(t *testing.T) {
 }
 
 func TestResolveAWSCredentialProviderScopesSecretVersionByRegion(t *testing.T) {
-	cache := NewSigV4CredentialCache()
+	cache := newTestSigV4CredentialCache(t)
 	secretID := uuid.New()
 	versionID := uuid.New()
 	payload := testAssumeRolePayload()
@@ -142,7 +142,7 @@ func TestResolveAWSCredentialProviderRequiresCacheForAssumeRole(t *testing.T) {
 }
 
 func TestResolveAWSCredentialProviderReplacesRotatedSecret(t *testing.T) {
-	cache := NewSigV4CredentialCache()
+	cache := newTestSigV4CredentialCache(t)
 	secretID := uuid.New()
 	payload := testAssumeRolePayload()
 	first, err := resolveAWSCredentialProvider(cache, secretID, uuid.New(), "us-west-2", payload)
@@ -158,24 +158,50 @@ func TestResolveAWSCredentialProviderReplacesRotatedSecret(t *testing.T) {
 	}
 }
 
-func TestResolveAWSCredentialProviderBoundsEntries(t *testing.T) {
-	cache := NewSigV4CredentialCache()
+func TestResolveAWSCredentialProviderEvictsLeastRecentlyUsed(t *testing.T) {
+	cache := newTestSigV4CredentialCache(t)
 	payload := testAssumeRolePayload()
-	for range maxSigV4CredentialCacheEntries + 1 {
-		_, err := resolveAWSCredentialProvider(
+	resolve := func(secretID, versionID uuid.UUID) aws.CredentialsProvider {
+		t.Helper()
+		provider, err := resolveAWSCredentialProvider(
 			cache,
-			uuid.New(),
-			uuid.New(),
+			secretID,
+			versionID,
 			"us-west-2",
 			payload,
 		)
 		if err != nil {
 			t.Fatalf("resolve provider: %v", err)
 		}
+		return provider
 	}
-	if got := len(cache.entries); got != maxSigV4CredentialCacheEntries {
+	firstSecretID, firstVersionID := uuid.New(), uuid.New()
+	first := resolve(firstSecretID, firstVersionID)
+	secondSecretID, secondVersionID := uuid.New(), uuid.New()
+	second := resolve(secondSecretID, secondVersionID)
+	for range maxSigV4CredentialCacheEntries - 2 {
+		resolve(uuid.New(), uuid.New())
+	}
+	resolve(firstSecretID, firstVersionID)
+	resolve(uuid.New(), uuid.New())
+	if got := resolve(firstSecretID, firstVersionID); got != first {
+		t.Fatal("recently used provider was evicted")
+	}
+	if got := resolve(secondSecretID, secondVersionID); got == second {
+		t.Fatal("least recently used provider was not evicted")
+	}
+	if got := cache.entries.Len(); got != maxSigV4CredentialCacheEntries {
 		t.Fatalf("cache entries = %d, want %d", got, maxSigV4CredentialCacheEntries)
 	}
+}
+
+func newTestSigV4CredentialCache(t *testing.T) *SigV4CredentialCache {
+	t.Helper()
+	cache, err := NewSigV4CredentialCache()
+	if err != nil {
+		t.Fatalf("create SigV4 credential cache: %v", err)
+	}
+	return cache
 }
 
 func testAssumeRolePayload() secrets.Payload {


### PR DESCRIPTION
- Keeps one worker-scoped cache of AWS SDK credential providers for SigV4 MCP servers that assume roles, avoiding a fresh STS session for every connection.
- Keys cached providers by secret, version, and region; secret rotation replaces stale entries and a 1,024-entry cap bounds process memory.
- Leaves static AWS credentials uncached and performs project-scoped secret authorization before every cache lookup.
- Continues retrieving credentials and generating a fresh SigV4 signature for every MCP request while the SDK handles expiry-aware refresh and single-flight retrieval.
