### PR TITLE
fix: Fix incorrectly reported conflict error for grants

### DIFF
--- a/internal/storage/executionstore/machine_pool_grants_integration_test.go
+++ b/internal/storage/executionstore/machine_pool_grants_integration_test.go
@@ -830,6 +830,14 @@ func TestMachineConfigEnvRejectsReservedOmnaraNamespace(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("create valid pool grant: %v", err)
 	}
+	if _, err := store.Execution().CreateProjectMachinePoolGrant(ctx, executionstore.CreateProjectMachinePoolGrantInput{
+		OrgID:          testOrgID,
+		ProjectID:      testProjectID,
+		MachinePoolID:  machinePool.ID,
+		IdempotencyKey: "idem-duplicate-pool-grant",
+	}); !errors.Is(err, storeerr.ErrConflict) {
+		t.Fatalf("duplicate pool grant error = %v, want ErrConflict", err)
+	}
 	compiled := mustCompileAgentYAMLWithMachineSourceResolvers(t, ctx, store, `
 instruction: Use the pool.
 model:

--- a/internal/storage/executionstore/project_machine_pool_grants_store.go
+++ b/internal/storage/executionstore/project_machine_pool_grants_store.go
@@ -486,7 +486,9 @@ func (s *Store) CreateProjectMachinePoolGrant(
 					poolErr,
 				)
 			}
-			return ProjectMachinePoolGrantRecord{}, storeerr.ErrIdempotencyConflict
+			return ProjectMachinePoolGrantRecord{}, storeerr.Tag(storeerr.ErrConflict, errors.New(
+				"a grant for this machine pool already exists on this project",
+			))
 		}
 		if storeutil.IsUniqueViolation(err) {
 			return ProjectMachinePoolGrantRecord{}, storeerr.ErrIdempotencyConflict

--- a/internal/storage/model_provider_configs_integration_test.go
+++ b/internal/storage/model_provider_configs_integration_test.go
@@ -805,8 +805,8 @@ model:
 		ConfiguredModelID:      configuredModel.ID,
 		MaxOutputTokens:        intPtr(48000),
 		DefaultMaxOutputTokens: intPtr(24000),
-	}); !errors.Is(err, storeerr.ErrIdempotencyConflict) {
-		t.Fatalf("conflicting project model grant replay error = %v, want ErrIdempotencyConflict", err)
+	}); !errors.Is(err, storeerr.ErrConflict) {
+		t.Fatalf("conflicting project model grant replay error = %v, want ErrConflict", err)
 	}
 	if _, err := pool.Exec(ctx, `
 		INSERT INTO project_model_grants(

--- a/internal/storage/modelstore/project_model_grants_store.go
+++ b/internal/storage/modelstore/project_model_grants_store.go
@@ -75,10 +75,9 @@ func (s *Store) CreateProjectModelGrant(
 	}
 	record := projectModelGrantRecordFromUpsertSQLC(row)
 	if !sameProjectModelGrantIntent(record, input) {
-		return ProjectModelGrantRecord{}, fmt.Errorf(
-			"an active project grant for this configured model already exists with a different configuration: %w",
-			storeerr.ErrIdempotencyConflict,
-		)
+		return ProjectModelGrantRecord{}, storeerr.Tag(storeerr.ErrConflict, errors.New(
+			"an active project grant for this configured model already exists with a different configuration",
+		))
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return ProjectModelGrantRecord{}, fmt.Errorf("commit create project model grant: %w", err)


### PR DESCRIPTION
We incorrectly report conflict errors as idempotency conflicts on grants. We should instead just report them as normal conflicts.