### PR TITLE
docs: Align docs theme with console design system

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -11,31 +11,30 @@
   },
   "logo": {
     "dark": "/logo/omnara-logo.svg",
-    "light": "/logo/omnara-logo.svg"
+    "light": "/logo/omnara-logo-light.svg"
   },
   "favicon": "/favicon.ico",
   "colors": {
-    "primary": "#d4a843",
-    "light": "#c9b06a",
-    "dark": "#1A1A1A"
+    "primary": "#5e6ad2",
+    "light": "#8188df",
+    "dark": "#4e59c7"
   },
   "background": {
     "color": {
-      "dark": "#1a1917"
-    },
-    "decoration": "gradient"
+      "light": "#ffffff",
+      "dark": "#0b0b0c"
+    }
   },
   "appearance": {
-    "default": "dark",
-    "strict": true
+    "default": "system"
   },
   "fonts": {
     "heading": {
-      "family": "Inter",
+      "family": "Geist",
       "weight": 600
     },
     "body": {
-      "family": "Inter",
+      "family": "Geist",
       "weight": 400
     }
   },

--- a/docs/logo/omnara-logo-light.svg
+++ b/docs/logo/omnara-logo-light.svg
@@ -1,0 +1,25 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_i_444_6982)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18.1104 2.02161C10.3044 1.56202 2.61003 8.4316 1.89894 22.8101H6.34976C6.34976 22.8101 6.34976 28.9478 6.34976 29.3195C6.34976 29.6912 6.34976 30 6.96942 30C7.58908 30 17.7852 30 17.7852 30V26.987C20.5969 27.3554 29.9638 24.1171 30.098 15.777C30.2322 7.43708 25.9164 2.48122 18.1104 2.02161ZM17.59 5.16132C22.7422 5.16132 26.919 9.33799 26.919 14.4902C26.919 19.6425 22.9375 23.8534 17.7852 23.8534V26.987C9.59656 22.7664 8.29139 20.5148 8.26103 14.4902C8.26107 9.33801 12.4377 5.16135 17.59 5.16132Z" fill="url(#paint0_linear_444_6982)"/>
+<path d="M10.8823 14.5647C10.8823 15.8752 11.9447 16.9375 13.2552 16.9375C14.5657 16.9375 15.6281 15.8752 15.6281 14.5647C15.6281 13.2542 14.5657 12.1918 13.2552 12.1918C11.9447 12.1918 10.8823 13.2542 10.8823 14.5647Z" fill="url(#paint1_linear_444_6982)"/>
+</g>
+<defs>
+<filter id="filter0_i_444_6982" x="1.89893" y="2" width="28.2021" height="28" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.396707" dy="0.396707"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_444_6982"/>
+</filter>
+<linearGradient id="paint0_linear_444_6982" x1="30.1011" y1="2" x2="1.89893" y2="30" gradientUnits="userSpaceOnUse">
+<stop stop-color="#232326"/>
+<stop offset="1" stop-color="#737377"/>
+</linearGradient>
+<linearGradient id="paint1_linear_444_6982" x1="30.1011" y1="2" x2="1.89893" y2="30" gradientUnits="userSpaceOnUse">
+<stop stop-color="#232326"/>
+<stop offset="1" stop-color="#737377"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
## Summary

Restyles the Mintlify docs site (docs.omnara.com) to match the console's design system, so moving between the product and the docs feels like one brand.

- Replaces the gold accent palette with the console's indigo ramp: `#5e6ad2` primary, `#8188df` for dark mode, `#4e59c7` deep variant
- Backgrounds now match the console exactly: white in light mode, near-black `#0b0b0c` in dark mode (was warm `#1a1917`); drops the gradient decoration for the console's flat, neutral look
- Enables light + dark modes with system default (docs were previously locked to dark-only), mirroring the console's theme toggle
- Switches typography from Inter to Geist, the console's font
- Adds `logo/omnara-logo-light.svg`, a dark-ink variant of the mark (`#232326 → #737377`, matching the console's light-mode foreground gradient), since the existing white logo would be invisible on the newly enabled light background

## Test plan
- [ ] `mintlify dev` in `docs/`: verify both light and dark modes render with indigo accents and correct backgrounds
- [ ] Logo is visible in both modes (dark-ink mark on light, white mark on dark)
- [ ] Spot-check embedded screenshots/images in docs content against the new backgrounds

Made with [Cursor](https://cursor.com)