### PR TITLE
feat: improve Slack message context and rendering

### DIFF
--- a/internal/httpapi/integration_event_routes_integration_test.go
+++ b/internal/httpapi/integration_event_routes_integration_test.go
@@ -2071,7 +2071,7 @@ func TestSlackEventsDelayedFileShareCreatesNeutralArtifactInput(t *testing.T) {
 		ctx,
 		pool,
 		input,
-		"This message was posted in a Slack thread that is already attached to this agent. It may be part of the ongoing conversation even if it does not directly mention the agent.\n\n"+
+		"This Slack thread may include multiple participants, and not every message is necessarily directed at you. Use your judgment to decide whether to call `send_integration_message` at all.\n\n"+
 			"<@U123> (Ada) in <#CDELAY> (#delayed), thread 222.333:\n"+
 			"Files for the previous Slack message.",
 		[]bool{true, true},

--- a/internal/integration/slack/events.go
+++ b/internal/integration/slack/events.go
@@ -20,6 +20,7 @@ var (
 	userMentionPattern      = regexp.MustCompile(`<@([^>|]+)(?:\|([^>]+))?>`)
 	channelMentionPattern   = regexp.MustCompile(`<#([^>|]+)(?:\|([^>]+))?>`)
 	broadcastMentionPattern = regexp.MustCompile(`<!((?:here|channel|everyone))(?:\|[^>]*)?>`)
+	slackTextEntityReplacer = strings.NewReplacer("&amp;", "&", "&lt;", "<", "&gt;", ">")
 )
 
 type Identity struct {
@@ -466,7 +467,7 @@ func routeThreadTS(route InboundRoute) string {
 func modelVisibleContext(event Event, route InboundRoute, newlyMapped bool) string {
 	switch {
 	case route.AppendOnly:
-		return "This message was posted in a Slack thread that is already attached to this agent. It may be part of the ongoing conversation even if it does not directly mention the agent."
+		return "This Slack thread may include multiple participants, and not every message is necessarily directed at you. Use your judgment to decide whether to call `send_integration_message` at all."
 	case event.Type == "app_mention" && event.ThreadTS != "" && event.ThreadTS != event.TS:
 		if newlyMapped {
 			return "This message directly mentioned the agent inside an existing Slack thread."
@@ -539,13 +540,14 @@ func (labels DisplayLabels) renderText(text string, includeIDs bool) string {
 		}
 		return raw
 	})
-	return broadcastMentionPattern.ReplaceAllStringFunc(text, func(raw string) string {
+	text = broadcastMentionPattern.ReplaceAllStringFunc(text, func(raw string) string {
 		match := broadcastMentionPattern.FindStringSubmatch(raw)
 		if len(match) < 2 {
 			return raw
 		}
 		return "@" + match[1]
 	})
+	return slackTextEntityReplacer.Replace(text)
 }
 
 func userReference(userID, displayName string) string {

--- a/internal/integration/slack/events_test.go
+++ b/internal/integration/slack/events_test.go
@@ -95,9 +95,9 @@ func TestModelInputTextPartsIncludeSlackContext(t *testing.T) {
 			},
 			route:       InboundRoute{ProviderRef: "C123:111.222", ProviderRefKind: "thread", AppendOnly: true},
 			wantMessage: "one more thing",
-			wantHidden: "This message was posted in a Slack thread that is already attached " +
-				"to this agent. It may be part of the ongoing conversation even if it does not " +
-				"directly mention the agent.\n\n" +
+			wantHidden: "This Slack thread may include multiple participants, and not every " +
+				"message is necessarily directed at you. Use your judgment to decide whether to call " +
+				"`send_integration_message` at all.\n\n" +
 				"<@U123> (Ada) in <#C123>, thread 111.222:\n",
 		},
 		{
@@ -278,6 +278,27 @@ func TestRenderTextRendersSlackBroadcastMentions(t *testing.T) {
 	want := "@here @channel @everyone @here <!subteam^S123|team> <!date^123^{date}|jan>"
 	if got != want {
 		t.Fatalf("RenderText = %q, want %q", got, want)
+	}
+}
+
+func TestRenderTextDecodesSlackEntities(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{name: "ampersand", text: "fish &amp; chips", want: "fish & chips"},
+		{name: "less than", text: "1 &lt; 2", want: "1 < 2"},
+		{name: "greater than", text: "2 &gt; 1", want: "2 > 1"},
+		{name: "one pass", text: "&amp;gt;", want: "&gt;"},
+		{name: "escaped mention", text: "&lt;@U123|Ada&gt;", want: "<@U123|Ada>"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := (DisplayLabels{}).RenderText(test.text); got != test.want {
+				t.Fatalf("RenderText(%q) = %q, want %q", test.text, got, test.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
- tell agents that attached Slack threads may contain multiple participants and let them decide whether to respond with `send_integration_message`
- decode Slack’s documented `&amp;`, `&lt;`, and `&gt;` entities after mention rendering while preserving one-pass behavior

basically the decoding avoids this:
<img width="721" height="158" alt="image" src="https://github.com/user-attachments/assets/a865a532-1833-49ab-bee7-3a58e45d343d" />
