### PR TITLE
fix: preserve profile config drafts and clear deleted profile cache

### DIFF
--- a/frontend/apps/web/e2e/web.spec.ts
+++ b/frontend/apps/web/e2e/web.spec.ts
@@ -56,6 +56,27 @@ async function signIn(page: Page, email: string, returnTo: string) {
   await expect(page).toHaveURL(returnTo)
 }
 
+async function createProfile(page: Page, name: string, instruction: string) {
+  await signIn(page, adminEmail, createAgentPath)
+  await page.getByLabel('Name', { exact: true }).fill(name)
+  await page.getByLabel('Instruction').fill(instruction)
+  await page.getByRole('button', { name: 'Create profile' }).click()
+  await expect(page).toHaveURL(new RegExp(`/projects/${projectID}/agent-profiles/aprf_[a-z2-7]+$`))
+}
+
+async function typeInConfigEditor(page: Page, text: string) {
+  const editor = page.getByRole('textbox', { name: 'Config (YAML)' })
+  await expect(editor).toBeVisible()
+  await editor.focus()
+  await page.keyboard.insertText(text)
+}
+
+async function visitAgentsTabAndReturn(page: Page) {
+  await page.getByRole('button', { name: 'Agents', exact: true }).click()
+  await expect(page.getByText('No agents from this profile yet', { exact: false })).toBeVisible()
+  await page.getByRole('button', { name: 'Configuration' }).click()
+}
+
 test('returns to a protected deep link after login', async ({ page }) => {
   const failures = installFailureTracking(page)
   await signIn(page, adminEmail, `${createAgentPath}?source=e2e#yaml`)
@@ -101,15 +122,11 @@ test('creates an agent from YAML', async ({ page }) => {
   await page.getByRole('button', { name: 'YAML' }).click()
 
   await page.getByLabel('Name', { exact: true }).fill('YAML E2E Agent')
-  const editorInput = page.getByRole('textbox', { name: 'Config (YAML)' })
-  await expect(editorInput).toBeVisible()
-
-  await editorInput.focus()
   const yamlLines = [
     'instruction: Test agent creation from YAML.',
     `model: { provider_config: "${providerConfig}", name: "${modelName}" }`,
   ]
-  await page.keyboard.insertText(yamlLines.join('\n'))
+  await typeInConfigEditor(page, yamlLines.join('\n'))
   await expect(page.getByRole('button', { name: 'Create & launch agent' })).toBeEnabled()
   await page.getByRole('button', { name: 'Create & launch agent' }).click()
 
@@ -136,15 +153,11 @@ test('creates an agent with the Builder', async ({ page }) => {
 
 test('creates a profile without launching an agent', async ({ page }) => {
   const failures = installFailureTracking(page)
-  await signIn(page, adminEmail, createAgentPath)
-
-  await page.getByLabel('Name', { exact: true }).fill('Profile Only Agent')
-  await page.getByLabel('Instruction').fill('Save this config as a profile without launching.')
-
-  await expect(page.getByRole('button', { name: 'Create profile' })).toBeEnabled()
-  await page.getByRole('button', { name: 'Create profile' }).click()
-
-  await expect(page).toHaveURL(new RegExp(`/projects/${projectID}/agent-profiles/aprf_[a-z2-7]+$`))
+  await createProfile(
+    page,
+    'Profile Only Agent',
+    'Save this config as a profile without launching.',
+  )
   await expect(page.getByText('Profile Only Agent').first()).toBeVisible()
   expect(failures).toEqual([])
 })
@@ -153,22 +166,12 @@ test('keeps profile config edits across tabs and confirms launching with unsaved
   page,
 }) => {
   const failures = installFailureTracking(page, [/^page: Canceled$/])
-  await signIn(page, adminEmail, createAgentPath)
+  await createProfile(page, 'Draft Keeper Profile', 'Keep unsaved edits across tab switches.')
 
-  await page.getByLabel('Name', { exact: true }).fill('Draft Keeper Profile')
-  await page.getByLabel('Instruction').fill('Keep unsaved edits across tab switches.')
-  await page.getByRole('button', { name: 'Create profile' }).click()
-  await expect(page).toHaveURL(new RegExp(`/projects/${projectID}/agent-profiles/aprf_[a-z2-7]+$`))
-
-  const editor = page.getByRole('textbox', { name: 'Config (YAML)' })
-  await expect(editor).toBeVisible()
-  await editor.focus()
-  await page.keyboard.insertText('# draft edit\n')
+  await typeInConfigEditor(page, '# draft edit\n')
   await expect(page.getByRole('button', { name: 'Save revision' })).toBeEnabled()
 
-  await page.getByRole('button', { name: 'Agents', exact: true }).click()
-  await expect(page.getByText('No agents from this profile yet', { exact: false })).toBeVisible()
-  await page.getByRole('button', { name: 'Configuration' }).click()
+  await visitAgentsTabAndReturn(page)
   await expect(page.getByText('# draft edit')).toBeVisible()
   await expect(page.getByRole('button', { name: 'Save revision' })).toBeEnabled()
 
@@ -193,12 +196,7 @@ test('keeps profile config edits across tabs and confirms launching with unsaved
 
 test('keeps the save pending across tab switches while the revision uploads', async ({ page }) => {
   const failures = installFailureTracking(page, [/^page: Canceled$/])
-  await signIn(page, adminEmail, createAgentPath)
-
-  await page.getByLabel('Name', { exact: true }).fill('Pending Save Profile')
-  await page.getByLabel('Instruction').fill('Hold the save request while tabs switch.')
-  await page.getByRole('button', { name: 'Create profile' }).click()
-  await expect(page).toHaveURL(new RegExp(`/projects/${projectID}/agent-profiles/aprf_[a-z2-7]+$`))
+  await createProfile(page, 'Pending Save Profile', 'Hold the save request while tabs switch.')
 
   let releaseSave!: () => void
   const holdSave = new Promise<void>((resolve) => {
@@ -209,19 +207,14 @@ test('keeps the save pending across tab switches while the revision uploads', as
     await route.continue()
   })
 
-  const editor = page.getByRole('textbox', { name: 'Config (YAML)' })
-  await expect(editor).toBeVisible()
-  await editor.focus()
-  await page.keyboard.insertText('# pending save\n')
+  await typeInConfigEditor(page, '# pending save\n')
 
   const saveButton = page.getByRole('button', { name: 'Save revision' })
   await expect(saveButton).toBeEnabled()
   await saveButton.click()
   await expect(saveButton).toBeDisabled()
 
-  await page.getByRole('button', { name: 'Agents', exact: true }).click()
-  await expect(page.getByText('No agents from this profile yet', { exact: false })).toBeVisible()
-  await page.getByRole('button', { name: 'Configuration' }).click()
+  await visitAgentsTabAndReturn(page)
 
   await expect(page.getByText('# pending save')).toBeVisible()
   await expect(saveButton).toBeDisabled()
@@ -237,7 +230,6 @@ test('keeps the save pending across tab switches while the revision uploads', as
 
   await expect(saveButton).toBeDisabled()
   await expect(page.getByRole('button', { name: 'Discard changes' })).toHaveCount(0)
-  await expect(page.getByText('# pending save')).toBeVisible()
   expect(failures).toEqual([])
 })
 
@@ -246,12 +238,7 @@ test('deletes a profile from its detail page', async ({ page }) => {
     /agent-profiles\/aprf_[a-z2-7]+ \(net::ERR_ABORTED\)$/,
     /^response: 404 .*\/agent-profiles\/aprf_[a-z2-7]+$/,
   ])
-  await signIn(page, adminEmail, createAgentPath)
-
-  await page.getByLabel('Name', { exact: true }).fill('Deleted Profile E2E')
-  await page.getByLabel('Instruction').fill('Delete this profile from its detail page.')
-  await page.getByRole('button', { name: 'Create profile' }).click()
-  await expect(page).toHaveURL(new RegExp(`/projects/${projectID}/agent-profiles/aprf_[a-z2-7]+$`))
+  await createProfile(page, 'Deleted Profile E2E', 'Delete this profile from its detail page.')
 
   page.once('dialog', (dialog) => void dialog.accept())
   await page.getByRole('button', { name: 'Row actions' }).click()

--- a/frontend/apps/web/e2e/web.spec.ts
+++ b/frontend/apps/web/e2e/web.spec.ts
@@ -227,7 +227,14 @@ test('keeps the save pending across tab switches while the revision uploads', as
   await expect(saveButton).toBeDisabled()
   await expect(page.getByRole('button', { name: 'Discard changes' })).toHaveCount(0)
 
+  const saveResponse = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST' &&
+      /\/agent-profiles\/aprf_[a-z2-7]+\/config$/.test(new URL(response.url()).pathname),
+  )
   releaseSave()
+  expect((await saveResponse).ok()).toBe(true)
+
   await expect(saveButton).toBeDisabled()
   await expect(page.getByRole('button', { name: 'Discard changes' })).toHaveCount(0)
   await expect(page.getByText('# pending save')).toBeVisible()
@@ -237,6 +244,7 @@ test('keeps the save pending across tab switches while the revision uploads', as
 test('deletes a profile from its detail page', async ({ page }) => {
   const failures = installFailureTracking(page, [
     /agent-profiles\/aprf_[a-z2-7]+ \(net::ERR_ABORTED\)$/,
+    /^response: 404 .*\/agent-profiles\/aprf_[a-z2-7]+$/,
   ])
   await signIn(page, adminEmail, createAgentPath)
 
@@ -251,6 +259,11 @@ test('deletes a profile from its detail page', async ({ page }) => {
 
   await expect(page).toHaveURL(`/projects/${projectID}/agents`)
   await expect(page.getByRole('heading', { name: 'Agent profiles' })).toBeVisible()
+  await expect(page.getByText('Deleted Profile E2E')).toHaveCount(0)
+
+  await page.goBack()
+  await expect(page.getByRole('heading', { name: 'Something went wrong' })).toBeVisible()
+  await expect(page.getByText(/^404: /)).toBeVisible()
   await expect(page.getByText('Deleted Profile E2E')).toHaveCount(0)
   expect(failures).toEqual([])
 })

--- a/frontend/apps/web/e2e/web.spec.ts
+++ b/frontend/apps/web/e2e/web.spec.ts
@@ -21,10 +21,12 @@ function installFailureTracking(page: Page) {
   const failures: string[] = []
 
   page.on('pageerror', (error) => {
+    if (error.message === 'Canceled') return
     failures.push(`page: ${error.message}`)
   })
   page.on('requestfailed', (request) => {
     if (request.method() === 'POST' && new URL(request.url()).pathname === '/api/auth/login') return
+    if (request.failure()?.errorText === 'net::ERR_ABORTED') return
     failures.push(`request: ${request.url()} (${request.failure()?.errorText ?? 'failed'})`)
   })
   page.on('response', (response) => {
@@ -143,6 +145,67 @@ test('creates a profile without launching an agent', async ({ page }) => {
 
   await expect(page).toHaveURL(new RegExp(`/projects/${projectID}/agent-profiles/aprf_[a-z2-7]+$`))
   await expect(page.getByText('Profile Only Agent').first()).toBeVisible()
+  expect(failures).toEqual([])
+})
+
+test('keeps profile config edits across tabs and confirms launching with unsaved edits', async ({
+  page,
+}) => {
+  const failures = installFailureTracking(page)
+  await signIn(page, adminEmail, createAgentPath)
+
+  await page.getByLabel('Name', { exact: true }).fill('Draft Keeper Profile')
+  await page.getByLabel('Instruction').fill('Keep unsaved edits across tab switches.')
+  await page.getByRole('button', { name: 'Create profile' }).click()
+  await expect(page).toHaveURL(new RegExp(`/projects/${projectID}/agent-profiles/aprf_[a-z2-7]+$`))
+
+  const editor = page.getByRole('textbox', { name: 'Config (YAML)' })
+  await expect(editor).toBeVisible()
+  await editor.focus()
+  await page.keyboard.insertText('# draft edit\n')
+  await expect(page.getByRole('button', { name: 'Save revision' })).toBeEnabled()
+
+  await page.getByRole('button', { name: 'Agents', exact: true }).click()
+  await expect(page.getByText('No agents from this profile yet', { exact: false })).toBeVisible()
+  await page.getByRole('button', { name: 'Configuration' }).click()
+  await expect(page.getByText('# draft edit')).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Save revision' })).toBeEnabled()
+
+  const confirms: string[] = []
+  page.once('dialog', (dialog) => {
+    confirms.push(dialog.message())
+    void dialog.dismiss()
+  })
+  await page.getByRole('button', { name: 'Launch' }).click()
+  await expect.poll(() => confirms.length).toBe(1)
+  expect(confirms[0]).toContain('unsaved configuration changes')
+  await expect(page).toHaveURL(new RegExp(`/projects/${projectID}/agent-profiles/aprf_[a-z2-7]+$`))
+
+  await page.getByRole('button', { name: 'Discard changes' }).click()
+  await expect(page.getByText('# draft edit')).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'Save revision' })).toBeDisabled()
+
+  await page.getByRole('button', { name: 'Launch' }).click()
+  await expect(page).toHaveURL(new RegExp(`/projects/${projectID}/agents/agt_[a-z2-7]+$`))
+  expect(failures).toEqual([])
+})
+
+test('deletes a profile from its detail page', async ({ page }) => {
+  const failures = installFailureTracking(page)
+  await signIn(page, adminEmail, createAgentPath)
+
+  await page.getByLabel('Name', { exact: true }).fill('Deleted Profile E2E')
+  await page.getByLabel('Instruction').fill('Delete this profile from its detail page.')
+  await page.getByRole('button', { name: 'Create profile' }).click()
+  await expect(page).toHaveURL(new RegExp(`/projects/${projectID}/agent-profiles/aprf_[a-z2-7]+$`))
+
+  page.once('dialog', (dialog) => void dialog.accept())
+  await page.getByRole('button', { name: 'Row actions' }).click()
+  await page.getByRole('menuitem', { name: 'Delete' }).click()
+
+  await expect(page).toHaveURL(`/projects/${projectID}/agents`)
+  await expect(page.getByRole('heading', { name: 'Agent profiles' })).toBeVisible()
+  await expect(page.getByText('Deleted Profile E2E')).toHaveCount(0)
   expect(failures).toEqual([])
 })
 

--- a/frontend/apps/web/e2e/web.spec.ts
+++ b/frontend/apps/web/e2e/web.spec.ts
@@ -17,23 +17,24 @@ const providerConfig = requiredEnvironmentVariable('OMNARA_WEB_E2E_PROVIDER_CONF
 const modelName = requiredEnvironmentVariable('OMNARA_WEB_E2E_MODEL_NAME')
 const createAgentPath = `/projects/${projectID}/agents/new`
 
-function installFailureTracking(page: Page) {
+function installFailureTracking(page: Page, ignore: RegExp[] = []) {
   const failures: string[] = []
+  const record = (failure: string) => {
+    if (!ignore.some((pattern) => pattern.test(failure))) failures.push(failure)
+  }
 
   page.on('pageerror', (error) => {
-    if (error.message === 'Canceled') return
-    failures.push(`page: ${error.message}`)
+    record(`page: ${error.message}`)
   })
   page.on('requestfailed', (request) => {
     if (request.method() === 'POST' && new URL(request.url()).pathname === '/api/auth/login') return
-    if (request.failure()?.errorText === 'net::ERR_ABORTED') return
-    failures.push(`request: ${request.url()} (${request.failure()?.errorText ?? 'failed'})`)
+    record(`request: ${request.url()} (${request.failure()?.errorText ?? 'failed'})`)
   })
   page.on('response', (response) => {
     const url = new URL(response.url())
     if (response.status() === 401 && url.pathname === '/api/v1/me') return
     if (response.status() >= 400) {
-      failures.push(`response: ${response.status()} ${url.pathname}`)
+      record(`response: ${response.status()} ${url.pathname}`)
     }
   })
 
@@ -151,7 +152,7 @@ test('creates a profile without launching an agent', async ({ page }) => {
 test('keeps profile config edits across tabs and confirms launching with unsaved edits', async ({
   page,
 }) => {
-  const failures = installFailureTracking(page)
+  const failures = installFailureTracking(page, [/^page: Canceled$/])
   await signIn(page, adminEmail, createAgentPath)
 
   await page.getByLabel('Name', { exact: true }).fill('Draft Keeper Profile')
@@ -190,8 +191,53 @@ test('keeps profile config edits across tabs and confirms launching with unsaved
   expect(failures).toEqual([])
 })
 
+test('keeps the save pending across tab switches while the revision uploads', async ({ page }) => {
+  const failures = installFailureTracking(page, [/^page: Canceled$/])
+  await signIn(page, adminEmail, createAgentPath)
+
+  await page.getByLabel('Name', { exact: true }).fill('Pending Save Profile')
+  await page.getByLabel('Instruction').fill('Hold the save request while tabs switch.')
+  await page.getByRole('button', { name: 'Create profile' }).click()
+  await expect(page).toHaveURL(new RegExp(`/projects/${projectID}/agent-profiles/aprf_[a-z2-7]+$`))
+
+  let releaseSave!: () => void
+  const holdSave = new Promise<void>((resolve) => {
+    releaseSave = resolve
+  })
+  await page.route('**/agent-profiles/aprf_*/config', async (route) => {
+    await holdSave
+    await route.continue()
+  })
+
+  const editor = page.getByRole('textbox', { name: 'Config (YAML)' })
+  await expect(editor).toBeVisible()
+  await editor.focus()
+  await page.keyboard.insertText('# pending save\n')
+
+  const saveButton = page.getByRole('button', { name: 'Save revision' })
+  await expect(saveButton).toBeEnabled()
+  await saveButton.click()
+  await expect(saveButton).toBeDisabled()
+
+  await page.getByRole('button', { name: 'Agents', exact: true }).click()
+  await expect(page.getByText('No agents from this profile yet', { exact: false })).toBeVisible()
+  await page.getByRole('button', { name: 'Configuration' }).click()
+
+  await expect(page.getByText('# pending save')).toBeVisible()
+  await expect(saveButton).toBeDisabled()
+  await expect(page.getByRole('button', { name: 'Discard changes' })).toHaveCount(0)
+
+  releaseSave()
+  await expect(saveButton).toBeDisabled()
+  await expect(page.getByRole('button', { name: 'Discard changes' })).toHaveCount(0)
+  await expect(page.getByText('# pending save')).toBeVisible()
+  expect(failures).toEqual([])
+})
+
 test('deletes a profile from its detail page', async ({ page }) => {
-  const failures = installFailureTracking(page)
+  const failures = installFailureTracking(page, [
+    /agent-profiles\/aprf_[a-z2-7]+ \(net::ERR_ABORTED\)$/,
+  ])
   await signIn(page, adminEmail, createAgentPath)
 
   await page.getByLabel('Name', { exact: true }).fill('Deleted Profile E2E')

--- a/frontend/apps/web/src/routes/AgentProfileView.tsx
+++ b/frontend/apps/web/src/routes/AgentProfileView.tsx
@@ -8,7 +8,7 @@ import {
 } from '@omnara/react'
 import { type AgentProfile, ApiError } from '@omnara/sdk'
 import { useNavigate, useParams } from '@tanstack/react-router'
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 
 import { AgentConfigYamlField } from '@/components/agents/AgentConfigYamlField'
 import { AgentProfileIntegrations } from '@/components/agents/AgentProfileIntegrations'
@@ -85,13 +85,6 @@ export function AgentProfileView() {
     }
   }
 
-  const deletedRef = useRef(false)
-  useEffect(() => {
-    return () => {
-      if (deletedRef.current) removeProfileQuery(profileId)
-    }
-  }, [profileId, removeProfileQuery])
-
   async function launch() {
     if (
       configDirty &&
@@ -119,8 +112,9 @@ export function AgentProfileView() {
     if (!window.confirm(`Delete agent profile ${profile.name}?`)) return
     deleteProfile.mutate(profile.id, {
       onSuccess: () => {
-        deletedRef.current = true
-        void navigate({ to: '/projects/$projectId/agents', params: { projectId } })
+        void navigate({ to: '/projects/$projectId/agents', params: { projectId } }).then(() => {
+          removeProfileQuery(profile.id)
+        })
       },
       onError: (error) => {
         window.alert(error instanceof ApiError ? error.message : 'Could not delete agent profile')

--- a/frontend/apps/web/src/routes/AgentProfileView.tsx
+++ b/frontend/apps/web/src/routes/AgentProfileView.tsx
@@ -27,9 +27,6 @@ import { useProjectPage } from '@/lib/use-project-page'
 
 type ProfileTab = 'configuration' | 'agents'
 
-// The YAML draft lives here (not in ConfigurationTab) so it survives tab
-// switches. It is keyed to the profile and revision it was edited against,
-// and discarded once either changes.
 interface ConfigDraft {
   profileId: string
   configId: string

--- a/frontend/apps/web/src/routes/AgentProfileView.tsx
+++ b/frontend/apps/web/src/routes/AgentProfileView.tsx
@@ -81,6 +81,7 @@ function ProfileView({ profile, projectId }: { profile: AgentProfile; projectId:
         config: config.id,
         expected_current_config_id: profile.current_config_id,
       })
+      setDraft(null)
     } catch (err) {
       setSaveError(err instanceof ApiError ? err.message : 'Could not update agent profile')
     }

--- a/frontend/apps/web/src/routes/AgentProfileView.tsx
+++ b/frontend/apps/web/src/routes/AgentProfileView.tsx
@@ -8,7 +8,7 @@ import {
 } from '@omnara/react'
 import { type AgentProfile, ApiError } from '@omnara/sdk'
 import { useNavigate, useParams } from '@tanstack/react-router'
-import { type SyntheticEvent, useState } from 'react'
+import { type SyntheticEvent, useEffect, useRef, useState } from 'react'
 
 import { AgentConfigYamlField } from '@/components/agents/AgentConfigYamlField'
 import { AgentProfileIntegrations } from '@/components/agents/AgentProfileIntegrations'
@@ -59,6 +59,13 @@ export function AgentProfileView() {
   const removeProfileQuery = useRemoveAgentProfileQuery(activeOrg.id, projectId)
   const navigate = useNavigate()
 
+  const deletedRef = useRef(false)
+  useEffect(() => {
+    return () => {
+      if (deletedRef.current) removeProfileQuery(profileId)
+    }
+  }, [profileId, removeProfileQuery])
+
   async function launch() {
     if (
       configDirty &&
@@ -86,9 +93,8 @@ export function AgentProfileView() {
     if (!window.confirm(`Delete agent profile ${profile.name}?`)) return
     deleteProfile.mutate(profile.id, {
       onSuccess: () => {
-        void navigate({ to: '/projects/$projectId/agents', params: { projectId } }).then(() => {
-          removeProfileQuery(profile.id)
-        })
+        deletedRef.current = true
+        void navigate({ to: '/projects/$projectId/agents', params: { projectId } })
       },
       onError: (error) => {
         window.alert(error instanceof ApiError ? error.message : 'Could not delete agent profile')
@@ -209,7 +215,13 @@ function ConfigurationTab({
   const createConfig = useCreateAgentConfig(orgId, projectId)
   const updateProfile = useUpdateAgentProfile(orgId, projectId)
   const [error, setError] = useState('')
+  const [errorRevision, setErrorRevision] = useState(profile.current_config_id)
   const pending = createConfig.isPending || updateProfile.isPending
+
+  if (errorRevision !== profile.current_config_id) {
+    setErrorRevision(profile.current_config_id)
+    setError('')
+  }
 
   async function submit(event: SyntheticEvent<HTMLFormElement>) {
     event.preventDefault()

--- a/frontend/apps/web/src/routes/AgentProfileView.tsx
+++ b/frontend/apps/web/src/routes/AgentProfileView.tsx
@@ -3,6 +3,7 @@ import {
   useCreateAgent,
   useCreateAgentConfig,
   useDeleteAgentProfile,
+  useRemoveAgentProfileQuery,
   useUpdateAgentProfile,
 } from '@omnara/react'
 import { type AgentProfile, ApiError } from '@omnara/sdk'
@@ -55,6 +56,7 @@ export function AgentProfileView() {
 
   const createAgent = useCreateAgent(activeOrg.id, projectId)
   const deleteProfile = useDeleteAgentProfile(activeOrg.id, projectId)
+  const removeProfileQuery = useRemoveAgentProfileQuery(activeOrg.id, projectId)
   const navigate = useNavigate()
 
   async function launch() {
@@ -84,7 +86,9 @@ export function AgentProfileView() {
     if (!window.confirm(`Delete agent profile ${profile.name}?`)) return
     deleteProfile.mutate(profile.id, {
       onSuccess: () => {
-        void navigate({ to: '/projects/$projectId/agents', params: { projectId } })
+        void navigate({ to: '/projects/$projectId/agents', params: { projectId } }).then(() => {
+          removeProfileQuery(profile.id)
+        })
       },
       onError: (error) => {
         window.alert(error instanceof ApiError ? error.message : 'Could not delete agent profile')

--- a/frontend/apps/web/src/routes/AgentProfileView.tsx
+++ b/frontend/apps/web/src/routes/AgentProfileView.tsx
@@ -27,6 +27,15 @@ import { useProjectPage } from '@/lib/use-project-page'
 
 type ProfileTab = 'configuration' | 'agents'
 
+// The YAML draft lives here (not in ConfigurationTab) so it survives tab
+// switches. It is keyed to the profile and revision it was edited against,
+// and discarded once either changes.
+interface ConfigDraft {
+  profileId: string
+  configId: string
+  yaml: string
+}
+
 export function AgentProfileView() {
   const { activeOrg } = useActiveOrg()
   const { project } = useProjectPage()
@@ -39,12 +48,27 @@ export function AgentProfileView() {
 
   const [tab, setTab] = useState<ProfileTab>('configuration')
   const [deployOpen, setDeployOpen] = useState(false)
+  const [draft, setDraft] = useState<ConfigDraft | null>(null)
+
+  const savedYaml = profile.current_config.source ?? ''
+  const activeDraft =
+    draft?.profileId === profile.id && draft.configId === profile.current_config_id ? draft : null
+  const yaml = activeDraft?.yaml ?? savedYaml
+  const configDirty = yaml !== savedYaml
 
   const createAgent = useCreateAgent(activeOrg.id, projectId)
   const deleteProfile = useDeleteAgentProfile(activeOrg.id, projectId)
   const navigate = useNavigate()
 
   async function launch() {
+    if (
+      configDirty &&
+      !window.confirm(
+        'You have unsaved configuration changes. Launch uses the last saved revision. Continue?',
+      )
+    ) {
+      return
+    }
     try {
       const launched = await createAgent.mutateAsync({
         profile: profile.id,
@@ -129,6 +153,14 @@ export function AgentProfileView() {
           projectId={projectId}
           profile={profile}
           canManage={canManage}
+          yaml={yaml}
+          dirty={configDirty}
+          onYamlChange={(value) => {
+            setDraft({ profileId: profile.id, configId: profile.current_config_id, yaml: value })
+          }}
+          onDiscard={() => {
+            setDraft(null)
+          }}
         />
       ) : (
         <AgentsTable
@@ -159,27 +191,24 @@ function ConfigurationTab({
   projectId,
   profile,
   canManage,
+  yaml,
+  dirty,
+  onYamlChange,
+  onDiscard,
 }: {
   orgId: string
   projectId: string
   profile: AgentProfile
   canManage: boolean
+  yaml: string
+  dirty: boolean
+  onYamlChange: (value: string) => void
+  onDiscard: () => void
 }) {
   const createConfig = useCreateAgentConfig(orgId, projectId)
   const updateProfile = useUpdateAgentProfile(orgId, projectId)
-  const [yaml, setYaml] = useState(profile.current_config.source ?? '')
   const [error, setError] = useState('')
-  const [editedConfigId, setEditedConfigId] = useState(profile.current_config_id)
   const pending = createConfig.isPending || updateProfile.isPending
-
-  // Reset the editor when a new revision lands (after a save or elsewhere).
-  if (editedConfigId !== profile.current_config_id) {
-    setEditedConfigId(profile.current_config_id)
-    setYaml(profile.current_config.source ?? '')
-    setError('')
-  }
-
-  const dirty = yaml !== (profile.current_config.source ?? '')
 
   async function submit(event: SyntheticEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -218,7 +247,7 @@ function ConfigurationTab({
           <AgentConfigYamlField
             id="agent-profile-config-yaml"
             value={yaml}
-            onChange={setYaml}
+            onChange={onYamlChange}
             readOnly={!canManage}
             className="h-[28rem]"
           />
@@ -239,7 +268,7 @@ function ConfigurationTab({
                   type="button"
                   variant="ghost"
                   onClick={() => {
-                    setYaml(profile.current_config.source ?? '')
+                    onDiscard()
                     setError('')
                   }}
                 >

--- a/frontend/apps/web/src/routes/AgentProfileView.tsx
+++ b/frontend/apps/web/src/routes/AgentProfileView.tsx
@@ -3,7 +3,6 @@ import {
   useCreateAgent,
   useCreateAgentConfig,
   useDeleteAgentProfile,
-  useRemoveAgentProfileQuery,
   useUpdateAgentProfile,
 } from '@omnara/react'
 import { type AgentProfile, ApiError } from '@omnara/sdk'
@@ -29,18 +28,23 @@ import { useProjectPage } from '@/lib/use-project-page'
 type ProfileTab = 'configuration' | 'agents'
 
 interface ConfigDraft {
-  profileId: string
   configId: string
   yaml: string
 }
 
 export function AgentProfileView() {
   const { activeOrg } = useActiveOrg()
-  const { project } = useProjectPage()
   const params = useParams({ strict: false })
   const projectId = params.projectId ?? ''
   const profileId = params.profileId ?? ''
   const { data: profile } = useAgentProfile(activeOrg.id, projectId, profileId)
+
+  return <ProfileView key={profile.id} profile={profile} projectId={projectId} />
+}
+
+function ProfileView({ profile, projectId }: { profile: AgentProfile; projectId: string }) {
+  const { activeOrg } = useActiveOrg()
+  const { project } = useProjectPage()
   const canOperate = project?.access.can_operate ?? false
   const canManage = project?.access.can_manage ?? false
 
@@ -49,8 +53,7 @@ export function AgentProfileView() {
   const [draft, setDraft] = useState<ConfigDraft | null>(null)
 
   const savedYaml = profile.current_config.source ?? ''
-  const activeDraft =
-    draft?.profileId === profile.id && draft.configId === profile.current_config_id ? draft : null
+  const activeDraft = draft?.configId === profile.current_config_id ? draft : null
   const yaml = activeDraft?.yaml ?? savedYaml
   const configDirty = yaml !== savedYaml
 
@@ -58,16 +61,14 @@ export function AgentProfileView() {
   const createConfig = useCreateAgentConfig(activeOrg.id, projectId)
   const updateProfile = useUpdateAgentProfile(activeOrg.id, projectId)
   const deleteProfile = useDeleteAgentProfile(activeOrg.id, projectId)
-  const removeProfileQuery = useRemoveAgentProfileQuery(activeOrg.id, projectId)
   const navigate = useNavigate()
 
-  const revisionKey = `${profile.id}:${profile.current_config_id}`
   const [saveError, setSaveError] = useState('')
-  const [saveErrorRevision, setSaveErrorRevision] = useState(revisionKey)
+  const [saveErrorConfigId, setSaveErrorConfigId] = useState(profile.current_config_id)
   const savePending = createConfig.isPending || updateProfile.isPending
 
-  if (saveErrorRevision !== revisionKey) {
-    setSaveErrorRevision(revisionKey)
+  if (saveErrorConfigId !== profile.current_config_id) {
+    setSaveErrorConfigId(profile.current_config_id)
     setSaveError('')
   }
 
@@ -112,9 +113,7 @@ export function AgentProfileView() {
     if (!window.confirm(`Delete agent profile ${profile.name}?`)) return
     deleteProfile.mutate(profile.id, {
       onSuccess: () => {
-        void navigate({ to: '/projects/$projectId/agents', params: { projectId } }).then(() => {
-          removeProfileQuery(profile.id)
-        })
+        void navigate({ to: '/projects/$projectId/agents', params: { projectId } })
       },
       onError: (error) => {
         window.alert(error instanceof ApiError ? error.message : 'Could not delete agent profile')
@@ -184,7 +183,7 @@ export function AgentProfileView() {
           error={saveError}
           pending={savePending}
           onYamlChange={(value) => {
-            setDraft({ profileId: profile.id, configId: profile.current_config_id, yaml: value })
+            setDraft({ configId: profile.current_config_id, yaml: value })
           }}
           onDiscard={() => {
             setDraft(null)

--- a/frontend/apps/web/src/routes/AgentProfileView.tsx
+++ b/frontend/apps/web/src/routes/AgentProfileView.tsx
@@ -8,7 +8,7 @@ import {
 } from '@omnara/react'
 import { type AgentProfile, ApiError } from '@omnara/sdk'
 import { useNavigate, useParams } from '@tanstack/react-router'
-import { type SyntheticEvent, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { AgentConfigYamlField } from '@/components/agents/AgentConfigYamlField'
 import { AgentProfileIntegrations } from '@/components/agents/AgentProfileIntegrations'
@@ -55,9 +55,35 @@ export function AgentProfileView() {
   const configDirty = yaml !== savedYaml
 
   const createAgent = useCreateAgent(activeOrg.id, projectId)
+  const createConfig = useCreateAgentConfig(activeOrg.id, projectId)
+  const updateProfile = useUpdateAgentProfile(activeOrg.id, projectId)
   const deleteProfile = useDeleteAgentProfile(activeOrg.id, projectId)
   const removeProfileQuery = useRemoveAgentProfileQuery(activeOrg.id, projectId)
   const navigate = useNavigate()
+
+  const revisionKey = `${profile.id}:${profile.current_config_id}`
+  const [saveError, setSaveError] = useState('')
+  const [saveErrorRevision, setSaveErrorRevision] = useState(revisionKey)
+  const savePending = createConfig.isPending || updateProfile.isPending
+
+  if (saveErrorRevision !== revisionKey) {
+    setSaveErrorRevision(revisionKey)
+    setSaveError('')
+  }
+
+  async function saveRevision() {
+    setSaveError('')
+    try {
+      const config = await createConfig.mutateAsync({ source: yaml, source_format: 'yaml' })
+      await updateProfile.mutateAsync({
+        agentProfileID: profile.id,
+        config: config.id,
+        expected_current_config_id: profile.current_config_id,
+      })
+    } catch (err) {
+      setSaveError(err instanceof ApiError ? err.message : 'Could not update agent profile')
+    }
+  }
 
   const deletedRef = useRef(false)
   useEffect(() => {
@@ -155,18 +181,23 @@ export function AgentProfileView() {
 
       {tab === 'configuration' ? (
         <ConfigurationTab
-          key={profile.id}
           orgId={activeOrg.id}
           projectId={projectId}
           profile={profile}
           canManage={canManage}
           yaml={yaml}
           dirty={configDirty}
+          error={saveError}
+          pending={savePending}
           onYamlChange={(value) => {
             setDraft({ profileId: profile.id, configId: profile.current_config_id, yaml: value })
           }}
           onDiscard={() => {
             setDraft(null)
+            setSaveError('')
+          }}
+          onSave={() => {
+            void saveRevision()
           }}
         />
       ) : (
@@ -200,8 +231,11 @@ function ConfigurationTab({
   canManage,
   yaml,
   dirty,
+  error,
+  pending,
   onYamlChange,
   onDiscard,
+  onSave,
 }: {
   orgId: string
   projectId: string
@@ -209,35 +243,12 @@ function ConfigurationTab({
   canManage: boolean
   yaml: string
   dirty: boolean
+  error: string
+  pending: boolean
   onYamlChange: (value: string) => void
   onDiscard: () => void
+  onSave: () => void
 }) {
-  const createConfig = useCreateAgentConfig(orgId, projectId)
-  const updateProfile = useUpdateAgentProfile(orgId, projectId)
-  const [error, setError] = useState('')
-  const [errorRevision, setErrorRevision] = useState(profile.current_config_id)
-  const pending = createConfig.isPending || updateProfile.isPending
-
-  if (errorRevision !== profile.current_config_id) {
-    setErrorRevision(profile.current_config_id)
-    setError('')
-  }
-
-  async function submit(event: SyntheticEvent<HTMLFormElement>) {
-    event.preventDefault()
-    setError('')
-    try {
-      const config = await createConfig.mutateAsync({ source: yaml, source_format: 'yaml' })
-      await updateProfile.mutateAsync({
-        agentProfileID: profile.id,
-        config: config.id,
-        expected_current_config_id: profile.current_config_id,
-      })
-    } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Could not update agent profile')
-    }
-  }
-
   return (
     <div className="flex flex-col gap-6">
       <DetailList
@@ -253,7 +264,8 @@ function ConfigurationTab({
       />
       <form
         onSubmit={(event) => {
-          void submit(event)
+          event.preventDefault()
+          onSave()
         }}
       >
         <FieldGroup>
@@ -277,14 +289,7 @@ function ConfigurationTab({
                 Save revision
               </Button>
               {dirty && !pending && (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  onClick={() => {
-                    onDiscard()
-                    setError('')
-                  }}
-                >
+                <Button type="button" variant="ghost" onClick={onDiscard}>
                   Discard changes
                 </Button>
               )}

--- a/frontend/packages/react/src/domains/agent-profiles.ts
+++ b/frontend/packages/react/src/domains/agent-profiles.ts
@@ -11,6 +11,7 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from '@tanstack/react-query'
+import { useCallback } from 'react'
 
 import { useOmnaraClient } from '../omnara-client'
 import {
@@ -131,9 +132,12 @@ export function useDeleteAgentProfile(orgID: string, projectID: string) {
 export function useRemoveAgentProfileQuery(orgID: string, projectID: string) {
   const client = useOmnaraClient()
   const queryClient = useQueryClient()
-  return (agentProfileID: string) => {
-    queryClient.removeQueries({
-      queryKey: getAgentProfileQueryKey({ path: { orgID, projectID, agentProfileID }, client }),
-    })
-  }
+  return useCallback(
+    (agentProfileID: string) => {
+      queryClient.removeQueries({
+        queryKey: getAgentProfileQueryKey({ path: { orgID, projectID, agentProfileID }, client }),
+      })
+    },
+    [client, queryClient, orgID, projectID],
+  )
 }

--- a/frontend/packages/react/src/domains/agent-profiles.ts
+++ b/frontend/packages/react/src/domains/agent-profiles.ts
@@ -119,10 +119,21 @@ export function useDeleteAgentProfile(orgID: string, projectID: string) {
           path: { orgID, projectID, agentProfileID },
           client,
         }),
+        type: 'inactive',
       })
       await queryClient.invalidateQueries({
         queryKey: listAgentProfilesQueryKey({ path: { orgID, projectID }, client }),
       })
     },
   })
+}
+
+export function useRemoveAgentProfileQuery(orgID: string, projectID: string) {
+  const client = useOmnaraClient()
+  const queryClient = useQueryClient()
+  return (agentProfileID: string) => {
+    queryClient.removeQueries({
+      queryKey: getAgentProfileQueryKey({ path: { orgID, projectID, agentProfileID }, client }),
+    })
+  }
 }

--- a/frontend/packages/react/src/domains/agent-profiles.ts
+++ b/frontend/packages/react/src/domains/agent-profiles.ts
@@ -11,7 +11,6 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from '@tanstack/react-query'
-import { useCallback } from 'react'
 
 import { useOmnaraClient } from '../omnara-client'
 import {
@@ -132,12 +131,9 @@ export function useDeleteAgentProfile(orgID: string, projectID: string) {
 export function useRemoveAgentProfileQuery(orgID: string, projectID: string) {
   const client = useOmnaraClient()
   const queryClient = useQueryClient()
-  return useCallback(
-    (agentProfileID: string) => {
-      queryClient.removeQueries({
-        queryKey: getAgentProfileQueryKey({ path: { orgID, projectID, agentProfileID }, client }),
-      })
-    },
-    [client, queryClient, orgID, projectID],
-  )
+  return (agentProfileID: string) => {
+    queryClient.removeQueries({
+      queryKey: getAgentProfileQueryKey({ path: { orgID, projectID, agentProfileID }, client }),
+    })
+  }
 }

--- a/frontend/packages/react/src/domains/agent-profiles.ts
+++ b/frontend/packages/react/src/domains/agent-profiles.ts
@@ -113,7 +113,13 @@ export function useDeleteAgentProfile(orgID: string, projectID: string) {
       })
       return data
     },
-    onSuccess: async () => {
+    onSuccess: async (_data, agentProfileID) => {
+      queryClient.removeQueries({
+        queryKey: getAgentProfileQueryKey({
+          path: { orgID, projectID, agentProfileID },
+          client,
+        }),
+      })
       await queryClient.invalidateQueries({
         queryKey: listAgentProfilesQueryKey({ path: { orgID, projectID }, client }),
       })

--- a/frontend/packages/react/src/domains/agent-profiles.ts
+++ b/frontend/packages/react/src/domains/agent-profiles.ts
@@ -6,6 +6,8 @@ import {
   listAgentProfilesQueryKey,
 } from '@omnara/sdk/tanstack'
 import {
+  type QueryClient,
+  type QueryKey,
   useInfiniteQuery,
   useMutation,
   useQueryClient,
@@ -114,13 +116,10 @@ export function useDeleteAgentProfile(orgID: string, projectID: string) {
       return data
     },
     onSuccess: async (_data, agentProfileID) => {
-      queryClient.removeQueries({
-        queryKey: getAgentProfileQueryKey({
-          path: { orgID, projectID, agentProfileID },
-          client,
-        }),
-        type: 'inactive',
-      })
+      removeQueryWhenInactive(
+        queryClient,
+        getAgentProfileQueryKey({ path: { orgID, projectID, agentProfileID }, client }),
+      )
       await queryClient.invalidateQueries({
         queryKey: listAgentProfilesQueryKey({ path: { orgID, projectID }, client }),
       })
@@ -128,12 +127,23 @@ export function useDeleteAgentProfile(orgID: string, projectID: string) {
   })
 }
 
-export function useRemoveAgentProfileQuery(orgID: string, projectID: string) {
-  const client = useOmnaraClient()
-  const queryClient = useQueryClient()
-  return (agentProfileID: string) => {
-    queryClient.removeQueries({
-      queryKey: getAgentProfileQueryKey({ path: { orgID, projectID, agentProfileID }, client }),
-    })
+function removeQueryWhenInactive(queryClient: QueryClient, queryKey: QueryKey) {
+  const cache = queryClient.getQueryCache()
+  const query = cache.find({ queryKey, exact: true })
+  if (!query) return
+  if (query.getObserversCount() === 0) {
+    cache.remove(query)
+    return
   }
+  const unsubscribe = cache.subscribe((event) => {
+    if (event.query !== query) return
+    if (event.type === 'removed') {
+      unsubscribe()
+      return
+    }
+    if (event.type === 'observerRemoved' && query.getObserversCount() === 0) {
+      unsubscribe()
+      cache.remove(query)
+    }
+  })
 }

--- a/frontend/packages/react/src/index.ts
+++ b/frontend/packages/react/src/index.ts
@@ -26,6 +26,7 @@ export {
   useCreateAgentProfile,
   useCreateSlackSetup,
   useDeleteAgentProfile,
+  useRemoveAgentProfileQuery,
   useUpdateAgentProfile,
 } from './domains/agent-profiles'
 export {

--- a/frontend/packages/react/src/index.ts
+++ b/frontend/packages/react/src/index.ts
@@ -26,7 +26,6 @@ export {
   useCreateAgentProfile,
   useCreateSlackSetup,
   useDeleteAgentProfile,
-  useRemoveAgentProfileQuery,
   useUpdateAgentProfile,
 } from './domains/agent-profiles'
 export {


### PR DESCRIPTION
## Summary

Addresses the three Bugbot findings left on #332 after merge:

- **Tab switch drops unsaved edits**: the YAML draft now lives in `AgentProfileView` (keyed to the profile and config revision it was edited against), so switching between the Configuration and Agents tabs no longer discards in-progress edits. The draft is automatically dropped when a new revision lands or when navigating to a different profile — including profiles that share a deduplicated config.
- **Launch ignores unsaved config edits**: with the draft lifted, the header Launch button now detects pending edits and asks for confirmation before launching from the last saved revision.
- **Delete skips profile cache invalidation**: `useDeleteAgentProfile` now removes the profile detail query from the cache (in addition to invalidating the list), so navigating back to a deleted profile can't briefly serve stale data.

## Test plan

- [x] Frontend typecheck, lint, prettier
- [x] SDK + react package unit tests (47 passed)
- [x] Playwright e2e suite (7/7 passed)
- [ ] Manual: edit profile YAML, switch tabs and back — draft persists; Launch with dirty editor prompts; delete profile then navigate back — no stale render

Made with [Cursor](https://cursor.com)