### PR TITLE
fix: retry machine provider provisioning

### DIFF
--- a/internal/machinepool/manager.go
+++ b/internal/machinepool/manager.go
@@ -23,8 +23,15 @@ const (
 	providerInspectionTimeout           = 5 * time.Second
 	providerDeletionTimeout             = 5 * time.Second
 	providerFailureRetryDelay           = time.Minute
+	providerProvisionRetryAttempts      = 4
 	poolMachineReconcileConcurrency     = 8
 )
+
+var providerProvisionRetryDelays = [...]time.Duration{
+	time.Second,
+	5 * time.Second,
+	15 * time.Second,
+}
 
 type Manager struct {
 	Execution                  *executionstore.Store
@@ -153,14 +160,16 @@ func (m Manager) ProvisionMachine(ctx context.Context, orgID, machineID storage.
 	machine.ProviderProvisionAttemptedAt = &providerProvisioning.ProviderProvisionAttemptedAt
 	machine.UpdatedAt = providerProvisioning.UpdatedAt
 	providerCtx, cancel = context.WithTimeout(ctx, provider.ProvisioningTimeout())
-	provisionResult, provisionErr := provider.ProvisionMachine(
-		providerCtx,
-		installationID,
-		machine.ID,
-		machineProvisioning,
-		providerProvisioning.DaemonToken.Token,
-		machineEnv,
-	)
+	provisionResult, provisionErr := provisionMachineWithRetry(providerCtx, func() (providers.ProvisionMachineResult, error) {
+		return provider.ProvisionMachine(
+			providerCtx,
+			installationID,
+			machine.ID,
+			machineProvisioning,
+			providerProvisioning.DaemonToken.Token,
+			machineEnv,
+		)
+	}, waitForProviderProvisionRetry)
 	cancel()
 	if provisionResult.ProviderResourceID != "" {
 		observation, err := m.Execution.RecordPoolMachineProvisioningResource(
@@ -208,6 +217,55 @@ func (m Manager) ProvisionMachine(ctx context.Context, orgID, machineID storage.
 		machine.ProvisionAttempts,
 	)
 	return err
+}
+
+func provisionMachineWithRetry(
+	ctx context.Context,
+	provision func() (providers.ProvisionMachineResult, error),
+	wait func(context.Context, time.Duration) error,
+) (providers.ProvisionMachineResult, error) {
+	var observed providers.ProvisionMachineResult
+	for attempt := range providerProvisionRetryAttempts {
+		result, err := provision()
+		if result.ProviderResourceID != "" {
+			if observed.ProviderResourceID != "" && observed.ProviderResourceID != result.ProviderResourceID {
+				return observed, fmt.Errorf(
+					"provider returned conflicting resource ids %q and %q",
+					observed.ProviderResourceID,
+					result.ProviderResourceID,
+				)
+			}
+			observed.ProviderResourceID = result.ProviderResourceID
+		}
+		if result.SandboxURL != "" {
+			observed.SandboxURL = result.SandboxURL
+		}
+		if err == nil {
+			return observed, nil
+		}
+		if attempt == providerProvisionRetryAttempts-1 || ctx.Err() != nil {
+			return observed, err
+		}
+		delay := providerProvisionRetryDelays[attempt]
+		if retryAfter, ok := providers.RetryAfter(err); ok {
+			delay = max(delay, retryAfter)
+		}
+		if err := wait(ctx, delay); err != nil {
+			return observed, err
+		}
+	}
+	panic("unreachable")
+}
+
+func waitForProviderProvisionRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func (m Manager) WakeMachine(ctx context.Context, orgID, machineID storage.ID) (bool, error) {

--- a/internal/machinepool/manager.go
+++ b/internal/machinepool/manager.go
@@ -29,8 +29,8 @@ const (
 
 var providerProvisionRetryDelays = [...]time.Duration{
 	time.Second,
-	5 * time.Second,
-	15 * time.Second,
+	2 * time.Second,
+	4 * time.Second,
 }
 
 type Manager struct {

--- a/internal/machinepool/manager.go
+++ b/internal/machinepool/manager.go
@@ -162,17 +162,12 @@ func (m Manager) ProvisionMachine(ctx context.Context, orgID, machineID storage.
 	providerCtx, cancel = context.WithTimeout(ctx, provider.ProvisioningTimeout())
 	provisionResult, provisionErr := provisionMachineWithRetry(
 		providerCtx,
-		func() (providers.ProvisionMachineResult, error) {
-			return provider.ProvisionMachine(
-				providerCtx,
-				installationID,
-				machine.ID,
-				machineProvisioning,
-				providerProvisioning.DaemonToken.Token,
-				machineEnv,
-			)
-		},
-		waitForProviderProvisionRetry,
+		provider,
+		installationID,
+		machine.ID,
+		machineProvisioning,
+		providerProvisioning.DaemonToken.Token,
+		machineEnv,
 	)
 	cancel()
 	if provisionResult.ProviderResourceID != "" {
@@ -225,13 +220,23 @@ func (m Manager) ProvisionMachine(ctx context.Context, orgID, machineID storage.
 
 func provisionMachineWithRetry(
 	ctx context.Context,
-	provision func() (providers.ProvisionMachineResult, error),
-	wait func(context.Context, time.Duration) error,
+	provider providers.Provider,
+	installationID, machineID storage.ID,
+	machineProvisioning executionstore.MachineProvisioningConfig,
+	machineToken string,
+	machineEnv map[string]string,
 ) (providers.ProvisionMachineResult, error) {
 	var observed providers.ProvisionMachineResult
 	var provisionErr error
 	for attempt := range providerProvisionRetryAttempts {
-		result, err := provision()
+		result, err := provider.ProvisionMachine(
+			ctx,
+			installationID,
+			machineID,
+			machineProvisioning,
+			machineToken,
+			machineEnv,
+		)
 		provisionErr = err
 		if result.ProviderResourceID != "" {
 			if observed.ProviderResourceID != "" && observed.ProviderResourceID != result.ProviderResourceID {
@@ -255,15 +260,19 @@ func provisionMachineWithRetry(
 		if attempt == providerProvisionRetryAttempts-1 {
 			break
 		}
-		delay := providerProvisionRetryDelays[attempt]
-		if retryAfter, ok := providers.RetryAfter(err); ok {
-			delay = max(delay, retryAfter)
-		}
-		if err := wait(ctx, delay); err != nil {
+		if err := waitForProviderProvisionRetry(ctx, providerProvisionRetryDelay(attempt, err)); err != nil {
 			return observed, provisionErr
 		}
 	}
 	return observed, provisionErr
+}
+
+func providerProvisionRetryDelay(attempt int, err error) time.Duration {
+	delay := providerProvisionRetryDelays[attempt]
+	if retryAfter, ok := providers.RetryAfter(err); ok {
+		delay = max(delay, retryAfter)
+	}
+	return delay
 }
 
 func waitForProviderProvisionRetry(ctx context.Context, delay time.Duration) error {

--- a/internal/machinepool/manager.go
+++ b/internal/machinepool/manager.go
@@ -238,6 +238,9 @@ func provisionMachineWithRetry(
 			machineEnv,
 		)
 		provisionErr = err
+		if errors.Is(err, providers.ErrResourceReplaced) {
+			observed = providers.ProvisionMachineResult{}
+		}
 		if result.ProviderResourceID != "" {
 			if observed.ProviderResourceID != "" && observed.ProviderResourceID != result.ProviderResourceID {
 				return observed, fmt.Errorf(

--- a/internal/machinepool/manager.go
+++ b/internal/machinepool/manager.go
@@ -260,13 +260,16 @@ func provisionMachineWithRetry(
 			delay = max(delay, retryAfter)
 		}
 		if err := wait(ctx, delay); err != nil {
-			return observed, err
+			return observed, provisionErr
 		}
 	}
 	return observed, provisionErr
 }
 
 func waitForProviderProvisionRetry(ctx context.Context, delay time.Duration) error {
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= delay {
+		return context.DeadlineExceeded
+	}
 	timer := time.NewTimer(delay)
 	defer timer.Stop()
 	select {

--- a/internal/machinepool/manager.go
+++ b/internal/machinepool/manager.go
@@ -160,16 +160,20 @@ func (m Manager) ProvisionMachine(ctx context.Context, orgID, machineID storage.
 	machine.ProviderProvisionAttemptedAt = &providerProvisioning.ProviderProvisionAttemptedAt
 	machine.UpdatedAt = providerProvisioning.UpdatedAt
 	providerCtx, cancel = context.WithTimeout(ctx, provider.ProvisioningTimeout())
-	provisionResult, provisionErr := provisionMachineWithRetry(providerCtx, func() (providers.ProvisionMachineResult, error) {
-		return provider.ProvisionMachine(
-			providerCtx,
-			installationID,
-			machine.ID,
-			machineProvisioning,
-			providerProvisioning.DaemonToken.Token,
-			machineEnv,
-		)
-	}, waitForProviderProvisionRetry)
+	provisionResult, provisionErr := provisionMachineWithRetry(
+		providerCtx,
+		func() (providers.ProvisionMachineResult, error) {
+			return provider.ProvisionMachine(
+				providerCtx,
+				installationID,
+				machine.ID,
+				machineProvisioning,
+				providerProvisioning.DaemonToken.Token,
+				machineEnv,
+			)
+		},
+		waitForProviderProvisionRetry,
+	)
 	cancel()
 	if provisionResult.ProviderResourceID != "" {
 		observation, err := m.Execution.RecordPoolMachineProvisioningResource(
@@ -225,8 +229,10 @@ func provisionMachineWithRetry(
 	wait func(context.Context, time.Duration) error,
 ) (providers.ProvisionMachineResult, error) {
 	var observed providers.ProvisionMachineResult
+	var provisionErr error
 	for attempt := range providerProvisionRetryAttempts {
 		result, err := provision()
+		provisionErr = err
 		if result.ProviderResourceID != "" {
 			if observed.ProviderResourceID != "" && observed.ProviderResourceID != result.ProviderResourceID {
 				return observed, fmt.Errorf(
@@ -243,8 +249,11 @@ func provisionMachineWithRetry(
 		if err == nil {
 			return observed, nil
 		}
-		if attempt == providerProvisionRetryAttempts-1 || ctx.Err() != nil {
+		if ctx.Err() != nil {
 			return observed, err
+		}
+		if attempt == providerProvisionRetryAttempts-1 {
+			break
 		}
 		delay := providerProvisionRetryDelays[attempt]
 		if retryAfter, ok := providers.RetryAfter(err); ok {
@@ -254,7 +263,7 @@ func provisionMachineWithRetry(
 			return observed, err
 		}
 	}
-	panic("unreachable")
+	return observed, provisionErr
 }
 
 func waitForProviderProvisionRetry(ctx context.Context, delay time.Duration) error {

--- a/internal/machinepool/manager_test.go
+++ b/internal/machinepool/manager_test.go
@@ -272,6 +272,25 @@ func TestProvisionMachineWithRetryExhaustsAttempts(t *testing.T) {
 	}
 }
 
+func TestProvisionMachineWithRetryPreservesProviderErrorWhenWaitExpires(t *testing.T) {
+	providerErr := errors.New("provider unavailable")
+	result, err := provisionMachineWithRetry(
+		context.Background(),
+		func() (providers.ProvisionMachineResult, error) {
+			return providers.ProvisionMachineResult{ProviderResourceID: "resource-1"}, providerErr
+		},
+		func(context.Context, time.Duration) error {
+			return context.DeadlineExceeded
+		},
+	)
+	if !errors.Is(err, providerErr) {
+		t.Fatalf("provision error = %v, want %v", err, providerErr)
+	}
+	if result.ProviderResourceID != "resource-1" {
+		t.Fatalf("provision result = %+v, want observed resource", result)
+	}
+}
+
 func TestProvisionMachineWithRetryHonorsProviderDelay(t *testing.T) {
 	providerErr := providers.WithRetryAfter(
 		errors.New("rate limited"),

--- a/internal/machinepool/manager_test.go
+++ b/internal/machinepool/manager_test.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/omnara-ai/omnara/internal/machinepool/providers"
+	"github.com/omnara-ai/omnara/internal/storage"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 )
 
@@ -203,11 +203,85 @@ func TestRunBoundedReconcileLimitsConcurrency(t *testing.T) {
 	}
 }
 
+type provisionRetryProvider struct {
+	provision func() (providers.ProvisionMachineResult, error)
+}
+
+func (p provisionRetryProvider) ProvisionMachine(
+	context.Context,
+	storage.ID,
+	storage.ID,
+	executionstore.MachineProvisioningConfig,
+	string,
+	map[string]string,
+) (providers.ProvisionMachineResult, error) {
+	return p.provision()
+}
+
+func (provisionRetryProvider) ProvisioningTimeout() time.Duration {
+	return time.Minute
+}
+
+func (provisionRetryProvider) PrepareProvisioning(
+	context.Context,
+	executionstore.MachineProvisioningConfig,
+) (executionstore.MachineResourceFacts, error) {
+	return executionstore.MachineResourceFacts{}, errors.New("not implemented")
+}
+
+func (provisionRetryProvider) InspectMachine(
+	context.Context,
+	storage.ID,
+	storage.ID,
+	executionstore.MachineProvisioningConfig,
+	string,
+) (string, bool, error) {
+	return "", false, errors.New("not implemented")
+}
+
+func (provisionRetryProvider) DeleteMachine(
+	context.Context,
+	storage.ID,
+	storage.ID,
+	executionstore.MachineProvisioningConfig,
+	string,
+) error {
+	return errors.New("not implemented")
+}
+
+func provisionWithRetryForTest(
+	ctx context.Context,
+	provision func() (providers.ProvisionMachineResult, error),
+) (providers.ProvisionMachineResult, error) {
+	return provisionMachineWithRetry(
+		ctx,
+		provisionRetryProvider{provision: provision},
+		storage.ID{},
+		storage.ID{},
+		executionstore.MachineProvisioningConfig{},
+		"",
+		nil,
+	)
+}
+
+func stubProvisionRetryDelays(t *testing.T) {
+	t.Helper()
+	saved := providerProvisionRetryDelays
+	providerProvisionRetryDelays = [...]time.Duration{
+		time.Millisecond,
+		time.Millisecond,
+		time.Millisecond,
+	}
+	t.Cleanup(func() {
+		providerProvisionRetryDelays = saved
+	})
+}
+
 func TestProvisionMachineWithRetrySucceedsAndPreservesObservation(t *testing.T) {
+	stubProvisionRetryDelays(t)
 	providerErr := errors.New("temporary provider failure")
 	calls := 0
-	var delays []time.Duration
-	result, err := provisionMachineWithRetry(
+	result, err := provisionWithRetryForTest(
 		context.Background(),
 		func() (providers.ProvisionMachineResult, error) {
 			calls++
@@ -220,10 +294,6 @@ func TestProvisionMachineWithRetrySucceedsAndPreservesObservation(t *testing.T) 
 				return providers.ProvisionMachineResult{ProviderResourceID: "resource-1", SandboxURL: "https://sandbox.test/"}, nil
 			}
 		},
-		func(_ context.Context, delay time.Duration) error {
-			delays = append(delays, delay)
-			return nil
-		},
 	)
 	if err != nil {
 		t.Fatalf("provision with retry: %v", err)
@@ -234,38 +304,24 @@ func TestProvisionMachineWithRetrySucceedsAndPreservesObservation(t *testing.T) 
 	if result.ProviderResourceID != "resource-1" || result.SandboxURL != "https://sandbox.test/" {
 		t.Fatalf("provision result = %+v", result)
 	}
-	wantDelays := []time.Duration{time.Second, 2 * time.Second}
-	if !slices.Equal(delays, wantDelays) {
-		t.Fatalf("retry delays = %v, want %v", delays, wantDelays)
-	}
 }
 
 func TestProvisionMachineWithRetryExhaustsAttempts(t *testing.T) {
+	stubProvisionRetryDelays(t)
 	providerErr := errors.New("provider unavailable")
 	calls := 0
-	waits := 0
-	result, err := provisionMachineWithRetry(
+	result, err := provisionWithRetryForTest(
 		context.Background(),
 		func() (providers.ProvisionMachineResult, error) {
 			calls++
 			return providers.ProvisionMachineResult{ProviderResourceID: "resource-1"}, providerErr
 		},
-		func(context.Context, time.Duration) error {
-			waits++
-			return nil
-		},
 	)
 	if !errors.Is(err, providerErr) {
 		t.Fatalf("provision error = %v, want %v", err, providerErr)
 	}
-	if calls != providerProvisionRetryAttempts || waits != providerProvisionRetryAttempts-1 {
-		t.Fatalf(
-			"provision calls/waits = %d/%d, want %d/%d",
-			calls,
-			waits,
-			providerProvisionRetryAttempts,
-			providerProvisionRetryAttempts-1,
-		)
+	if calls != providerProvisionRetryAttempts {
+		t.Fatalf("provision calls = %d, want %d", calls, providerProvisionRetryAttempts)
 	}
 	if result.ProviderResourceID != "resource-1" {
 		t.Fatalf("provision result = %+v, want observed resource", result)
@@ -274,55 +330,44 @@ func TestProvisionMachineWithRetryExhaustsAttempts(t *testing.T) {
 
 func TestProvisionMachineWithRetryPreservesProviderErrorWhenWaitExpires(t *testing.T) {
 	providerErr := errors.New("provider unavailable")
-	result, err := provisionMachineWithRetry(
-		context.Background(),
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	calls := 0
+	result, err := provisionWithRetryForTest(
+		ctx,
 		func() (providers.ProvisionMachineResult, error) {
+			calls++
 			return providers.ProvisionMachineResult{ProviderResourceID: "resource-1"}, providerErr
-		},
-		func(context.Context, time.Duration) error {
-			return context.DeadlineExceeded
 		},
 	)
 	if !errors.Is(err, providerErr) {
 		t.Fatalf("provision error = %v, want %v", err, providerErr)
+	}
+	if calls != 1 {
+		t.Fatalf("provision calls = %d, want 1", calls)
 	}
 	if result.ProviderResourceID != "resource-1" {
 		t.Fatalf("provision result = %+v, want observed resource", result)
 	}
 }
 
-func TestProvisionMachineWithRetryHonorsProviderDelay(t *testing.T) {
+func TestProviderProvisionRetryDelayHonorsRetryAfter(t *testing.T) {
 	providerErr := providers.WithRetryAfter(
 		errors.New("rate limited"),
 		http.Header{"Retry-After": []string{"12"}},
 	)
-	calls := 0
-	var delay time.Duration
-	_, err := provisionMachineWithRetry(
-		context.Background(),
-		func() (providers.ProvisionMachineResult, error) {
-			calls++
-			if calls == 1 {
-				return providers.ProvisionMachineResult{}, providerErr
-			}
-			return providers.ProvisionMachineResult{ProviderResourceID: "resource-1"}, nil
-		},
-		func(_ context.Context, got time.Duration) error {
-			delay = got
-			return nil
-		},
-	)
-	if err != nil {
-		t.Fatalf("provision with retry-after: %v", err)
-	}
-	if delay != 12*time.Second {
+	if delay := providerProvisionRetryDelay(0, providerErr); delay != 12*time.Second {
 		t.Fatalf("retry delay = %s, want 12s", delay)
+	}
+	if delay := providerProvisionRetryDelay(1, errors.New("provider unavailable")); delay != 2*time.Second {
+		t.Fatalf("retry delay = %s, want 2s", delay)
 	}
 }
 
 func TestProvisionMachineWithRetryRejectsConflictingResources(t *testing.T) {
+	stubProvisionRetryDelays(t)
 	calls := 0
-	result, err := provisionMachineWithRetry(
+	result, err := provisionWithRetryForTest(
 		context.Background(),
 		func() (providers.ProvisionMachineResult, error) {
 			calls++
@@ -331,7 +376,6 @@ func TestProvisionMachineWithRetryRejectsConflictingResources(t *testing.T) {
 			}
 			return providers.ProvisionMachineResult{ProviderResourceID: "resource-2"}, nil
 		},
-		func(context.Context, time.Duration) error { return nil },
 	)
 	if err == nil || !strings.Contains(err.Error(), "conflicting resource ids") {
 		t.Fatalf("provision error = %v, want conflicting resource ids", err)

--- a/internal/machinepool/manager_test.go
+++ b/internal/machinepool/manager_test.go
@@ -234,7 +234,7 @@ func TestProvisionMachineWithRetrySucceedsAndPreservesObservation(t *testing.T) 
 	if result.ProviderResourceID != "resource-1" || result.SandboxURL != "https://sandbox.test/" {
 		t.Fatalf("provision result = %+v", result)
 	}
-	wantDelays := []time.Duration{time.Second, 5 * time.Second}
+	wantDelays := []time.Duration{time.Second, 2 * time.Second}
 	if !slices.Equal(delays, wantDelays) {
 		t.Fatalf("retry delays = %v, want %v", delays, wantDelays)
 	}

--- a/internal/machinepool/manager_test.go
+++ b/internal/machinepool/manager_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/omnara-ai/omnara/internal/machinepool/providers"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 )
 
@@ -197,5 +200,118 @@ func TestRunBoundedReconcileLimitsConcurrency(t *testing.T) {
 	}
 	if got := maxSeen.Load(); got != 3 {
 		t.Fatalf("max concurrency = %d, want 3", got)
+	}
+}
+
+func TestProvisionMachineWithRetrySucceedsAndPreservesObservation(t *testing.T) {
+	providerErr := errors.New("temporary provider failure")
+	calls := 0
+	var delays []time.Duration
+	result, err := provisionMachineWithRetry(
+		context.Background(),
+		func() (providers.ProvisionMachineResult, error) {
+			calls++
+			switch calls {
+			case 1:
+				return providers.ProvisionMachineResult{ProviderResourceID: "resource-1"}, providerErr
+			case 2:
+				return providers.ProvisionMachineResult{}, providerErr
+			default:
+				return providers.ProvisionMachineResult{ProviderResourceID: "resource-1", SandboxURL: "https://sandbox.test/"}, nil
+			}
+		},
+		func(_ context.Context, delay time.Duration) error {
+			delays = append(delays, delay)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("provision with retry: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("provision calls = %d, want 3", calls)
+	}
+	if result.ProviderResourceID != "resource-1" || result.SandboxURL != "https://sandbox.test/" {
+		t.Fatalf("provision result = %+v", result)
+	}
+	wantDelays := []time.Duration{time.Second, 5 * time.Second}
+	if !slices.Equal(delays, wantDelays) {
+		t.Fatalf("retry delays = %v, want %v", delays, wantDelays)
+	}
+}
+
+func TestProvisionMachineWithRetryExhaustsAttempts(t *testing.T) {
+	providerErr := errors.New("provider unavailable")
+	calls := 0
+	waits := 0
+	result, err := provisionMachineWithRetry(
+		context.Background(),
+		func() (providers.ProvisionMachineResult, error) {
+			calls++
+			return providers.ProvisionMachineResult{ProviderResourceID: "resource-1"}, providerErr
+		},
+		func(context.Context, time.Duration) error {
+			waits++
+			return nil
+		},
+	)
+	if !errors.Is(err, providerErr) {
+		t.Fatalf("provision error = %v, want %v", err, providerErr)
+	}
+	if calls != providerProvisionRetryAttempts || waits != providerProvisionRetryAttempts-1 {
+		t.Fatalf("provision calls/waits = %d/%d, want %d/%d", calls, waits, providerProvisionRetryAttempts, providerProvisionRetryAttempts-1)
+	}
+	if result.ProviderResourceID != "resource-1" {
+		t.Fatalf("provision result = %+v, want observed resource", result)
+	}
+}
+
+func TestProvisionMachineWithRetryHonorsProviderDelay(t *testing.T) {
+	providerErr := providers.WithRetryAfter(
+		errors.New("rate limited"),
+		http.Header{"Retry-After": []string{"12"}},
+	)
+	calls := 0
+	var delay time.Duration
+	_, err := provisionMachineWithRetry(
+		context.Background(),
+		func() (providers.ProvisionMachineResult, error) {
+			calls++
+			if calls == 1 {
+				return providers.ProvisionMachineResult{}, providerErr
+			}
+			return providers.ProvisionMachineResult{ProviderResourceID: "resource-1"}, nil
+		},
+		func(_ context.Context, got time.Duration) error {
+			delay = got
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("provision with retry-after: %v", err)
+	}
+	if delay != 12*time.Second {
+		t.Fatalf("retry delay = %s, want 12s", delay)
+	}
+}
+
+func TestProvisionMachineWithRetryRejectsConflictingResources(t *testing.T) {
+	calls := 0
+	result, err := provisionMachineWithRetry(
+		context.Background(),
+		func() (providers.ProvisionMachineResult, error) {
+			calls++
+			if calls == 1 {
+				return providers.ProvisionMachineResult{ProviderResourceID: "resource-1"}, errors.New("ambiguous failure")
+			}
+			return providers.ProvisionMachineResult{ProviderResourceID: "resource-2"}, nil
+		},
+		func(context.Context, time.Duration) error { return nil },
+	)
+	if err == nil || !strings.Contains(err.Error(), "conflicting resource ids") {
+		t.Fatalf("provision error = %v, want conflicting resource ids", err)
+	}
+	if result.ProviderResourceID != "resource-1" {
+		t.Fatalf("provision result = %+v, want first observed resource", result)
 	}
 }

--- a/internal/machinepool/manager_test.go
+++ b/internal/machinepool/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -361,6 +362,35 @@ func TestProviderProvisionRetryDelayHonorsRetryAfter(t *testing.T) {
 	}
 	if delay := providerProvisionRetryDelay(1, errors.New("provider unavailable")); delay != 2*time.Second {
 		t.Fatalf("retry delay = %s, want 2s", delay)
+	}
+}
+
+func TestProvisionMachineWithRetryDiscardsReplacedResource(t *testing.T) {
+	stubProvisionRetryDelays(t)
+	calls := 0
+	result, err := provisionWithRetryForTest(
+		context.Background(),
+		func() (providers.ProvisionMachineResult, error) {
+			calls++
+			switch calls {
+			case 1:
+				return providers.ProvisionMachineResult{ProviderResourceID: "resource-1"},
+					errors.New("delete stale sandbox: unavailable")
+			case 2:
+				return providers.ProvisionMachineResult{}, fmt.Errorf("sandbox was deleted: %w", providers.ErrResourceReplaced)
+			default:
+				return providers.ProvisionMachineResult{ProviderResourceID: "resource-2"}, nil
+			}
+		},
+	)
+	if err != nil {
+		t.Fatalf("provision after replacement: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("provision calls = %d, want 3", calls)
+	}
+	if result.ProviderResourceID != "resource-2" {
+		t.Fatalf("provision result = %+v, want replaced resource", result)
 	}
 }
 

--- a/internal/machinepool/manager_test.go
+++ b/internal/machinepool/manager_test.go
@@ -259,7 +259,13 @@ func TestProvisionMachineWithRetryExhaustsAttempts(t *testing.T) {
 		t.Fatalf("provision error = %v, want %v", err, providerErr)
 	}
 	if calls != providerProvisionRetryAttempts || waits != providerProvisionRetryAttempts-1 {
-		t.Fatalf("provision calls/waits = %d/%d, want %d/%d", calls, waits, providerProvisionRetryAttempts, providerProvisionRetryAttempts-1)
+		t.Fatalf(
+			"provision calls/waits = %d/%d, want %d/%d",
+			calls,
+			waits,
+			providerProvisionRetryAttempts,
+			providerProvisionRetryAttempts-1,
+		)
 	}
 	if result.ProviderResourceID != "resource-1" {
 		t.Fatalf("provision result = %+v, want observed resource", result)

--- a/internal/machinepool/providers/blaxel/provider.go
+++ b/internal/machinepool/providers/blaxel/provider.go
@@ -171,8 +171,9 @@ func (p *provider) ProvisionMachine(
 			return result, err
 		}
 		return providers.ProvisionMachineResult{}, fmt.Errorf(
-			"blaxel sandbox %q was deleted; provisioning must be retried",
+			"blaxel sandbox %q was deleted; provisioning must be retried: %w",
 			name,
+			providers.ErrResourceReplaced,
 		)
 	}
 	if normalizeSandboxDeploymentStatus(target.Status) != sandboxDeploymentDeployed {

--- a/internal/machinepool/providers/blaxel/provider_test.go
+++ b/internal/machinepool/providers/blaxel/provider_test.go
@@ -383,7 +383,7 @@ func TestBlaxelProviderProvisionReplacesUnusableSandbox(t *testing.T) {
 				"machine-token",
 				nil,
 			)
-			if err == nil || !strings.Contains(err.Error(), "was deleted; provisioning must be retried") {
+			if !errors.Is(err, providers.ErrResourceReplaced) {
 				t.Fatalf("first provision after %s conflict error = %v", status, err)
 			}
 			if len(api.deletedNames) != 1 || api.deletedNames[0] != name ||

--- a/internal/machinepool/providers/daytona/provider.go
+++ b/internal/machinepool/providers/daytona/provider.go
@@ -197,8 +197,9 @@ func (p *provider) ProvisionMachine(
 				return result, err
 			}
 			return providers.ProvisionMachineResult{}, fmt.Errorf(
-				"daytona sandbox %q was deleted; provisioning must be retried",
+				"daytona sandbox %q was deleted; provisioning must be retried: %w",
 				name,
+				providers.ErrResourceReplaced,
 			)
 		}
 		select {

--- a/internal/machinepool/providers/daytona/provider_test.go
+++ b/internal/machinepool/providers/daytona/provider_test.go
@@ -206,7 +206,7 @@ func TestDaytonaProviderProvisionHandlesUnusableSandbox(t *testing.T) {
 			"token",
 			nil,
 		)
-		if err == nil || !strings.Contains(err.Error(), "must be retried") || api.deleteCalls != 1 {
+		if !errors.Is(err, providers.ErrResourceReplaced) || api.deleteCalls != 1 {
 			t.Fatalf("terminal result = error %v deletes %d", err, api.deleteCalls)
 		}
 	})

--- a/internal/machinepool/providers/provider.go
+++ b/internal/machinepool/providers/provider.go
@@ -59,7 +59,8 @@ type Provider interface {
 		context.Context,
 		executionstore.MachineProvisioningConfig,
 	) (executionstore.MachineResourceFacts, error)
-	// ProvisionMachine must be idempotent by installation and machine identity.
+	// ProvisionMachine must be idempotent by installation and machine identity;
+	// the caller may retry it immediately after any error.
 	// Calling it is the external side-effect boundary and must be recorded durably first.
 	// Retries for the same machine must converge on one canonical live provider
 	// resource, usually by using a deterministic allocation name. A provider must

--- a/internal/machinepool/providers/provider.go
+++ b/internal/machinepool/providers/provider.go
@@ -30,6 +30,11 @@ type ProvisionMachineResult struct {
 	SandboxURL         string
 }
 
+// ErrResourceReplaced signals that the provider deleted a replaceable resource
+// and any previously observed resource id is stale; the next retry may observe
+// a different id for the same machine.
+var ErrResourceReplaced = errors.New("provider resource was replaced")
+
 type WakeMachineInput struct {
 	ProviderResourceID string
 	SandboxURL         string
@@ -66,6 +71,8 @@ type Provider interface {
 	// resource, usually by using a deterministic allocation name. A provider must
 	// not create more than one live sandbox for one Omnara machine. The result must
 	// include any trusted resource id observed before a later readiness error.
+	// After deleting a replaceable resource the provider must return an error
+	// wrapping ErrResourceReplaced so callers discard previously observed ids.
 	// machineEnv is the machine's resolved environment and is applied to the
 	// provider resource at creation; retries that adopt an existing resource
 	// keep the environment it was created with.


### PR DESCRIPTION
## Summary
- retry idempotent machine provider provisioning up to three times before entering the durable reconciliation failure path
- use bounded backoff and honor provider `Retry-After` hints
- preserve provider resource observations across ambiguous failures and reject conflicting resource identities

## Tests
- `GOTOOLCHAIN=auto go test ./internal/machinepool ./internal/machinepool/providers/blaxel ./internal/machinepool/providers/daytona ./internal/machinepool/providers/unikraft`
