### PR TITLE
fix: sync docs with cluster releases

### DIFF
--- a/.github/workflows/cluster-release.yaml
+++ b/.github/workflows/cluster-release.yaml
@@ -150,3 +150,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.manifest.outputs.version }}
         run: if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then gh release upload "$GITHUB_REF_NAME" cluster-release.json --clobber && gh release edit "$GITHUB_REF_NAME" --draft=false --latest=false --prerelease=false --notes-file release-notes.md --title "cluster $VERSION" --verify-tag; else gh release create "$GITHUB_REF_NAME" cluster-release.json --latest=false --notes-file release-notes.md --title "cluster $VERSION" --verify-tag; fi
+
+      - name: Publish documentation
+        env:
+          DOCS_BRANCH: docs-production
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          source_commit=$(jq -er '.source_commit' cluster-release.json)
+          gh api --method PATCH "repos/$GITHUB_REPOSITORY/git/refs/heads/$DOCS_BRANCH" -f sha="$source_commit" -F force=false


### PR DESCRIPTION
Relevant external changes:
- our production mintlify setup now points to the protected `docs-production` branch, which is currently at the same commit as the latest cluster release (`cluster-v0.1.9`)

Changes in this PR:
- this PR updates the cluster release workflow to automatically advance `docs-production` to the exact `source_commit` recorded in each published cluster release manifest
- it updates the `docs-production` branch only after the GitHub release is successfully published

thus we can keep unreleased documentation changes on `main` out of the public mintlify site