### PR TITLE
fix: Retry transient Blaxel sandbox creation failures

### DIFF
--- a/internal/machinepool/providers/blaxel/client.go
+++ b/internal/machinepool/providers/blaxel/client.go
@@ -21,11 +21,9 @@ const (
 	apiBaseURL           = "https://api.blaxel.ai/v0"
 	apiVersion           = "2026-04-28"
 	maxSandboxListLimit  = 200
-	dataPlaneRetries     = 2
-	dataPlaneRetryDelay  = 500 * time.Millisecond
-	createRetries        = 2
-	createRetryDelay     = 250 * time.Millisecond
-	maxCreateRetryDelay  = 5 * time.Second
+	requestRetries       = 2
+	requestRetryDelay    = 250 * time.Millisecond
+	maxRequestRetryDelay = 5 * time.Second
 	maxAPIDiagnosticSize = 128
 )
 
@@ -188,9 +186,6 @@ func (c *restClient) CreateSandbox(
 		c.apiBaseURL+"/sandboxes?createIfNotExist=true",
 		request,
 		&result,
-		createRetries,
-		isTransientServerError,
-		createRetryDelayFor,
 	)
 	if err == nil || !isTransientServerError(err) {
 		return result, err
@@ -203,13 +198,13 @@ func (c *restClient) CreateSandbox(
 	return sandbox{}, err
 }
 
-func createRetryDelayFor(err error, attempt int) time.Duration {
-	delay := createRetryDelay << attempt
+func requestRetryDelayFor(err error, attempt int) time.Duration {
+	delay := requestRetryDelay << attempt
 	delay = delay/2 + time.Duration(rand.Int64N(int64(delay)))
 	if retryAfter, ok := providers.RetryAfter(err); ok && retryAfter > delay {
 		delay = retryAfter
 	}
-	return min(delay, maxCreateRetryDelay)
+	return min(delay, maxRequestRetryDelay)
 }
 
 func waitForRetry(ctx context.Context, delay time.Duration) error {
@@ -290,7 +285,7 @@ func (c *restClient) GetSandboxProcess(
 		return sandboxProcess{}, false, err
 	}
 	var process sandboxProcess
-	_, err = c.doDataPlaneRequest(
+	_, err = c.doRequestWithRetry(
 		ctx,
 		http.MethodGet,
 		sandboxURL+"/process/"+url.PathEscape(name),
@@ -311,7 +306,7 @@ func (c *restClient) WakeSandbox(ctx context.Context, target sandbox) error {
 	if err != nil {
 		return err
 	}
-	statusCode, err := c.doDataPlaneRequest(
+	statusCode, err := c.doRequestWithRetry(
 		ctx,
 		http.MethodGet,
 		fmt.Sprintf("%s/port/%d/", sandboxURL, daemonprotocol.WakeListenerPort),
@@ -347,39 +342,19 @@ func sandboxDataPlaneURL(target sandbox) (string, error) {
 	return sandboxURL, nil
 }
 
-func (c *restClient) doDataPlaneRequest(
-	ctx context.Context,
-	method, requestURL string,
-	body, out any,
-) (int, error) {
-	return c.doRequestWithRetry(
-		ctx,
-		method,
-		requestURL,
-		body,
-		out,
-		dataPlaneRetries,
-		isGatewayError,
-		func(error, int) time.Duration { return dataPlaneRetryDelay },
-	)
-}
-
 func (c *restClient) doRequestWithRetry(
 	ctx context.Context,
 	method, requestURL string,
 	body, out any,
-	maxRetries int,
-	retryable func(error) bool,
-	retryDelay func(error, int) time.Duration,
 ) (int, error) {
 	var statusCode int
 	var lastErr error
-	for attempt := 0; attempt <= maxRetries; attempt++ {
+	for attempt := 0; attempt <= requestRetries; attempt++ {
 		statusCode, lastErr = c.doRequest(ctx, method, requestURL, body, out)
-		if lastErr == nil || !retryable(lastErr) || attempt == maxRetries {
+		if lastErr == nil || !isTransientServerError(lastErr) || attempt == requestRetries {
 			return statusCode, lastErr
 		}
-		if err := waitForRetry(ctx, retryDelay(lastErr, attempt)); err != nil {
+		if err := waitForRetry(ctx, requestRetryDelayFor(lastErr, attempt)); err != nil {
 			return 0, err
 		}
 	}
@@ -506,12 +481,9 @@ func isConflict(err error) bool {
 	return isStatus(err, http.StatusConflict)
 }
 
-func isGatewayError(err error) bool {
-	return isStatus(err, http.StatusBadGateway) ||
+func isTransientServerError(err error) bool {
+	return isStatus(err, http.StatusInternalServerError) ||
+		isStatus(err, http.StatusBadGateway) ||
 		isStatus(err, http.StatusServiceUnavailable) ||
 		isStatus(err, http.StatusGatewayTimeout)
-}
-
-func isTransientServerError(err error) bool {
-	return isStatus(err, http.StatusInternalServerError) || isGatewayError(err)
 }

--- a/internal/machinepool/providers/blaxel/client.go
+++ b/internal/machinepool/providers/blaxel/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -17,11 +18,15 @@ import (
 )
 
 const (
-	apiBaseURL          = "https://api.blaxel.ai/v0"
-	apiVersion          = "2026-04-28"
-	maxSandboxListLimit = 200
-	dataPlaneRetries    = 2
-	dataPlaneRetryDelay = 500 * time.Millisecond
+	apiBaseURL           = "https://api.blaxel.ai/v0"
+	apiVersion           = "2026-04-28"
+	maxSandboxListLimit  = 200
+	dataPlaneRetries     = 2
+	dataPlaneRetryDelay  = 500 * time.Millisecond
+	createRetries        = 2
+	createRetryDelay     = 250 * time.Millisecond
+	maxCreateRetryDelay  = 5 * time.Second
+	maxAPIDiagnosticSize = 128
 )
 
 type apiClient interface {
@@ -176,18 +181,51 @@ func (c *restClient) CreateSandbox(
 	ctx context.Context,
 	request createSandboxRequest,
 ) (sandbox, error) {
-	var result sandbox
-	_, err := c.doRequest(
-		ctx,
-		http.MethodPost,
-		c.apiBaseURL+"/sandboxes?createIfNotExist=true",
-		request,
-		&result,
-	)
-	if err != nil {
-		return sandbox{}, err
+	var lastErr error
+	for attempt := 0; attempt <= createRetries; attempt++ {
+		var result sandbox
+		_, lastErr = c.doRequest(
+			ctx,
+			http.MethodPost,
+			c.apiBaseURL+"/sandboxes?createIfNotExist=true",
+			request,
+			&result,
+		)
+		if lastErr == nil || !isTransientServerError(lastErr) {
+			return result, lastErr
+		}
+		if attempt < createRetries {
+			if err := waitForRetry(ctx, createRetryDelayFor(lastErr, attempt)); err != nil {
+				return sandbox{}, err
+			}
+		}
 	}
-	return result, nil
+	if request.Metadata.Name != "" {
+		if existing, found, err := c.GetSandbox(ctx, request.Metadata.Name); err == nil && found {
+			return existing, nil
+		}
+	}
+	return sandbox{}, lastErr
+}
+
+func createRetryDelayFor(err error, attempt int) time.Duration {
+	delay := createRetryDelay << attempt
+	delay = delay/2 + time.Duration(rand.Int64N(int64(delay)))
+	if retryAfter, ok := providers.RetryAfter(err); ok && retryAfter > delay {
+		delay = retryAfter
+	}
+	return min(delay, maxCreateRetryDelay)
+}
+
+func waitForRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func (c *restClient) GetSandbox(
@@ -373,7 +411,11 @@ func (c *restClient) doRequestWithHeaders(
 	statusCode, raw := response.StatusCode, response.Body
 	if statusCode < 200 || statusCode >= 300 {
 		return statusCode, providers.WithRetryAfter(
-			apiError{StatusCode: statusCode},
+			apiError{
+				StatusCode: statusCode,
+				ErrorCode:  responseErrorCode(raw),
+				RequestID:  responseRequestID(response.Header),
+			},
 			response.Header,
 		)
 	}
@@ -388,10 +430,56 @@ func (c *restClient) doRequestWithHeaders(
 
 type apiError struct {
 	StatusCode int
+	ErrorCode  string
+	RequestID  string
 }
 
 func (e apiError) Error() string {
-	return fmt.Sprintf("blaxel API returned HTTP %d", e.StatusCode)
+	message := fmt.Sprintf("blaxel API returned HTTP %d", e.StatusCode)
+	if e.ErrorCode != "" {
+		message += fmt.Sprintf(" (code %q)", e.ErrorCode)
+	}
+	if e.RequestID != "" {
+		message += fmt.Sprintf(" (request %q)", e.RequestID)
+	}
+	return message
+}
+
+func responseErrorCode(raw []byte) string {
+	var response struct {
+		ErrorCode string `json:"errorCode"`
+		Code      string `json:"code"`
+	}
+	if err := json.Unmarshal(raw, &response); err != nil {
+		return ""
+	}
+	code := strings.TrimSpace(response.ErrorCode)
+	if code == "" {
+		code = strings.TrimSpace(response.Code)
+	}
+	return boundedAPIDiagnostic(code)
+}
+
+func responseRequestID(header http.Header) string {
+	for _, name := range []string{"X-Blaxel-Request-Id", "X-Request-Id", "Request-Id"} {
+		if requestID := boundedAPIDiagnostic(header.Get(name)); requestID != "" {
+			return requestID
+		}
+	}
+	return ""
+}
+
+func boundedAPIDiagnostic(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) > maxAPIDiagnosticSize {
+		value = value[:maxAPIDiagnosticSize]
+	}
+	return strings.Map(func(character rune) rune {
+		if character < 0x20 || character == 0x7f {
+			return -1
+		}
+		return character
+	}, value)
 }
 
 func isStatus(err error, statusCode int) bool {
@@ -411,4 +499,8 @@ func isGatewayError(err error) bool {
 	return isStatus(err, http.StatusBadGateway) ||
 		isStatus(err, http.StatusServiceUnavailable) ||
 		isStatus(err, http.StatusGatewayTimeout)
+}
+
+func isTransientServerError(err error) bool {
+	return isStatus(err, http.StatusInternalServerError) || isGatewayError(err)
 }

--- a/internal/machinepool/providers/blaxel/client.go
+++ b/internal/machinepool/providers/blaxel/client.go
@@ -181,31 +181,26 @@ func (c *restClient) CreateSandbox(
 	ctx context.Context,
 	request createSandboxRequest,
 ) (sandbox, error) {
-	var lastErr error
-	for attempt := 0; attempt <= createRetries; attempt++ {
-		var result sandbox
-		_, lastErr = c.doRequest(
-			ctx,
-			http.MethodPost,
-			c.apiBaseURL+"/sandboxes?createIfNotExist=true",
-			request,
-			&result,
-		)
-		if lastErr == nil || !isTransientServerError(lastErr) {
-			return result, lastErr
-		}
-		if attempt < createRetries {
-			if err := waitForRetry(ctx, createRetryDelayFor(lastErr, attempt)); err != nil {
-				return sandbox{}, err
-			}
-		}
+	var result sandbox
+	_, err := c.doRequestWithRetry(
+		ctx,
+		http.MethodPost,
+		c.apiBaseURL+"/sandboxes?createIfNotExist=true",
+		request,
+		&result,
+		createRetries,
+		isTransientServerError,
+		createRetryDelayFor,
+	)
+	if err == nil || !isTransientServerError(err) {
+		return result, err
 	}
 	if request.Metadata.Name != "" {
-		if existing, found, err := c.GetSandbox(ctx, request.Metadata.Name); err == nil && found {
+		if existing, found, getErr := c.GetSandbox(ctx, request.Metadata.Name); getErr == nil && found {
 			return existing, nil
 		}
 	}
-	return sandbox{}, lastErr
+	return sandbox{}, err
 }
 
 func createRetryDelayFor(err error, attempt int) time.Duration {
@@ -357,19 +352,35 @@ func (c *restClient) doDataPlaneRequest(
 	method, requestURL string,
 	body, out any,
 ) (int, error) {
+	return c.doRequestWithRetry(
+		ctx,
+		method,
+		requestURL,
+		body,
+		out,
+		dataPlaneRetries,
+		isGatewayError,
+		func(error, int) time.Duration { return dataPlaneRetryDelay },
+	)
+}
+
+func (c *restClient) doRequestWithRetry(
+	ctx context.Context,
+	method, requestURL string,
+	body, out any,
+	maxRetries int,
+	retryable func(error) bool,
+	retryDelay func(error, int) time.Duration,
+) (int, error) {
 	var statusCode int
 	var lastErr error
-	for attempt := 0; attempt <= dataPlaneRetries; attempt++ {
+	for attempt := 0; attempt <= maxRetries; attempt++ {
 		statusCode, lastErr = c.doRequest(ctx, method, requestURL, body, out)
-		if lastErr == nil || !isGatewayError(lastErr) || attempt == dataPlaneRetries {
+		if lastErr == nil || !retryable(lastErr) || attempt == maxRetries {
 			return statusCode, lastErr
 		}
-		timer := time.NewTimer(dataPlaneRetryDelay)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return 0, ctx.Err()
-		case <-timer.C:
+		if err := waitForRetry(ctx, retryDelay(lastErr, attempt)); err != nil {
+			return 0, err
 		}
 	}
 	return statusCode, lastErr

--- a/internal/machinepool/providers/blaxel/client_test.go
+++ b/internal/machinepool/providers/blaxel/client_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/omnara-ai/omnara/internal/machinepool/providers"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
@@ -218,6 +219,100 @@ func TestBlaxelRESTClientDoesNotRetryProcessStart(t *testing.T) {
 	}
 }
 
+func TestBlaxelRESTClientRetriesTransientCreateErrors(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := calls.Add(1)
+		if r.Method != http.MethodPost || r.URL.Path != "/sandboxes" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			return
+		}
+		switch call {
+		case 1:
+			w.WriteHeader(http.StatusInternalServerError)
+		case 2:
+			w.WriteHeader(http.StatusServiceUnavailable)
+		default:
+			_, _ = w.Write([]byte(`{"metadata":{"name":"omnara-mch-test"},"status":"DEPLOYED"}`))
+		}
+	}))
+	defer server.Close()
+
+	result, err := newTestRESTClient(server.URL).CreateSandbox(
+		context.Background(),
+		createSandboxRequest{Metadata: resourceMetadata{Name: "omnara-mch-test"}},
+	)
+	if err != nil || result.Metadata.Name != "omnara-mch-test" || calls.Load() != 3 {
+		t.Fatalf("create result=%+v calls=%d err=%v", result, calls.Load(), err)
+	}
+}
+
+func TestBlaxelRESTClientCreateConvergesAfterAmbiguousErrors(t *testing.T) {
+	var createCalls atomic.Int32
+	var getCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/sandboxes":
+			createCalls.Add(1)
+			w.Header().Set("X-Blaxel-Request-Id", "req-create")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"errorCode":"CREATE_TIMEOUT"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/sandboxes/omnara-mch-test":
+			getCalls.Add(1)
+			_, _ = w.Write([]byte(`{"metadata":{"name":"omnara-mch-test"},"status":"DEPLOYED"}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	result, err := newTestRESTClient(server.URL).CreateSandbox(
+		context.Background(),
+		createSandboxRequest{Metadata: resourceMetadata{Name: "omnara-mch-test"}},
+	)
+	if err != nil || result.Metadata.Name != "omnara-mch-test" ||
+		createCalls.Load() != createRetries+1 || getCalls.Load() != 1 {
+		t.Fatalf(
+			"create result=%+v create calls=%d get calls=%d err=%v",
+			result, createCalls.Load(), getCalls.Load(), err,
+		)
+	}
+}
+
+func TestBlaxelRESTClientCreateHonorsRetryAfterAndCancellation(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	time.AfterFunc(25*time.Millisecond, cancel)
+	_, err := newTestRESTClient(server.URL).CreateSandbox(
+		ctx,
+		createSandboxRequest{Metadata: resourceMetadata{Name: "omnara-mch-test"}},
+	)
+	if !errors.Is(err, context.Canceled) || calls.Load() != 1 {
+		t.Fatalf("create calls=%d err=%v, want cancellation before retry", calls.Load(), err)
+	}
+}
+
+func TestBlaxelCreateTransientStatuses(t *testing.T) {
+	for _, statusCode := range []int{500, 502, 503, 504} {
+		if !isTransientServerError(apiError{StatusCode: statusCode}) {
+			t.Errorf("HTTP %d should be transient", statusCode)
+		}
+	}
+	for _, statusCode := range []int{400, 409, 429, 501} {
+		if isTransientServerError(apiError{StatusCode: statusCode}) {
+			t.Errorf("HTTP %d should not be transient", statusCode)
+		}
+	}
+}
+
 func TestBlaxelRESTClientDataPlaneCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	client := newTestRESTClient("https://api.invalid.test")
@@ -244,6 +339,7 @@ func TestBlaxelRESTClientDataPlaneCancellation(t *testing.T) {
 
 func TestBlaxelRESTClientDoesNotExposeErrorResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Blaxel-Request-Id", "req-123")
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte(
 			`{"errorCode":"UPSTREAM_FAILURE","error":"OMNARA_MACHINE_TOKEN=secret-token"}`,
@@ -253,8 +349,9 @@ func TestBlaxelRESTClientDoesNotExposeErrorResponse(t *testing.T) {
 
 	client := newTestRESTClient(server.URL)
 	_, _, err := client.GetSandbox(context.Background(), "omnara-mch-test")
-	if err == nil || err.Error() != "blaxel API returned HTTP 500" {
-		t.Fatalf("provider error = %v, want status without response body", err)
+	want := `blaxel API returned HTTP 500 (code "UPSTREAM_FAILURE") (request "req-123")`
+	if err == nil || err.Error() != want || strings.Contains(err.Error(), "secret-token") {
+		t.Fatalf("provider error = %v, want safe bounded diagnostics", err)
 	}
 }
 

--- a/internal/machinepool/providers/blaxel/client_test.go
+++ b/internal/machinepool/providers/blaxel/client_test.go
@@ -271,7 +271,7 @@ func TestBlaxelRESTClientCreateConvergesAfterAmbiguousErrors(t *testing.T) {
 		createSandboxRequest{Metadata: resourceMetadata{Name: "omnara-mch-test"}},
 	)
 	if err != nil || result.Metadata.Name != "omnara-mch-test" ||
-		createCalls.Load() != createRetries+1 || getCalls.Load() != 1 {
+		createCalls.Load() != requestRetries+1 || getCalls.Load() != 1 {
 		t.Fatalf(
 			"create result=%+v create calls=%d get calls=%d err=%v",
 			result, createCalls.Load(), getCalls.Load(), err,
@@ -325,7 +325,7 @@ func TestBlaxelRESTClientDataPlaneCancellation(t *testing.T) {
 		}, nil
 	})
 
-	_, err := client.doDataPlaneRequest(
+	_, err := client.doRequestWithRetry(
 		ctx,
 		http.MethodGet,
 		"https://sandbox.invalid.test/process",


### PR DESCRIPTION
## Summary
- retry sandbox creation on HTTP 500, 502, 503, and 504 with bounded exponential backoff and jitter
- honor bounded `Retry-After` hints and recover ambiguous failures by fetching the deterministic sandbox
- include bounded structured error codes and request IDs without exposing arbitrary response bodies

## Testing
- `go test ./internal/machinepool/providers/blaxel`
- `go vet ./internal/machinepool/providers/blaxel`

## Note
- `go test ./internal/machinepool/providers/...` reaches an unrelated existing failure in managed startup tests due to concurrent use of the same daemon binary (`text file busy`)
