### PR TITLE
feat: add help link to user menu

### DIFF
--- a/frontend/apps/web/src/components/app-shell/NavUser.tsx
+++ b/frontend/apps/web/src/components/app-shell/NavUser.tsx
@@ -1,6 +1,6 @@
 import { useMe } from '@omnara/react'
 import { sessionLogout } from '@omnara/sdk/browser'
-import { ChevronsUpDown, LogOut, Monitor, Moon, Sun } from 'lucide-react'
+import { ChevronsUpDown, CircleHelp, LogOut, Monitor, Moon, Sun } from 'lucide-react'
 import { useState } from 'react'
 
 import {
@@ -122,6 +122,15 @@ export function NavUser() {
             <DropdownMenuSeparator />
             <ThemeMenuItems />
             <DropdownMenuSeparator />
+            <DropdownMenuItem
+              asChild
+              className="hover:bg-primary/15 focus:bg-primary/15 [&_svg]:!text-foreground"
+            >
+              <a href="https://docs.omnara.com/support" target="_blank" rel="noreferrer">
+                <CircleHelp />
+                <span className="translate-y-px">Need help?</span>
+              </a>
+            </DropdownMenuItem>
             <DropdownMenuItem
               variant="destructive"
               disabled={logoutStatus.kind === 'pending'}


### PR DESCRIPTION
- adds a `Need help?` action directly above log out so support is discoverable from every authenticated page
- opens the existing [Omnara support page](https://docs.omnara.com/support) in a new tab without interrupting console work

Normal state:
<img width="277" height="263" alt="image" src="https://github.com/user-attachments/assets/08fe3755-970e-4540-b39d-1ebcad0b0e1f" />

State on cursor hover:
<img width="269" height="264" alt="image" src="https://github.com/user-attachments/assets/1986abf0-fd6c-4506-af34-ba2ea1fbe32a" />

