### PR TITLE
fix: prompt users to select an OAuth account

### DIFF
--- a/internal/httpapi/auth/oauth_routes.go
+++ b/internal/httpapi/auth/oauth_routes.go
@@ -27,6 +27,7 @@ const (
 	oauthFlowCookieTTL        = 10 * time.Minute
 	oauthLoginRateLimit       = 30
 	oauthLoginClientRateLimit = 120
+	googleOIDCIssuer          = "https://accounts.google.com"
 )
 
 func (h *Handler) connectorLoginRoute(w http.ResponseWriter, r *http.Request) {
@@ -91,6 +92,10 @@ func (h *Handler) startExternalLogin(w http.ResponseWriter, r *http.Request, slu
 		return
 	}
 	options := []oauth2.AuthCodeOption{oauth2.S256ChallengeOption(codeVerifier)}
+	if connector.Kind == identitystore.AuthConnectorKindGitHub ||
+		(connector.Kind == identitystore.AuthConnectorKindOIDC && connector.Issuer == googleOIDCIssuer) {
+		options = append(options, oauth2.SetAuthURLParam("prompt", "select_account"))
+	}
 	if connector.Kind == identitystore.AuthConnectorKindOIDC {
 		options = append(options, oauth2.SetAuthURLParam("nonce", nonce))
 	}
@@ -301,7 +306,7 @@ func (h *Handler) oidcIdentity(
 		}
 	}
 	emailVerified := claims.EmailVerified != nil && *claims.EmailVerified
-	if emailVerified && connector.Issuer == "https://accounts.google.com" {
+	if emailVerified && connector.Issuer == googleOIDCIssuer {
 		emailVerified = googleEmailAuthoritative(claims.Email, claims.HostedDomain)
 	}
 	return externalIdentity{

--- a/internal/httpapi/public_api_identity_workflow_integration_test.go
+++ b/internal/httpapi/public_api_identity_workflow_integration_test.go
@@ -2510,6 +2510,9 @@ func TestOAuthLoginGitHubConnectorMintsBrowserSessionAndRejectsReplay(t *testing
 	if err != nil {
 		t.Fatalf("parse cancel authorization URL: %v", err)
 	}
+	if got := authorizationURL.Query().Get("prompt"); got != "select_account" {
+		t.Fatalf("authorization prompt = %q, want select_account", got)
+	}
 	cancelState := authorizationURL.Query().Get("state")
 	if cancelState == "" {
 		t.Fatal("cancel authorization URL missing state")


### PR DESCRIPTION
## Summary
Before, a user couldn't select a google or github account to login with if they only had been logged into one account. It would automatically redirect them to app.omnara.com without account selection.

- request the account chooser for Google and GitHub sign-ins
- leave other OIDC connectors unchanged
- verify the GitHub authorization redirect includes `prompt=select_account`
