### PR TITLE
feat: add organization resource limit overrides

### DIFF
--- a/internal/dbmigrate/postgres_integration_test.go
+++ b/internal/dbmigrate/postgres_integration_test.go
@@ -66,7 +66,7 @@ func TestPostgresStoredOrgScopeColumnsMatchOwnershipBoundaries(t *testing.T) {
 	defer cancel()
 
 	_, db := openPostgresMigrationTestDB(t, ctx)
-	const expected = "agent_configs,agent_machine_bindings,agents,configured_model_revisions,configured_models,daemon_runtimes,integration_installs,machine_daemon_tokens,machine_online_intervals,machine_pools,machines,model_call_contexts,model_provider_configs,org_api_keys,org_invitations,org_managed_work_admission,org_memberships,process_actions,processes,project_machine_grants,project_machine_pool_grants,project_memberships,project_model_grants,projects,secret_grants,secret_oauth_refresh_leases,secret_versions,secrets,skill_grants,skills"
+	const expected = "agent_configs,agent_machine_bindings,agents,configured_model_revisions,configured_models,daemon_runtimes,integration_installs,machine_daemon_tokens,machine_online_intervals,machine_pools,machines,model_call_contexts,model_provider_configs,org_api_keys,org_invitations,org_managed_work_admission,org_memberships,org_resource_limit_overrides,process_actions,processes,project_machine_grants,project_machine_pool_grants,project_memberships,project_model_grants,projects,secret_grants,secret_oauth_refresh_leases,secret_versions,secrets,skill_grants,skills"
 	var actual string
 	if err := db.QueryRowContext(ctx, `
 SELECT coalesce(string_agg(column_info.table_name, ',' ORDER BY column_info.table_name), '')

--- a/internal/harness/tools/process_tools.go
+++ b/internal/harness/tools/process_tools.go
@@ -134,10 +134,7 @@ func startCommand(
 				return failProcessTransaction(
 					err,
 					processToolErrorAgentLimitReached,
-					fmt.Sprintf(
-						"this agent already has %d unfinished processes; use list_processes and stop_process before starting another",
-						executionstore.MaxNonTerminalProcessesPerAgent,
-					),
+					"this agent has reached its unfinished process limit; use list_processes and stop_process before starting another",
 					false,
 					"",
 					"",

--- a/internal/httpapi/default_model_provider_org_integration_test.go
+++ b/internal/httpapi/default_model_provider_org_integration_test.go
@@ -152,7 +152,7 @@ func TestConcurrentOrganizationCreationCommitsOnlyOneFinalOwnedSlot(t *testing.T
 	)
 	store := integrationStoreForHandler(t, handler)
 	user, token := createOrgRouteUser(t, pool, store, "default-provider-final-slot")
-	for index := 0; index < 99; index++ {
+	for index := 0; index < identitystore.MaxOwnedOrgsPerUser-1; index++ {
 		if _, err := store.Organizations().CreateOrgForUser(ctx, orglifecycle.CreateOrgForUserInput{
 			UserID:         user.ID,
 			Name:           fmt.Sprintf("Existing Org %03d", index),
@@ -212,8 +212,12 @@ func TestConcurrentOrganizationCreationCommitsOnlyOneFinalOwnedSlot(t *testing.T
 	`, user.ID).Scan(&ownedCount); err != nil {
 		t.Fatalf("read final owned capacity: %v", err)
 	}
-	if ownedCount != 100 {
-		t.Fatalf("owned organizations=%d, want 100", ownedCount)
+	if ownedCount != identitystore.MaxOwnedOrgsPerUser {
+		t.Fatalf(
+			"owned organizations=%d, want %d",
+			ownedCount,
+			identitystore.MaxOwnedOrgsPerUser,
+		)
 	}
 }
 

--- a/internal/storage/executionstore/agent_configs_store.go
+++ b/internal/storage/executionstore/agent_configs_store.go
@@ -257,6 +257,10 @@ func insertAgentConfigTx(
 		if err := lockResourceCreation(ctx, qtx, resourceAgentConfigs, input.ProjectID.String()); err != nil {
 			return AgentConfigRecord{}, err
 		}
+		limits, err := resolveResourceLimits(ctx, qtx, input.OrgID)
+		if err != nil {
+			return AgentConfigRecord{}, err
+		}
 		configCount, err := qtx.CountAgentConfigsForProject(
 			ctx,
 			dbsqlc.CountAgentConfigsForProjectParams{ProjectID: input.ProjectID},
@@ -264,10 +268,10 @@ func insertAgentConfigTx(
 		if err != nil {
 			return AgentConfigRecord{}, fmt.Errorf("count agent configs: %w", err)
 		}
-		if configCount > MaxAgentConfigsPerProject {
+		if configCount > limits.MaxAgentConfigsPerProject {
 			return AgentConfigRecord{}, resourceLimitExceeded(
 				"agent configs",
-				MaxAgentConfigsPerProject,
+				limits.MaxAgentConfigsPerProject,
 			)
 		}
 	}

--- a/internal/storage/executionstore/agent_profiles_store.go
+++ b/internal/storage/executionstore/agent_profiles_store.go
@@ -60,6 +60,10 @@ func (s *Store) CreateAgentProfile(
 	if err := lockResourceCreation(ctx, qtx, resourceAgentProfiles, input.ProjectID.String()); err != nil {
 		return AgentProfileRecord{}, err
 	}
+	limits, err := resolveResourceLimits(ctx, qtx, input.OrgID)
+	if err != nil {
+		return AgentProfileRecord{}, err
+	}
 	profileCount, err := qtx.CountActiveAgentProfilesForProject(
 		ctx,
 		dbsqlc.CountActiveAgentProfilesForProjectParams{ProjectID: input.ProjectID},
@@ -67,10 +71,10 @@ func (s *Store) CreateAgentProfile(
 	if err != nil {
 		return AgentProfileRecord{}, fmt.Errorf("count active agent profiles: %w", err)
 	}
-	if profileCount > MaxActiveAgentProfilesPerProject {
+	if profileCount > limits.MaxActiveAgentProfilesPerProject {
 		return AgentProfileRecord{}, resourceLimitExceeded(
 			"active agent profiles",
-			MaxActiveAgentProfilesPerProject,
+			limits.MaxActiveAgentProfilesPerProject,
 		)
 	}
 

--- a/internal/storage/executionstore/agent_runtime_store.go
+++ b/internal/storage/executionstore/agent_runtime_store.go
@@ -97,6 +97,10 @@ func insertAgentWithProjectLifecycleLockTx(
 		if err := lockResourceCreation(ctx, qtx, resourceAgents, input.ProjectID.String()); err != nil {
 			return AgentRecord{}, false, err
 		}
+		limits, err := resolveResourceLimits(ctx, qtx, input.OrgID)
+		if err != nil {
+			return AgentRecord{}, false, err
+		}
 		agentCount, err := qtx.CountActiveAgentsForProject(
 			ctx,
 			dbsqlc.CountActiveAgentsForProjectParams{ProjectID: input.ProjectID},
@@ -104,10 +108,10 @@ func insertAgentWithProjectLifecycleLockTx(
 		if err != nil {
 			return AgentRecord{}, false, fmt.Errorf("count active agents: %w", err)
 		}
-		if agentCount > MaxActiveAgentsPerProject {
+		if agentCount > limits.MaxActiveAgentsPerProject {
 			return AgentRecord{}, false, resourceLimitExceeded(
 				"active agents",
-				MaxActiveAgentsPerProject,
+				limits.MaxActiveAgentsPerProject,
 			)
 		}
 		return record, true, nil

--- a/internal/storage/executionstore/machine_connection_store.go
+++ b/internal/storage/executionstore/machine_connection_store.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/omnara-ai/omnara/internal/storage/identitystore"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
 )
+
+const maxConnectBYOMachineProjectIDs = 100
 
 type ConnectBYOMachineInput struct {
 	OrgID       ID
@@ -28,7 +29,7 @@ func (s *Store) ConnectBYOMachine(
 	ctx context.Context,
 	input ConnectBYOMachineInput,
 ) (ConnectBYOMachineResult, error) {
-	if len(input.ProjectIDs) > int(identitystore.MaxActiveProjectsPerOrg) {
+	if len(input.ProjectIDs) > maxConnectBYOMachineProjectIDs {
 		return ConnectBYOMachineResult{}, storeerr.InvalidRequest(errors.New("too many project IDs"))
 	}
 	projectSet := make(map[ID]struct{}, len(input.ProjectIDs))

--- a/internal/storage/executionstore/machine_daemon_bootstrap_store.go
+++ b/internal/storage/executionstore/machine_daemon_bootstrap_store.go
@@ -98,6 +98,10 @@ func createBYOMachineDaemonTokenTx(
 	); err != nil {
 		return MachineDaemonTokenRecord{}, err
 	}
+	limits, err := resolveResourceLimits(ctx, qtx, input.OrgID)
+	if err != nil {
+		return MachineDaemonTokenRecord{}, err
+	}
 	tokenCount, err := qtx.CountActiveMachineDaemonTokensForMachine(
 		ctx,
 		dbsqlc.CountActiveMachineDaemonTokensForMachineParams{
@@ -108,10 +112,10 @@ func createBYOMachineDaemonTokenTx(
 	if err != nil {
 		return MachineDaemonTokenRecord{}, fmt.Errorf("count active BYO daemon tokens: %w", err)
 	}
-	if tokenCount > MaxActiveBYODaemonTokensPerMachine {
+	if tokenCount > limits.MaxActiveByoDaemonTokensPerMachine {
 		return MachineDaemonTokenRecord{}, resourceLimitExceeded(
 			"active machine daemon tokens",
-			MaxActiveBYODaemonTokensPerMachine,
+			limits.MaxActiveByoDaemonTokensPerMachine,
 		)
 	}
 	return machineDaemonTokenFromCreate(row), nil

--- a/internal/storage/executionstore/machine_pools_store.go
+++ b/internal/storage/executionstore/machine_pools_store.go
@@ -314,6 +314,10 @@ func (s *Store) CreateMachinePool(
 		if err := lockResourceCreation(ctx, qtx, resourceMachinePools, input.OrgID.String()); err != nil {
 			return MachinePoolRecord{}, err
 		}
+		limits, err := resolveResourceLimits(ctx, qtx, input.OrgID)
+		if err != nil {
+			return MachinePoolRecord{}, err
+		}
 		poolCount, err := qtx.CountActiveTenantMachinePoolsForOrg(
 			ctx,
 			dbsqlc.CountActiveTenantMachinePoolsForOrgParams{OrgID: input.OrgID},
@@ -321,10 +325,10 @@ func (s *Store) CreateMachinePool(
 		if err != nil {
 			return MachinePoolRecord{}, fmt.Errorf("count active tenant machine pools: %w", err)
 		}
-		if poolCount > MaxActiveTenantMachinePoolsPerOrg {
+		if poolCount > limits.MaxActiveTenantMachinePoolsPerOrg {
 			return MachinePoolRecord{}, resourceLimitExceeded(
 				"active machine pools",
-				MaxActiveTenantMachinePoolsPerOrg,
+				limits.MaxActiveTenantMachinePoolsPerOrg,
 			)
 		}
 		if err := tx.Commit(ctx); err != nil {

--- a/internal/storage/executionstore/process_limits_integration_test.go
+++ b/internal/storage/executionstore/process_limits_integration_test.go
@@ -20,8 +20,20 @@ func TestAgentProcessLimitSerializesConcurrentStartsAndPreservesReplay(
 	t.Parallel()
 	ctx := context.Background()
 	fixture := newProcessDaemonFixture(t, ctx, "agent_process_limit")
+	const processLimit = 2
+	if _, err := fixture.Store.pool.Exec(
+		ctx,
+		`INSERT INTO org_resource_limit_overrides (
+    org_id,
+    max_non_terminal_processes_per_agent
+) VALUES ($1, $2)`,
+		fixture.OrgID,
+		processLimit,
+	); err != nil {
+		t.Fatalf("set process limit override: %v", err)
+	}
 
-	toolCallItems := make([]processToolCallBatchItem, executionstore.MaxNonTerminalProcessesPerAgent+1)
+	toolCallItems := make([]processToolCallBatchItem, processLimit+1)
 	for index := range toolCallItems {
 		toolCallItems[index] = builtInProcessToolCallBatchItem(
 			fmt.Sprintf("agent_process_limit_%d", index),
@@ -55,7 +67,7 @@ func TestAgentProcessLimitSerializesConcurrentStartsAndPreservesReplay(
 			},
 		)
 	}
-	processes := make([]executionstore.ProcessRecord, executionstore.MaxNonTerminalProcessesPerAgent-1)
+	processes := make([]executionstore.ProcessRecord, processLimit-1)
 	for index := range processes {
 		processes[index], err = startProcess(index)
 		if err != nil {
@@ -72,7 +84,7 @@ func TestAgentProcessLimitSerializesConcurrentStartsAndPreservesReplay(
 	start := make(chan struct{})
 	var ready sync.WaitGroup
 	ready.Add(2)
-	for index := executionstore.MaxNonTerminalProcessesPerAgent - 1; index <= executionstore.MaxNonTerminalProcessesPerAgent; index++ {
+	for index := processLimit - 1; index <= processLimit; index++ {
 		go func() {
 			ready.Done()
 			<-start

--- a/internal/storage/executionstore/processes_store.go
+++ b/internal/storage/executionstore/processes_store.go
@@ -11,8 +11,6 @@ import (
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
 )
 
-const MaxNonTerminalProcessesPerAgent = 32
-
 type DaemonProcessOffer struct {
 	Process          ProcessRecord     `json:"process"`
 	Env              map[string]string `json:"env"`
@@ -123,6 +121,10 @@ func (t *toolCallTransaction) startProcess(
 	if err := t.lockForMutation(ctx); err != nil {
 		return ProcessRecord{}, err
 	}
+	limits, err := resolveResourceLimits(ctx, t.q, executionConfig.OrgID)
+	if err != nil {
+		return ProcessRecord{}, err
+	}
 	nonTerminalProcesses, err := t.q.CountNonTerminalProcessesForAgent(
 		ctx,
 		dbsqlc.CountNonTerminalProcessesForAgentParams{
@@ -133,8 +135,12 @@ func (t *toolCallTransaction) startProcess(
 	if err != nil {
 		return ProcessRecord{}, fmt.Errorf("count non-terminal agent processes: %w", err)
 	}
-	if nonTerminalProcesses >= MaxNonTerminalProcessesPerAgent {
-		return ProcessRecord{}, storeerr.ErrAgentProcessLimitReached
+	if nonTerminalProcesses >= limits.MaxNonTerminalProcessesPerAgent {
+		return ProcessRecord{}, fmt.Errorf(
+			"non-terminal processes limit of %d reached: %w",
+			limits.MaxNonTerminalProcessesPerAgent,
+			storeerr.ErrAgentProcessLimitReached,
+		)
 	}
 	row, err := t.q.InsertProcess(ctx, dbsqlc.InsertProcessParams{
 		ToolCallID:            toolCallID,

--- a/internal/storage/executionstore/resource_limits.go
+++ b/internal/storage/executionstore/resource_limits.go
@@ -16,13 +16,6 @@ const (
 	resourceMachineDaemonTokens = "machine_daemon_tokens"
 	resourceMachinePools        = "machine_pools"
 	resourceMachines            = "machines"
-
-	MaxAgentConfigsPerProject          = 10_000
-	MaxActiveAgentProfilesPerProject   = 1_000
-	MaxActiveAgentsPerProject          = 10_000
-	MaxActiveBYODaemonTokensPerMachine = 20
-	MaxActiveTenantMachinePoolsPerOrg  = 100
-	MaxLiveMachinesPerOrg              = 10_000
 )
 
 func lockResourceCreation(
@@ -32,6 +25,14 @@ func lockResourceCreation(
 	scope string,
 ) error {
 	return resourceguard.Lock(ctx, qtx, resourceKind, scope)
+}
+
+func resolveResourceLimits(
+	ctx context.Context,
+	qtx *dbsqlc.Queries,
+	orgID ID,
+) (dbsqlc.EffectiveResourceLimit, error) {
+	return resourceguard.ResolveLimits(ctx, qtx, orgID)
 }
 
 func resourceLimitExceeded(resource string, limit int64) error {
@@ -50,6 +51,10 @@ func insertMachineWithResourceLimitTx(
 	if err := lockResourceCreation(ctx, qtx, resourceMachines, input.OrgID.String()); err != nil {
 		return dbsqlc.InsertMachineRow{}, err
 	}
+	limits, err := resolveResourceLimits(ctx, qtx, input.OrgID)
+	if err != nil {
+		return dbsqlc.InsertMachineRow{}, err
+	}
 	machineCount, err := qtx.CountLiveMachinesForOrg(
 		ctx,
 		dbsqlc.CountLiveMachinesForOrgParams{OrgID: input.OrgID},
@@ -57,10 +62,10 @@ func insertMachineWithResourceLimitTx(
 	if err != nil {
 		return dbsqlc.InsertMachineRow{}, fmt.Errorf("count live machines: %w", err)
 	}
-	if machineCount > MaxLiveMachinesPerOrg {
+	if machineCount > limits.MaxLiveMachinesPerOrg {
 		return dbsqlc.InsertMachineRow{}, resourceLimitExceeded(
 			"live machines",
-			MaxLiveMachinesPerOrg,
+			limits.MaxLiveMachinesPerOrg,
 		)
 	}
 	return row, nil

--- a/internal/storage/identitystore/org_api_keys_store.go
+++ b/internal/storage/identitystore/org_api_keys_store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/omnara-ai/omnara/internal/authz"
 	"github.com/omnara-ai/omnara/internal/bearertoken"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
+	"github.com/omnara-ai/omnara/internal/storage/internal/resourceguard"
 	"github.com/omnara-ai/omnara/internal/storage/internal/storeutil"
 	"github.com/omnara-ai/omnara/internal/storage/listing"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
@@ -64,6 +65,10 @@ func (s *Store) CreateOrgAPIKeyWithPlaintext(
 		}
 		return CreatedOrgAPIKey{}, fmt.Errorf("create org api key: %w", err)
 	}
+	limits, err := resourceguard.ResolveLimits(ctx, qtx, input.OrgID)
+	if err != nil {
+		return CreatedOrgAPIKey{}, err
+	}
 	keyCount, err := qtx.CountActiveOrgAPIKeysForOrg(
 		ctx,
 		dbsqlc.CountActiveOrgAPIKeysForOrgParams{OrgID: input.OrgID},
@@ -71,10 +76,10 @@ func (s *Store) CreateOrgAPIKeyWithPlaintext(
 	if err != nil {
 		return CreatedOrgAPIKey{}, fmt.Errorf("count active org api keys: %w", err)
 	}
-	if keyCount > maxActiveOrgAPIKeysPerOrg {
+	if keyCount > limits.MaxActiveOrgApiKeysPerOrg {
 		return CreatedOrgAPIKey{}, resourceLimitExceeded(
 			"active org api keys",
-			maxActiveOrgAPIKeysPerOrg,
+			limits.MaxActiveOrgApiKeysPerOrg,
 		)
 	}
 	membership, err := qtx.AddOrgAPIKeyOrgMembership(

--- a/internal/storage/identitystore/org_invitations_store.go
+++ b/internal/storage/identitystore/org_invitations_store.go
@@ -91,6 +91,10 @@ func (s *Store) CreateOrgInvitation(
 	if err := resourceguard.Lock(ctx, qtx, resourceOrgInvitations, input.OrgID.String()); err != nil {
 		return OrgInvitationRecord{}, err
 	}
+	limits, err := resourceguard.ResolveLimits(ctx, qtx, input.OrgID)
+	if err != nil {
+		return OrgInvitationRecord{}, err
+	}
 	invitationCount, err := qtx.CountPendingOrgInvitationsForOrg(
 		ctx,
 		dbsqlc.CountPendingOrgInvitationsForOrgParams{OrgID: input.OrgID},
@@ -98,10 +102,10 @@ func (s *Store) CreateOrgInvitation(
 	if err != nil {
 		return OrgInvitationRecord{}, fmt.Errorf("count pending organization invitations: %w", err)
 	}
-	if invitationCount > MaxPendingOrgInvitationsPerOrg {
+	if invitationCount > limits.MaxPendingOrgInvitationsPerOrg {
 		return OrgInvitationRecord{}, resourceLimitExceeded(
 			"pending organization invitations",
-			MaxPendingOrgInvitationsPerOrg,
+			limits.MaxPendingOrgInvitationsPerOrg,
 		)
 	}
 	if err := tx.Commit(ctx); err != nil {

--- a/internal/storage/identitystore/orgs_projects_store.go
+++ b/internal/storage/identitystore/orgs_projects_store.go
@@ -15,12 +15,11 @@ import (
 )
 
 const (
-	MaxOwnedOrgsPerUser      = 100
+	MaxOwnedOrgsPerUser      = 1000
 	MaxOrgMembershipsPerUser = 1000
 	defaultProjectName       = "Default"
 	DefaultProjectKey        = "default"
 	resourceProjects         = "projects"
-	MaxActiveProjectsPerOrg  = int64(100)
 )
 
 func checkOrgCreationCapacity(
@@ -280,6 +279,10 @@ func (s *Store) CreateProjectForPrincipal(
 		if err := resourceguard.Lock(ctx, qtx, resourceProjects, input.OrgID.String()); err != nil {
 			return ProjectRecord{}, err
 		}
+		limits, err := resourceguard.ResolveLimits(ctx, qtx, input.OrgID)
+		if err != nil {
+			return ProjectRecord{}, err
+		}
 		projectCount, err := qtx.CountActiveProjectsForOrg(
 			ctx,
 			dbsqlc.CountActiveProjectsForOrgParams{OrgID: input.OrgID},
@@ -287,10 +290,10 @@ func (s *Store) CreateProjectForPrincipal(
 		if err != nil {
 			return ProjectRecord{}, fmt.Errorf("count active projects: %w", err)
 		}
-		if projectCount > MaxActiveProjectsPerOrg {
+		if projectCount > limits.MaxActiveProjectsPerOrg {
 			return ProjectRecord{}, resourceLimitExceeded(
 				"active projects",
-				MaxActiveProjectsPerOrg,
+				limits.MaxActiveProjectsPerOrg,
 			)
 		}
 		if _, err := qtx.AddProjectMembership(

--- a/internal/storage/identitystore/support.go
+++ b/internal/storage/identitystore/support.go
@@ -38,10 +38,8 @@ type ID = uuid.UUID
 var NilID = uuid.Nil
 
 const (
-	resourceOrgInvitations                     = "org_invitations"
-	MaxPendingOrgInvitationsPerOrg       int64 = 1_000
-	MaxActivePersonalAccessTokensPerUser       = int64(100)
-	maxActiveOrgAPIKeysPerOrg                  = int64(1_000)
+	resourceOrgInvitations               = "org_invitations"
+	MaxActivePersonalAccessTokensPerUser = int64(1_000)
 )
 
 func isNilID(id ID) bool {

--- a/internal/storage/internal/dbsqlc/models_gen.go
+++ b/internal/storage/internal/dbsqlc/models_gen.go
@@ -209,6 +209,24 @@ type ConfiguredModelRevision struct {
 	CreatedAt                 time.Time
 }
 
+type EffectiveResourceLimit struct {
+	OrgID                                     uuid.UUID
+	MaxActiveProjectsPerOrg                   int64
+	MaxPendingOrgInvitationsPerOrg            int64
+	MaxActiveOrgApiKeysPerOrg                 int64
+	MaxActiveTenantModelProviderConfigsPerOrg int64
+	MaxActiveConfiguredModelsPerProvider      int64
+	MaxAgentConfigsPerProject                 int64
+	MaxActiveAgentProfilesPerProject          int64
+	MaxActiveAgentsPerProject                 int64
+	MaxActiveTenantSecretsPerOwner            int64
+	MaxActiveSkillsPerOwner                   int64
+	MaxActiveTenantMachinePoolsPerOrg         int64
+	MaxLiveMachinesPerOrg                     int64
+	MaxActiveByoDaemonTokensPerMachine        int64
+	MaxNonTerminalProcessesPerAgent           int64
+}
+
 type IntegrationInstall struct {
 	ID                       uuid.UUID
 	OrgID                    uuid.UUID

--- a/internal/storage/internal/dbsqlc/resource_limits.sql.go
+++ b/internal/storage/internal/dbsqlc/resource_limits.sql.go
@@ -290,6 +290,54 @@ func (q *Queries) CountPendingOrgInvitationsForOrg(ctx context.Context, arg Coun
 	return column_1, err
 }
 
+const getEffectiveResourceLimits = `-- name: GetEffectiveResourceLimits :one
+SELECT
+    org_id,
+    max_active_projects_per_org,
+    max_pending_org_invitations_per_org,
+    max_active_org_api_keys_per_org,
+    max_active_tenant_model_provider_configs_per_org,
+    max_active_configured_models_per_provider,
+    max_agent_configs_per_project,
+    max_active_agent_profiles_per_project,
+    max_active_agents_per_project,
+    max_active_tenant_secrets_per_owner,
+    max_active_skills_per_owner,
+    max_active_tenant_machine_pools_per_org,
+    max_live_machines_per_org,
+    max_active_byo_daemon_tokens_per_machine,
+    max_non_terminal_processes_per_agent
+FROM effective_resource_limits
+WHERE org_id = $1
+`
+
+type GetEffectiveResourceLimitsParams struct {
+	OrgID uuid.UUID
+}
+
+func (q *Queries) GetEffectiveResourceLimits(ctx context.Context, arg GetEffectiveResourceLimitsParams) (EffectiveResourceLimit, error) {
+	row := q.db.QueryRow(ctx, getEffectiveResourceLimits, arg.OrgID)
+	var i EffectiveResourceLimit
+	err := row.Scan(
+		&i.OrgID,
+		&i.MaxActiveProjectsPerOrg,
+		&i.MaxPendingOrgInvitationsPerOrg,
+		&i.MaxActiveOrgApiKeysPerOrg,
+		&i.MaxActiveTenantModelProviderConfigsPerOrg,
+		&i.MaxActiveConfiguredModelsPerProvider,
+		&i.MaxAgentConfigsPerProject,
+		&i.MaxActiveAgentProfilesPerProject,
+		&i.MaxActiveAgentsPerProject,
+		&i.MaxActiveTenantSecretsPerOwner,
+		&i.MaxActiveSkillsPerOwner,
+		&i.MaxActiveTenantMachinePoolsPerOrg,
+		&i.MaxLiveMachinesPerOrg,
+		&i.MaxActiveByoDaemonTokensPerMachine,
+		&i.MaxNonTerminalProcessesPerAgent,
+	)
+	return i, err
+}
+
 const lockResourceCreation = `-- name: LockResourceCreation :exec
 SELECT pg_advisory_xact_lock(
     hashtextextended(

--- a/internal/storage/internal/resourceguard/resourceguard.go
+++ b/internal/storage/internal/resourceguard/resourceguard.go
@@ -2,10 +2,13 @@ package resourceguard
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
+	"github.com/omnara-ai/omnara/internal/storage/storeerr"
 )
 
 func Lock(ctx context.Context, q *dbsqlc.Queries, resourceKind, scope string) error {
@@ -16,6 +19,26 @@ func Lock(ctx context.Context, q *dbsqlc.Queries, resourceKind, scope string) er
 		return fmt.Errorf("lock %s resource creation: %w", resourceKind, err)
 	}
 	return nil
+}
+
+func ResolveLimits(
+	ctx context.Context,
+	q *dbsqlc.Queries,
+	orgID uuid.UUID,
+) (dbsqlc.EffectiveResourceLimit, error) {
+	limits, err := q.GetEffectiveResourceLimits(ctx, dbsqlc.GetEffectiveResourceLimitsParams{
+		OrgID: orgID,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return dbsqlc.EffectiveResourceLimit{}, fmt.Errorf(
+			"resolve resource limits: %w",
+			storeerr.ErrNotFound,
+		)
+	}
+	if err != nil {
+		return dbsqlc.EffectiveResourceLimit{}, fmt.Errorf("resolve resource limits: %w", err)
+	}
+	return limits, nil
 }
 
 func OwnerScope(orgID uuid.UUID, ownerKind string, projectID, userID uuid.UUID) string {

--- a/internal/storage/modelstore/configured_models_store.go
+++ b/internal/storage/modelstore/configured_models_store.go
@@ -41,6 +41,10 @@ func (s *Store) CreateConfiguredModel(
 		); err != nil {
 			return ConfiguredModelRecord{}, err
 		}
+		limits, err := resourceguard.ResolveLimits(ctx, qtx, input.OrgID)
+		if err != nil {
+			return ConfiguredModelRecord{}, err
+		}
 		modelCount, err := qtx.CountActiveConfiguredModelsForProvider(
 			ctx,
 			dbsqlc.CountActiveConfiguredModelsForProviderParams{
@@ -51,10 +55,10 @@ func (s *Store) CreateConfiguredModel(
 		if err != nil {
 			return ConfiguredModelRecord{}, fmt.Errorf("count active configured models: %w", err)
 		}
-		if modelCount > MaxActiveConfiguredModelsPerProvider {
+		if modelCount > limits.MaxActiveConfiguredModelsPerProvider {
 			return ConfiguredModelRecord{}, resourceLimitExceeded(
 				"active configured models",
-				MaxActiveConfiguredModelsPerProvider,
+				limits.MaxActiveConfiguredModelsPerProvider,
 			)
 		}
 	}

--- a/internal/storage/modelstore/model_provider_configs_store.go
+++ b/internal/storage/modelstore/model_provider_configs_store.go
@@ -42,6 +42,10 @@ func (s *Store) CreateModelProviderConfig(
 		); err != nil {
 			return ModelProviderConfigRecord{}, err
 		}
+		limits, err := resourceguard.ResolveLimits(ctx, qtx, input.OrgID)
+		if err != nil {
+			return ModelProviderConfigRecord{}, err
+		}
 		configCount, err := qtx.CountActiveTenantModelProviderConfigsForOrg(
 			ctx,
 			dbsqlc.CountActiveTenantModelProviderConfigsForOrgParams{OrgID: input.OrgID},
@@ -52,10 +56,10 @@ func (s *Store) CreateModelProviderConfig(
 				err,
 			)
 		}
-		if configCount > MaxActiveTenantModelProviderConfigsPerOrg {
+		if configCount > limits.MaxActiveTenantModelProviderConfigsPerOrg {
 			return ModelProviderConfigRecord{}, resourceLimitExceeded(
 				"active model provider configs",
-				MaxActiveTenantModelProviderConfigsPerOrg,
+				limits.MaxActiveTenantModelProviderConfigsPerOrg,
 			)
 		}
 	}

--- a/internal/storage/modelstore/support.go
+++ b/internal/storage/modelstore/support.go
@@ -16,9 +16,6 @@ var NilID = uuid.Nil
 const (
 	resourceModelProviderConfigs = "model_provider_configs"
 	resourceConfiguredModels     = "configured_models"
-
-	MaxActiveTenantModelProviderConfigsPerOrg int64 = 100
-	MaxActiveConfiguredModelsPerProvider      int64 = 100
 )
 
 type Store struct {

--- a/internal/storage/queries/resource_limits.sql
+++ b/internal/storage/queries/resource_limits.sql
@@ -6,6 +6,26 @@ SELECT pg_advisory_xact_lock(
     )
 );
 
+-- name: GetEffectiveResourceLimits :one
+SELECT
+    org_id,
+    max_active_projects_per_org,
+    max_pending_org_invitations_per_org,
+    max_active_org_api_keys_per_org,
+    max_active_tenant_model_provider_configs_per_org,
+    max_active_configured_models_per_provider,
+    max_agent_configs_per_project,
+    max_active_agent_profiles_per_project,
+    max_active_agents_per_project,
+    max_active_tenant_secrets_per_owner,
+    max_active_skills_per_owner,
+    max_active_tenant_machine_pools_per_org,
+    max_live_machines_per_org,
+    max_active_byo_daemon_tokens_per_machine,
+    max_non_terminal_processes_per_agent
+FROM effective_resource_limits
+WHERE org_id = sqlc.arg(org_id);
+
 -- name: CountActiveProjectsForOrg :one
 SELECT count(*)::bigint
 FROM projects

--- a/internal/storage/resource_limits_integration_test.go
+++ b/internal/storage/resource_limits_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/omnara-ai/omnara/internal/agentconfig"
 	"github.com/omnara-ai/omnara/internal/modelprotocol"
 	"github.com/omnara-ai/omnara/internal/secrets"
@@ -26,12 +27,210 @@ import (
 	"github.com/omnara-ai/omnara/internal/testutil/integrationdb"
 )
 
+func setOrgResourceLimitOverrides(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	overrides map[string]int64,
+) {
+	t.Helper()
+	if len(overrides) == 0 {
+		if _, err := pool.Exec(
+			ctx,
+			`DELETE FROM org_resource_limit_overrides WHERE org_id = $1`,
+			testOrgID,
+		); err != nil {
+			t.Fatalf("clear resource limit overrides: %v", err)
+		}
+		return
+	}
+	value := func(key string) *int64 {
+		limit, ok := overrides[key]
+		if !ok {
+			return nil
+		}
+		return &limit
+	}
+	if _, err := pool.Exec(
+		ctx,
+		`INSERT INTO org_resource_limit_overrides (
+    org_id,
+    max_active_projects_per_org,
+    max_pending_org_invitations_per_org,
+    max_active_org_api_keys_per_org,
+    max_active_tenant_model_provider_configs_per_org,
+    max_active_configured_models_per_provider,
+    max_agent_configs_per_project,
+    max_active_agent_profiles_per_project,
+    max_active_agents_per_project,
+    max_active_tenant_secrets_per_owner,
+    max_active_skills_per_owner,
+    max_active_tenant_machine_pools_per_org,
+    max_live_machines_per_org,
+    max_active_byo_daemon_tokens_per_machine,
+    max_non_terminal_processes_per_agent
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
+)
+ON CONFLICT (org_id) DO UPDATE SET
+    max_active_projects_per_org = EXCLUDED.max_active_projects_per_org,
+    max_pending_org_invitations_per_org = EXCLUDED.max_pending_org_invitations_per_org,
+    max_active_org_api_keys_per_org = EXCLUDED.max_active_org_api_keys_per_org,
+    max_active_tenant_model_provider_configs_per_org = EXCLUDED.max_active_tenant_model_provider_configs_per_org,
+    max_active_configured_models_per_provider = EXCLUDED.max_active_configured_models_per_provider,
+    max_agent_configs_per_project = EXCLUDED.max_agent_configs_per_project,
+    max_active_agent_profiles_per_project = EXCLUDED.max_active_agent_profiles_per_project,
+    max_active_agents_per_project = EXCLUDED.max_active_agents_per_project,
+    max_active_tenant_secrets_per_owner = EXCLUDED.max_active_tenant_secrets_per_owner,
+    max_active_skills_per_owner = EXCLUDED.max_active_skills_per_owner,
+    max_active_tenant_machine_pools_per_org = EXCLUDED.max_active_tenant_machine_pools_per_org,
+    max_live_machines_per_org = EXCLUDED.max_live_machines_per_org,
+    max_active_byo_daemon_tokens_per_machine = EXCLUDED.max_active_byo_daemon_tokens_per_machine,
+    max_non_terminal_processes_per_agent = EXCLUDED.max_non_terminal_processes_per_agent`,
+		testOrgID,
+		value("max_active_projects_per_org"),
+		value("max_pending_org_invitations_per_org"),
+		value("max_active_org_api_keys_per_org"),
+		value("max_active_tenant_model_provider_configs_per_org"),
+		value("max_active_configured_models_per_provider"),
+		value("max_agent_configs_per_project"),
+		value("max_active_agent_profiles_per_project"),
+		value("max_active_agents_per_project"),
+		value("max_active_tenant_secrets_per_owner"),
+		value("max_active_skills_per_owner"),
+		value("max_active_tenant_machine_pools_per_org"),
+		value("max_live_machines_per_org"),
+		value("max_active_byo_daemon_tokens_per_machine"),
+		value("max_non_terminal_processes_per_agent"),
+	); err != nil {
+		t.Fatalf("set resource limit overrides: %v", err)
+	}
+}
+
+func TestOrgResourceLimitOverridesResolveAndValidate(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	pool := openIntegrationDB(t, ctx)
+	seedMigratedDB(t, ctx, pool)
+	q := dbsqlc.New(pool)
+
+	limits, err := resourceguard.ResolveLimits(ctx, q, testOrgID)
+	if err != nil {
+		t.Fatalf("resolve default resource limits: %v", err)
+	}
+	wantDefaults := dbsqlc.EffectiveResourceLimit{
+		OrgID:                                     testOrgID,
+		MaxActiveProjectsPerOrg:                   1_000,
+		MaxPendingOrgInvitationsPerOrg:            10_000,
+		MaxActiveOrgApiKeysPerOrg:                 10_000,
+		MaxActiveTenantModelProviderConfigsPerOrg: 10_000,
+		MaxActiveConfiguredModelsPerProvider:      10_000,
+		MaxAgentConfigsPerProject:                 10_000,
+		MaxActiveAgentProfilesPerProject:          10_000,
+		MaxActiveAgentsPerProject:                 10_000,
+		MaxActiveTenantSecretsPerOwner:            10_000,
+		MaxActiveSkillsPerOwner:                   10_000,
+		MaxActiveTenantMachinePoolsPerOrg:         10_000,
+		MaxLiveMachinesPerOrg:                     10_000,
+		MaxActiveByoDaemonTokensPerMachine:        20,
+		MaxNonTerminalProcessesPerAgent:           32,
+	}
+	if limits != wantDefaults {
+		t.Fatalf("default resource limits = %+v, want %+v", limits, wantDefaults)
+	}
+
+	overrides := map[string]int64{
+		"max_active_projects_per_org":                      0,
+		"max_pending_org_invitations_per_org":              2,
+		"max_active_org_api_keys_per_org":                  3,
+		"max_active_tenant_model_provider_configs_per_org": 4,
+		"max_active_configured_models_per_provider":        5,
+		"max_agent_configs_per_project":                    6,
+		"max_active_agent_profiles_per_project":            7,
+		"max_active_agents_per_project":                    8,
+		"max_active_tenant_secrets_per_owner":              9,
+		"max_active_skills_per_owner":                      10,
+		"max_active_tenant_machine_pools_per_org":          11,
+		"max_live_machines_per_org":                        12,
+		"max_active_byo_daemon_tokens_per_machine":         13,
+		"max_non_terminal_processes_per_agent":             42,
+	}
+	setOrgResourceLimitOverrides(t, ctx, pool, overrides)
+	limits, err = resourceguard.ResolveLimits(ctx, q, testOrgID)
+	if err != nil {
+		t.Fatalf("resolve overridden resource limits: %v", err)
+	}
+	wantOverrides := dbsqlc.EffectiveResourceLimit{
+		OrgID:                                     testOrgID,
+		MaxActiveProjectsPerOrg:                   0,
+		MaxPendingOrgInvitationsPerOrg:            2,
+		MaxActiveOrgApiKeysPerOrg:                 3,
+		MaxActiveTenantModelProviderConfigsPerOrg: 4,
+		MaxActiveConfiguredModelsPerProvider:      5,
+		MaxAgentConfigsPerProject:                 6,
+		MaxActiveAgentProfilesPerProject:          7,
+		MaxActiveAgentsPerProject:                 8,
+		MaxActiveTenantSecretsPerOwner:            9,
+		MaxActiveSkillsPerOwner:                   10,
+		MaxActiveTenantMachinePoolsPerOrg:         11,
+		MaxLiveMachinesPerOrg:                     12,
+		MaxActiveByoDaemonTokensPerMachine:        13,
+		MaxNonTerminalProcessesPerAgent:           42,
+	}
+	if limits != wantOverrides {
+		t.Fatalf("overridden resource limits = %+v, want %+v", limits, wantOverrides)
+	}
+
+	setOrgResourceLimitOverrides(t, ctx, pool, map[string]int64{})
+	limits, err = resourceguard.ResolveLimits(ctx, q, testOrgID)
+	if err != nil {
+		t.Fatalf("resolve resource limits after removing overrides: %v", err)
+	}
+	if limits != wantDefaults {
+		t.Fatalf("resource limits after removing overrides = %+v, want %+v", limits, wantDefaults)
+	}
+
+	for name, value := range map[string]string{
+		"negative":  "-1",
+		"too large": "9223372036854775808",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := pool.Exec(
+				ctx,
+				`INSERT INTO org_resource_limit_overrides (
+    org_id,
+    max_active_projects_per_org
+) VALUES ($1, $2::numeric)`,
+				testOrgID,
+				value,
+			); err == nil {
+				t.Fatalf("invalid resource limit override %s was accepted", value)
+			}
+		})
+	}
+
+	if _, err := pool.Exec(
+		ctx,
+		`UPDATE orgs SET deleted_at = now() WHERE id = $1`,
+		testOrgID,
+	); err != nil {
+		t.Fatalf("soft-delete organization: %v", err)
+	}
+	if _, err := resourceguard.ResolveLimits(ctx, q, testOrgID); !errors.Is(err, storeerr.ErrNotFound) {
+		t.Fatalf("resolve deleted organization resource limits error = %v, want ErrNotFound", err)
+	}
+}
+
 func TestProjectResourceLimitSerializesConcurrentCreation(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	pool := openIntegrationDB(t, ctx)
 	store := newIntegrationStore(pool)
 	seedDefaultProject(t, ctx, store)
+	const projectLimit = int64(3)
+	setOrgResourceLimitOverrides(t, ctx, pool, map[string]int64{
+		"max_active_projects_per_org": projectLimit,
+	})
 	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
 	creator := mustCreateIdentityUser(t, ctx, store, "limited-projects@example.com", "Limited Projects")
 	if _, err := store.Identity().AddOrgMembership(ctx, identitystore.AddOrgMembershipInput{
@@ -43,7 +242,7 @@ func TestProjectResourceLimitSerializesConcurrentCreation(t *testing.T) {
 INSERT INTO projects(org_id, name, idempotency_key, created_at, updated_at)
 SELECT $1, 'Limit seed project ' || n, 'limit-seed-project-' || n, $2, $2
 FROM generate_series(1, $3::integer) AS n
-`, testOrgID, now, identitystore.MaxActiveProjectsPerOrg-2); err != nil {
+`, testOrgID, now, projectLimit-2); err != nil {
 		t.Fatalf("seed projects to limit: %v", err)
 	}
 	inputs := []identitystore.CreateProjectForPrincipalInput{
@@ -104,8 +303,8 @@ FROM generate_series(1, $3::integer) AS n
 	if err != nil {
 		t.Fatalf("count active projects: %v", err)
 	}
-	if count != identitystore.MaxActiveProjectsPerOrg {
-		t.Fatalf("active project count = %d, want %d", count, identitystore.MaxActiveProjectsPerOrg)
+	if count != projectLimit {
+		t.Fatalf("active project count = %d, want %d", count, projectLimit)
 	}
 	replayed, err := store.Identity().CreateProjectForPrincipal(ctx, inputs[created.index])
 	if err != nil {
@@ -122,6 +321,12 @@ func TestIdentityResourceLimitsRollBackAndReleaseCapacity(t *testing.T) {
 	pool := openIntegrationDB(t, ctx)
 	store := newIntegrationStore(pool)
 	seedDefaultProject(t, ctx, store)
+	const invitationLimit = int64(2)
+	const orgAPIKeyLimit = int64(2)
+	setOrgResourceLimitOverrides(t, ctx, pool, map[string]int64{
+		"max_pending_org_invitations_per_org": invitationLimit,
+		"max_active_org_api_keys_per_org":     orgAPIKeyLimit,
+	})
 	now := time.Date(2026, 7, 24, 13, 0, 0, 0, time.UTC)
 
 	if _, err := pool.Exec(ctx, `
@@ -129,7 +334,7 @@ INSERT INTO org_invitations(org_id, email, normalized_email, org_role, created_a
 SELECT $1, 'limited-invite-' || n || '@example.com',
        'limited-invite-' || n || '@example.com', 'member', $2
 FROM generate_series(1, $3::integer) AS n
-`, testOrgID, now, identitystore.MaxPendingOrgInvitationsPerOrg); err != nil {
+`, testOrgID, now, invitationLimit); err != nil {
 		t.Fatalf("seed invitations to limit: %v", err)
 	}
 	if _, err := store.Identity().CreateOrgInvitation(ctx, identitystore.CreateOrgInvitationInput{
@@ -142,11 +347,11 @@ FROM generate_series(1, $3::integer) AS n
 		Scan(&invitationCount); err != nil {
 		t.Fatalf("count invitations: %v", err)
 	}
-	if invitationCount != identitystore.MaxPendingOrgInvitationsPerOrg {
+	if invitationCount != invitationLimit {
 		t.Fatalf(
 			"invitation count after rollback = %d, want %d",
 			invitationCount,
-			identitystore.MaxPendingOrgInvitationsPerOrg,
+			invitationLimit,
 		)
 	}
 
@@ -233,7 +438,6 @@ FROM generate_series(1, $3::integer) AS n
 		t.Fatalf("device auth flow after revoke = %+v, want approved token", approved)
 	}
 
-	const orgAPIKeyLimit = 1_000
 	if _, err := pool.Exec(ctx, `
 INSERT INTO org_api_keys(org_id, name, token_id, token_hash, created_by_user_id, created_at, updated_at)
 SELECT $1, 'Pre-canonical limit key ' || n, 'legacy-key-id-' || n,
@@ -282,6 +486,14 @@ func TestAgentResourceLimitsPreserveReplays(t *testing.T) {
 	pool := openIntegrationDB(t, ctx)
 	seedMigratedDB(t, ctx, pool)
 	store := newIntegrationStore(pool)
+	const agentConfigLimit = int64(20)
+	const agentProfileLimit = int64(2)
+	const agentLimit = int64(2)
+	setOrgResourceLimitOverrides(t, ctx, pool, map[string]int64{
+		"max_agent_configs_per_project":         agentConfigLimit,
+		"max_active_agent_profiles_per_project": agentProfileLimit,
+		"max_active_agents_per_project":         agentLimit,
+	})
 	now := time.Date(2026, 7, 24, 14, 0, 0, 0, time.UTC)
 	configID := mustCreateAgentConfig(t, ctx, store, testProjectID, "resource-limit", now)
 
@@ -313,7 +525,7 @@ func TestAgentResourceLimitsPreserveReplays(t *testing.T) {
 	)
 	SELECT current_version_id, project_id, id, 1, $2, 'create', created_at
 	FROM profiles
-	`, testProjectID, configID, now, executionstore.MaxActiveAgentProfilesPerProject-1); err != nil {
+	`, testProjectID, configID, now, agentProfileLimit-1); err != nil {
 		t.Fatalf("seed agent profiles to limit: %v", err)
 	}
 	replayedProfile, err := store.Execution().CreateAgentProfile(ctx, profileInput)
@@ -350,7 +562,7 @@ INSERT INTO agents(
 SELECT md5('resource-limit-agent-' || n)::uuid, $1, $2, 'active', $3,
        'limit-seed-agent-' || n, $4, $4
 FROM generate_series(1, $5::integer) AS n
-`, testOrgID, testProjectID, configID, now, executionstore.MaxActiveAgentsPerProject-1); err != nil {
+`, testOrgID, testProjectID, configID, now, agentLimit-1); err != nil {
 		t.Fatalf("seed agents to limit: %v", err)
 	}
 	replayedAgent, err := store.Execution().LaunchAgent(ctx, agentInput)
@@ -388,7 +600,7 @@ SELECT org_id, project_id, configured_model_id, definition,
 FROM agent_configs
 CROSS JOIN generate_series(1, $3::bigint) AS n
 WHERE id = $1
-`, configID, now, executionstore.MaxAgentConfigsPerProject-configCount); err != nil {
+`, configID, now, agentConfigLimit-configCount); err != nil {
 		t.Fatalf("seed agent configs to limit: %v", err)
 	}
 	sourceYAML := `
@@ -417,6 +629,10 @@ func TestSkillResourceLimitCountsIdentitiesNotRevisions(t *testing.T) {
 	pool := openIntegrationDB(t, ctx)
 	seedMigratedDB(t, ctx, pool)
 	store := newIntegrationStore(pool, WithBlobStore(integrationblob.MustOpen(t, ctx)))
+	const skillLimit = int64(2)
+	setOrgResourceLimitOverrides(t, ctx, pool, map[string]int64{
+		"max_active_skills_per_owner": skillLimit,
+	})
 	now := time.Date(2026, 7, 24, 15, 0, 0, 0, time.UTC)
 	admin := createSecretTestUser(t, ctx, store, "Resource Limit Skills Admin", "admin")
 	input := skillstore.CreateSkillInput{
@@ -447,7 +663,7 @@ func TestSkillResourceLimitCountsIdentitiesNotRevisions(t *testing.T) {
 INSERT INTO skills(org_id, owner_kind, name, created_at)
 SELECT $1, 'org', 'limit-seed-skill-' || n, $2
 FROM generate_series(1, $3::bigint) AS n
-`, testOrgID, now, skillstore.MaxActiveSkillsPerOwner-skillCount); err != nil {
+`, testOrgID, now, skillLimit-skillCount); err != nil {
 		t.Fatalf("seed skills to limit: %v", err)
 	}
 	if _, err := seedTx.Exec(ctx, `
@@ -554,6 +770,12 @@ func TestMachineResourceLimitsPreserveReplaysAndReleaseTokens(t *testing.T) {
 	pool := openIntegrationDB(t, ctx)
 	seedMigratedDB(t, ctx, pool)
 	store := newIntegrationStore(pool)
+	const machineLimit = int64(2)
+	const daemonTokenLimit = int64(2)
+	setOrgResourceLimitOverrides(t, ctx, pool, map[string]int64{
+		"max_live_machines_per_org":                machineLimit,
+		"max_active_byo_daemon_tokens_per_machine": daemonTokenLimit,
+	})
 	now := time.Date(2026, 7, 24, 16, 0, 0, 0, time.UTC)
 	machineInput := executionstore.CreateDaemonMachineInput{
 		OrgID:          testOrgID,
@@ -571,7 +793,7 @@ INSERT INTO machines(
 )
 SELECT $1, 'byo', 'Limit seed machine ' || n, 'byo', 'active', $2, $2, $2
 FROM generate_series(1, $3::integer) AS n
-`, testOrgID, now, executionstore.MaxLiveMachinesPerOrg-1); err != nil {
+`, testOrgID, now, machineLimit-1); err != nil {
 		t.Fatalf("seed machines to limit: %v", err)
 	}
 	replayed, err := store.Execution().CreateDaemonMachine(ctx, machineInput)
@@ -603,7 +825,7 @@ SELECT $1, $2, 'Limit seed daemon token ' || n,
        'legacy-daemon-token-hash-' || n, $3
 FROM generate_series(1, $4::integer) AS n
 `, testOrgID, machine.ID, now,
-		executionstore.MaxActiveBYODaemonTokensPerMachine-1); err != nil {
+		daemonTokenLimit-1); err != nil {
 		t.Fatalf("seed daemon tokens to limit: %v", err)
 	}
 	secondTokenInput := executionstore.CreateBYOMachineDaemonTokenInput{
@@ -632,10 +854,20 @@ func TestTenantResourceLimitsUseTheirIntendedScopes(t *testing.T) {
 	pool := openIntegrationDB(t, ctx)
 	seedMigratedDB(t, ctx, pool)
 	store := newSecretIntegrationStore(pool, WithBlobStore(integrationblob.MustOpen(t, ctx)))
+	const secretLimit = int64(2)
+	const modelProviderLimit = int64(2)
+	const configuredModelLimit = int64(2)
+	const machinePoolLimit = int64(2)
+	setOrgResourceLimitOverrides(t, ctx, pool, map[string]int64{
+		"max_active_tenant_secrets_per_owner":              secretLimit,
+		"max_active_tenant_model_provider_configs_per_org": modelProviderLimit,
+		"max_active_configured_models_per_provider":        configuredModelLimit,
+		"max_active_tenant_machine_pools_per_org":          machinePoolLimit,
+	})
 	now := time.Date(2026, 7, 24, 17, 0, 0, 0, time.UTC)
 	admin := createSecretTestUser(t, ctx, store, "Resource Limit Tenant Admin", "admin")
 
-	for i := range secretstore.MaxActiveTenantSecretsPerOwner {
+	for i := range secretLimit {
 		if _, _, err := store.Secrets().CreateSecret(ctx, secretstore.CreateSecretInput{
 			OrgID: testOrgID, OwnerKind: secretstore.SecretOwnerUser, OwnerUserID: admin.ID,
 			Name:     fmt.Sprintf("limit-seed-secret-%d", i),
@@ -667,7 +899,7 @@ SELECT config.org_id, config.management_kind, 'limit-seed-provider-' || n,
 FROM model_provider_configs AS config
 CROSS JOIN generate_series(1, $3::integer) AS n
 WHERE config.id = $1
-`, testDefaultProviderConfigID(), now, modelstore.MaxActiveTenantModelProviderConfigsPerOrg-1); err != nil {
+`, testDefaultProviderConfigID(), now, modelProviderLimit-1); err != nil {
 		t.Fatalf("seed model provider configs to limit: %v", err)
 	}
 	if _, err := store.Models().CreateModelProviderConfig(ctx, modelstore.CreateModelProviderConfigInput{
@@ -680,7 +912,7 @@ WHERE config.id = $1
 		t.Fatalf("model provider config over limit error = %v, want ErrConflict", err)
 	}
 
-	for i := range modelstore.MaxActiveConfiguredModelsPerProvider {
+	for i := range configuredModelLimit {
 		if _, err := store.Models().CreateConfiguredModel(ctx, modelstore.CreateConfiguredModelInput{
 			OrgID:                  testOrgID,
 			ModelProviderConfigID:  testDefaultProviderConfigID(),
@@ -734,7 +966,7 @@ SELECT $1, 'Limit seed pool ' || n, 'tenant', 'test.provider', 1,
        1024, '{"image":"test"}'::jsonb, $2, 1, 1, 1024, 1, 1024, $3, $3
 FROM generate_series(1, $4::integer) AS n
 `, testOrgID, testDefaultProviderCredentialSecretID, now,
-		executionstore.MaxActiveTenantMachinePoolsPerOrg); err != nil {
+		machinePoolLimit); err != nil {
 		t.Fatalf("seed machine pools to limit: %v", err)
 	}
 	if _, err := store.Execution().CreateMachinePool(ctx, poolInput); !errors.Is(err, storeerr.ErrConflict) {

--- a/internal/storage/secretstore/secret_writes_store.go
+++ b/internal/storage/secretstore/secret_writes_store.go
@@ -57,6 +57,10 @@ func (s *Store) CreateSecret(
 	); err != nil {
 		return SecretRecord{}, SecretVersionRecord{}, err
 	}
+	limits, err := resourceguard.ResolveLimits(ctx, qtx, input.OrgID)
+	if err != nil {
+		return SecretRecord{}, SecretVersionRecord{}, err
+	}
 	secretCount, err := qtx.CountActiveTenantSecretsForOwner(
 		ctx,
 		dbsqlc.CountActiveTenantSecretsForOwnerParams{
@@ -72,10 +76,10 @@ func (s *Store) CreateSecret(
 			err,
 		)
 	}
-	if secretCount > MaxActiveTenantSecretsPerOwner {
+	if secretCount > limits.MaxActiveTenantSecretsPerOwner {
 		return SecretRecord{}, SecretVersionRecord{}, resourceLimitExceeded(
 			"active secrets",
-			MaxActiveTenantSecretsPerOwner,
+			limits.MaxActiveTenantSecretsPerOwner,
 		)
 	}
 	if err := tx.Commit(ctx); err != nil {

--- a/internal/storage/secretstore/support.go
+++ b/internal/storage/secretstore/support.go
@@ -46,13 +46,12 @@ type ProjectRecord struct {
 }
 
 const (
-	resourceSecrets                = "secrets"
-	MaxActiveTenantSecretsPerOwner = int64(1_000)
-	orgActionSecretsList           = authz.OrgSecretsList
-	orgActionSecretsManage         = authz.OrgSecretsManage
-	projectActionSecretsList       = authz.ProjectSecretsList
-	projectActionSecretsManage     = authz.ProjectSecretsManage
-	principalTypeUser              = authz.PrincipalUser
+	resourceSecrets            = "secrets"
+	orgActionSecretsList       = authz.OrgSecretsList
+	orgActionSecretsManage     = authz.OrgSecretsManage
+	projectActionSecretsList   = authz.ProjectSecretsList
+	projectActionSecretsManage = authz.ProjectSecretsManage
+	principalTypeUser          = authz.PrincipalUser
 )
 
 func isNilID(id ID) bool {

--- a/internal/storage/skillstore/skill_revisions_store.go
+++ b/internal/storage/skillstore/skill_revisions_store.go
@@ -118,6 +118,10 @@ func (s *Store) insertSkillRevision(
 		} else if !errors.Is(err, pgx.ErrNoRows) {
 			return skillRevisionInsertResult{}, fmt.Errorf("look up skill by name: %w", err)
 		} else {
+			limits, err := resourceguard.ResolveLimits(ctx, qtx, input.OrgID)
+			if err != nil {
+				return skillRevisionInsertResult{}, err
+			}
 			skillCount, err := qtx.CountActiveSkillsForOwner(
 				ctx,
 				dbsqlc.CountActiveSkillsForOwnerParams{
@@ -130,10 +134,10 @@ func (s *Store) insertSkillRevision(
 			if err != nil {
 				return skillRevisionInsertResult{}, fmt.Errorf("count active skills: %w", err)
 			}
-			if skillCount >= MaxActiveSkillsPerOwner {
+			if skillCount >= limits.MaxActiveSkillsPerOwner {
 				return skillRevisionInsertResult{}, fmt.Errorf(
 					"active skills limit of %d reached: %w",
-					MaxActiveSkillsPerOwner,
+					limits.MaxActiveSkillsPerOwner,
 					storeerr.ErrConflict,
 				)
 			}

--- a/internal/storage/skillstore/store.go
+++ b/internal/storage/skillstore/store.go
@@ -20,8 +20,6 @@ const (
 
 	SkillAvailabilityDirect = "direct"
 	SkillAvailabilityGrant  = "grant"
-
-	MaxActiveSkillsPerOwner int64 = 1_000
 )
 
 type Access interface {

--- a/migrations/000019_org_resource_limit_overrides.sql
+++ b/migrations/000019_org_resource_limit_overrides.sql
@@ -1,0 +1,58 @@
+-- +goose Up
+
+CREATE TABLE org_resource_limit_overrides (
+    org_id uuid PRIMARY KEY REFERENCES orgs(id) ON DELETE CASCADE,
+    max_active_projects_per_org bigint CHECK (max_active_projects_per_org >= 0),
+    max_pending_org_invitations_per_org bigint CHECK (max_pending_org_invitations_per_org >= 0),
+    max_active_org_api_keys_per_org bigint CHECK (max_active_org_api_keys_per_org >= 0),
+    max_active_tenant_model_provider_configs_per_org bigint CHECK (max_active_tenant_model_provider_configs_per_org >= 0),
+    max_active_configured_models_per_provider bigint CHECK (max_active_configured_models_per_provider >= 0),
+    max_agent_configs_per_project bigint CHECK (max_agent_configs_per_project >= 0),
+    max_active_agent_profiles_per_project bigint CHECK (max_active_agent_profiles_per_project >= 0),
+    max_active_agents_per_project bigint CHECK (max_active_agents_per_project >= 0),
+    max_active_tenant_secrets_per_owner bigint CHECK (max_active_tenant_secrets_per_owner >= 0),
+    max_active_skills_per_owner bigint CHECK (max_active_skills_per_owner >= 0),
+    max_active_tenant_machine_pools_per_org bigint CHECK (max_active_tenant_machine_pools_per_org >= 0),
+    max_live_machines_per_org bigint CHECK (max_live_machines_per_org >= 0),
+    max_active_byo_daemon_tokens_per_machine bigint CHECK (max_active_byo_daemon_tokens_per_machine >= 0),
+    max_non_terminal_processes_per_agent bigint CHECK (max_non_terminal_processes_per_agent >= 0)
+);
+
+CREATE VIEW default_resource_limits AS
+SELECT
+    1000::bigint AS max_active_projects_per_org,
+    10000::bigint AS max_pending_org_invitations_per_org,
+    10000::bigint AS max_active_org_api_keys_per_org,
+    10000::bigint AS max_active_tenant_model_provider_configs_per_org,
+    10000::bigint AS max_active_configured_models_per_provider,
+    10000::bigint AS max_agent_configs_per_project,
+    10000::bigint AS max_active_agent_profiles_per_project,
+    10000::bigint AS max_active_agents_per_project,
+    10000::bigint AS max_active_tenant_secrets_per_owner,
+    10000::bigint AS max_active_skills_per_owner,
+    10000::bigint AS max_active_tenant_machine_pools_per_org,
+    10000::bigint AS max_live_machines_per_org,
+    20::bigint AS max_active_byo_daemon_tokens_per_machine,
+    32::bigint AS max_non_terminal_processes_per_agent;
+
+CREATE VIEW effective_resource_limits AS
+SELECT
+    orgs.id AS org_id,
+    coalesce(overrides.max_active_projects_per_org, defaults.max_active_projects_per_org) AS max_active_projects_per_org,
+    coalesce(overrides.max_pending_org_invitations_per_org, defaults.max_pending_org_invitations_per_org) AS max_pending_org_invitations_per_org,
+    coalesce(overrides.max_active_org_api_keys_per_org, defaults.max_active_org_api_keys_per_org) AS max_active_org_api_keys_per_org,
+    coalesce(overrides.max_active_tenant_model_provider_configs_per_org, defaults.max_active_tenant_model_provider_configs_per_org) AS max_active_tenant_model_provider_configs_per_org,
+    coalesce(overrides.max_active_configured_models_per_provider, defaults.max_active_configured_models_per_provider) AS max_active_configured_models_per_provider,
+    coalesce(overrides.max_agent_configs_per_project, defaults.max_agent_configs_per_project) AS max_agent_configs_per_project,
+    coalesce(overrides.max_active_agent_profiles_per_project, defaults.max_active_agent_profiles_per_project) AS max_active_agent_profiles_per_project,
+    coalesce(overrides.max_active_agents_per_project, defaults.max_active_agents_per_project) AS max_active_agents_per_project,
+    coalesce(overrides.max_active_tenant_secrets_per_owner, defaults.max_active_tenant_secrets_per_owner) AS max_active_tenant_secrets_per_owner,
+    coalesce(overrides.max_active_skills_per_owner, defaults.max_active_skills_per_owner) AS max_active_skills_per_owner,
+    coalesce(overrides.max_active_tenant_machine_pools_per_org, defaults.max_active_tenant_machine_pools_per_org) AS max_active_tenant_machine_pools_per_org,
+    coalesce(overrides.max_live_machines_per_org, defaults.max_live_machines_per_org) AS max_live_machines_per_org,
+    coalesce(overrides.max_active_byo_daemon_tokens_per_machine, defaults.max_active_byo_daemon_tokens_per_machine) AS max_active_byo_daemon_tokens_per_machine,
+    coalesce(overrides.max_non_terminal_processes_per_agent, defaults.max_non_terminal_processes_per_agent) AS max_non_terminal_processes_per_agent
+FROM orgs
+CROSS JOIN default_resource_limits AS defaults
+LEFT JOIN org_resource_limit_overrides AS overrides ON overrides.org_id = orgs.id
+WHERE orgs.deleted_at IS NULL;


### PR DESCRIPTION
- add a validated resource_limit_overrides JSONB field to organizations with optional overrides for all 14 existing org-resolved resource limits
- pair each override key with its application default and fall back to that default when an organization has no override
- resolve overrides inside the existing transactional admission paths while preserving idempotency, concurrency safety, scope boundaries, and fixed user-owned limits
- raise the reviewed default capacities to 1,000 or 10,000 where applicable while retaining the existing daemon-token and process limits

- supersede the original JSONB design with nullable, typed columns in a dedicated org_resource_limit_overrides table
- define defaults in the default_resource_limits SQL view and combine them with overrides through effective_resource_limits, so a missing row or NULL column uses the default
- map limit resolution for a deleted organization to NotFound and keep the BYO machine project-ID request cap independent from the project resource limit
