### PR TITLE
fix: include BYO machines in machine observation tools

### DIFF
--- a/docs/machines/overview.mdx
+++ b/docs/machines/overview.mdx
@@ -27,11 +27,11 @@ The [mounted storage example](/examples/mounted-storage) is the canonical BYO st
 Every machine reports two independent states:
 
 - **`lifecycle_state`** tracks whether the machine is being provisioned, active, being deleted, or deleted. It also reports provisioning and deletion failures.
-- **`connection_state`** reports whether its daemon is currently `online` or `offline`.
+- **`connection_state`** reports whether the machine is currently `online`, `asleep`, or `offline`.
 
 An `active` machine can be `offline`, for example when someone closes a laptop. New commands fail with a retryable error. A process may continue on the machine, but the agent cannot interact with it until the daemon reconnects. After a grace period, tool calls waiting on that process return a retryable `machine_unreachable` result.
 
-A machine is available to an agent only when its binding is attached, its lifecycle is `active`, and its daemon is `online`. The [`inspect_machine`](/tools/built-in#list_machines--inspect_machine) tool reports this as `executable`.
+A machine is available to an agent only when its binding is attached, its project grant still exists, its lifecycle is `active`, and its daemon is `online` or the machine is asleep and can be woken. The [`inspect_machine`](/tools/built-in#list_machines--inspect_machine) tool reports this as `executable`.
 
 ## Who may use a machine
 

--- a/docs/tools/built-in.mdx
+++ b/docs/tools/built-in.mdx
@@ -145,7 +145,7 @@ Agents remain observable when machine state changes:
 
 ## Machines
 
-These tools let an agent inspect, create, and delete its pool-backed machines. Its [config](/agents/configuration#machines) and [pool grants](/machines/pools) determine which pools it can use and how many machines it can create.
+These tools let an agent inspect its BYO and pool-backed machines, and create or delete pool-backed machines. Its [config](/agents/configuration#machines) and [machine or pool grants](/machines/overview#who-may-use-a-machine) determine which machines it can use and how many pool-backed machines it can create.
 
 ### `create_machine`
 
@@ -157,7 +157,7 @@ Deletes a pool-backed machine. Requires `machine_ref`.
 
 ### `list_machines` / `inspect_machine`
 
-`list_machines` lists the agent's pool-backed machines. `inspect_machine` shows whether a specific pool-backed machine is online and ready to run commands; provide `machine_ref` when the agent has more than one.
+`list_machines` lists the agent's BYO and pool-backed machines. `inspect_machine` shows whether a specific machine is ready to run commands; provide `machine_ref` when the agent has more than one. Results identify the machine's `source_kind` and `binding_kind`; only pool bindings can be passed to `delete_machine`.
 
 ## Integrations
 

--- a/internal/harness/tools/machine_execution_target_integration_test.go
+++ b/internal/harness/tools/machine_execution_target_integration_test.go
@@ -192,6 +192,203 @@ func TestResolveMachineExecutionTargetUsesMachineRefSelection(t *testing.T) {
 	_ = secondAgentBinding
 }
 
+func TestMachineObservationToolsIncludeAttachedBYOMachine(t *testing.T) {
+	ctx := context.Background()
+	fixture := newMachineDispatchFixture(t, ctx, "observe-byo")
+	byo := createExecutableBinding(
+		t,
+		ctx,
+		fixture.Store,
+		fixture.UserID,
+		"observe-byo",
+		fixture.Now.Add(5*time.Second),
+	)
+	machineRef := "mchr-byo001"
+	if _, err := fixture.Pool.Exec(
+		ctx,
+		`INSERT INTO agent_machine_bindings(
+		   org_id, project_id, agent_id, machine_id, machine_ref, binding_kind, state,
+		   description, cwd, created_at, updated_at
+		 )
+		 VALUES ($1, $2, $3, $4, $5, 'explicit', 'attached', $6, $7, $8, $8)`,
+		toolsTestOrgID,
+		toolsTestProjectID,
+		fixture.Launch.Agent.ID,
+		byo.MachineID,
+		machineRef,
+		"local checkout",
+		"/checkout",
+		fixture.Now.Add(6*time.Second),
+	); err != nil {
+		t.Fatalf("attach BYO machine: %v", err)
+	}
+
+	listCall := model.ToolCall{ID: "call_observe-byo-list", Name: "list_machines", Input: json.RawMessage(`{}`)}
+	inspectCall := model.ToolCall{ID: "call_observe-byo-inspect", Name: "inspect_machine", Input: json.RawMessage(`{}`)}
+	mixedInspectCall := model.ToolCall{
+		ID:    "call_observe-byo-mixed-inspect",
+		Name:  "inspect_machine",
+		Input: json.RawMessage(`{}`),
+	}
+	createPoolCall := model.ToolCall{ID: "call_observe-byo-create-pool", Name: "create_machine", Input: json.RawMessage(`{}`)}
+	toolCalls, lock, admitted, contextRecord := recordMachineToolCallsForDirectStoreTest(
+		t,
+		ctx,
+		fixture.Store,
+		fixture.Launch.Agent.ID,
+		fixture.UserID,
+		fixture.Config.ID,
+		"observe-byo",
+		[]model.ToolCall{listCall, inspectCall, mixedInspectCall, createPoolCall},
+		fixture.Now.Add(7*time.Second),
+	)
+	for _, index := range []int{0, 3} {
+		if _, err := fixture.Store.Execution().MarkToolCallReady(
+			ctx,
+			executionstore.MarkToolCallReadyInput{
+				ProjectID:     toolsTestProjectID,
+				AgentID:       fixture.Launch.Agent.ID,
+				ID:            toolCalls[index].ID,
+				RuntimeLockID: lock.ID,
+			},
+		); err != nil {
+			t.Fatalf("allow %s: %v", toolCalls[index].ProviderCallID, err)
+		}
+	}
+	turn := Turn{
+		ProjectID:          toolsTestProjectID,
+		AgentID:            fixture.Launch.Agent.ID,
+		SourceEventID:      admitted.Events[0].ID,
+		RuntimeLockID:      lock.ID,
+		ModelCallContextID: contextRecord.ID,
+		Tools: map[string]ToolSpec{
+			"list_machines": {
+				Permission: toolpermission.DefaultSelection(toolpermission.ModeAlwaysAllow),
+			},
+			"inspect_machine": {
+				Permission: toolpermission.DefaultSelection(toolpermission.ModeAlwaysAsk),
+			},
+		},
+	}
+	executor := Executor{
+		Store: fixture.Store,
+		Now:   func() time.Time { return fixture.Now.Add(8 * time.Second) },
+	}
+	if err := executor.PrepareToolCallPermission(ctx, turn, inspectCall); err != nil {
+		t.Fatalf("prepare inspect_machine permission: %v", err)
+	}
+
+	listResult, err := executor.Dispatch(ctx, turn, listCall)
+	if err != nil {
+		t.Fatalf("dispatch list_machines: %v", err)
+	}
+	listBody := toolResultMapFromTestParts(t, listResult.ContentParts)
+	machines, ok := listBody["machines"].([]any)
+	if !ok || len(machines) != 1 {
+		t.Fatalf("list_machines result = %+v, want one machine", listBody)
+	}
+	listed, ok := machines[0].(map[string]any)
+	if !ok {
+		t.Fatalf("list_machines entry = %+v", machines[0])
+	}
+	assertBYOMachineObservationResult(t, listed, machineRef, byo.DisplayName)
+
+	interaction, found, err := fixture.Store.Execution().GetAgentInteractionByToolCallKind(
+		ctx,
+		toolsTestProjectID,
+		fixture.Launch.Agent.ID,
+		toolCalls[1].ID,
+		"permission",
+	)
+	if err != nil {
+		t.Fatalf("load inspect_machine permission: %v", err)
+	}
+	if !found {
+		t.Fatal("inspect_machine permission interaction not found")
+	}
+	resolvedBy, err := executionstore.OmnaraActorParams(
+		toolsTestOrgID,
+		toolsTestUserPrincipal(fixture.UserID),
+	)
+	if err != nil {
+		t.Fatalf("build inspect_machine permission actor: %v", err)
+	}
+	if _, err := fixture.Store.Execution().ResolveAgentInteraction(
+		ctx,
+		executionstore.ResolveAgentInteractionInput{
+			ProjectID: toolsTestProjectID,
+			AgentID:   fixture.Launch.Agent.ID,
+			ID:        interaction.ID,
+			Resolution: interactionform.Resolution{
+				Answers: []interactionform.Answer{{
+					OptionIndices: []int{toolpermission.AllowOptionIndex},
+				}},
+			},
+			Actor: resolvedBy,
+		},
+	); err != nil {
+		t.Fatalf("approve inspect_machine permission: %v", err)
+	}
+	executor.Now = func() time.Time { return fixture.Now.Add(9 * time.Second) }
+	inspectResult, err := executor.Dispatch(ctx, turn, inspectCall)
+	if err != nil {
+		t.Fatalf("dispatch inspect_machine: %v", err)
+	}
+	inspected := toolResultMapFromTestParts(t, inspectResult.ContentParts)
+	assertBYOMachineObservationResult(t, inspected, machineRef, byo.DisplayName)
+
+	if _, err := storagetest.ExecuteToolCallCommand[executionstore.CreatePoolMachineResult](
+		ctx,
+		fixture.Store,
+		executionstore.ExecuteToolCallInput{
+			ProjectID:     toolsTestProjectID,
+			AgentID:       fixture.Launch.Agent.ID,
+			ToolCallID:    toolCalls[3].ID,
+			RuntimeLockID: lock.ID,
+		},
+		executionstore.CreatePoolMachineForToolCall(
+			executionstore.CreatePoolMachineInput{MachinePoolID: fixture.MachinePool.ID},
+			func(executionstore.CreatePoolMachineResult) (executionstore.ToolCallCompletionInput, error) {
+				return executionstore.ToolCallCompletionInput{
+					Outcome:            executionstore.ToolResultOutcomeSucceeded,
+					ResultContentParts: json.RawMessage(`[{"type":"text","text":"accepted"}]`),
+				}, nil
+			},
+		),
+	); err != nil {
+		t.Fatalf("create pool machine for mixed observation: %v", err)
+	}
+	if err := executor.PrepareToolCallPermission(ctx, turn, mixedInspectCall); err != nil {
+		t.Fatalf("prepare mixed-source inspect_machine permission: %v", err)
+	}
+	mixedResult, err := executor.Dispatch(ctx, turn, mixedInspectCall)
+	if err != nil {
+		t.Fatalf("dispatch mixed-source inspect_machine: %v", err)
+	}
+	mixedBody := toolResultMapFromTestParts(t, mixedResult.ContentParts)
+	if mixedBody["error_code"] != ErrMachineSelectionRequired.Error() ||
+		mixedBody["error"] != "machine_ref is required when multiple machines are available" {
+		t.Fatalf("mixed-source inspect_machine result = %+v", mixedBody)
+	}
+}
+
+func assertBYOMachineObservationResult(
+	t *testing.T,
+	result map[string]any,
+	machineRef, displayName string,
+) {
+	t.Helper()
+	if result["machine_ref"] != machineRef || result["source_kind"] != "byo" ||
+		result["binding_kind"] != "explicit" || result["binding_state"] != "attached" ||
+		result["display_name"] != displayName || result["cwd"] != "/checkout" ||
+		result["connection_state"] != "online" || result["executable"] != true {
+		t.Fatalf("BYO machine observation = %+v", result)
+	}
+	if _, found := result["machine_pool_name"]; found {
+		t.Fatalf("BYO machine observation includes machine_pool_name: %+v", result)
+	}
+}
+
 func TestApprovedImplicitMachineTargetChangeFailsTerminally(t *testing.T) {
 	ctx := context.Background()
 	fixture := newMachineDispatchFixture(t, ctx, "approved-machine-target-change")

--- a/internal/harness/tools/machine_execution_target_integration_test.go
+++ b/internal/harness/tools/machine_execution_target_integration_test.go
@@ -203,25 +203,58 @@ func TestMachineObservationToolsIncludeAttachedBYOMachine(t *testing.T) {
 		"observe-byo",
 		fixture.Now.Add(5*time.Second),
 	)
-	machineRef := "mchr-byo001"
-	if _, err := fixture.Pool.Exec(
+	sourceYAML := `instruction: Test BYO machine observation.
+model:
+  provider_config: openai-prod
+  name: tools-test
+machine_sources:
+  - machine_name: ` + byo.DisplayName + `
+    cwd: /checkout
+    description: local checkout
+  - machine_pool_name: ` + fixture.MachinePool.Name + `
+    max_machines: 1
+    initial_num_machines: 0
+tools:
+  create_machine: {}
+  list_machines: {}
+  inspect_machine: {}
+`
+	compiled := compileToolsAgentYAMLResolved(
+		t,
 		ctx,
-		`INSERT INTO agent_machine_bindings(
-		   org_id, project_id, agent_id, machine_id, machine_ref, binding_kind, state,
-		   description, cwd, created_at, updated_at
-		 )
-		 VALUES ($1, $2, $3, $4, $5, 'explicit', 'attached', $6, $7, $8, $8)`,
-		toolsTestOrgID,
-		toolsTestProjectID,
-		fixture.Launch.Agent.ID,
-		byo.MachineID,
-		machineRef,
-		"local checkout",
-		"/checkout",
+		fixture.Store,
+		fixture.UserID,
+		sourceYAML,
 		fixture.Now.Add(6*time.Second),
-	); err != nil {
-		t.Fatalf("attach BYO machine: %v", err)
+	)
+	config, err := fixture.Store.Execution().CreateAgentConfig(ctx, executionstore.CreateAgentConfigInput{
+		ProjectID:               toolsTestProjectID,
+		Definition:              json.RawMessage(compiled.CanonicalJSON),
+		Source:                  sourceYAML,
+		SourceFormat:            "yaml",
+		ConfiguredModelID:       parseConfiguredModelID(t, compiled),
+		CompiledDefinition:      json.RawMessage(compiled.CanonicalJSON),
+		CompilerVersion:         agentconfig.CompilerVersion,
+		EffectiveDefinitionHash: compiled.Hash,
+	})
+	if err != nil {
+		t.Fatalf("create BYO observation config: %v", err)
 	}
+	launch, err := fixture.Store.Execution().LaunchAgent(ctx, executionstore.LaunchAgentInput{
+		ProjectID:      toolsTestProjectID,
+		AgentConfigID:  config.ID,
+		LaunchedBy:     toolsTestUserPrincipal(fixture.UserID),
+		IdempotencyKey: "tools-machine-observation-launch-observe-byo",
+	})
+	if err != nil {
+		t.Fatalf("launch BYO observation agent: %v", err)
+	}
+	if len(launch.MachineBindings) != 1 ||
+		launch.MachineBindings[0].MachineID != byo.MachineID ||
+		launch.MachineBindings[0].BindingKind != executionstore.MachineBindingKindExplicit {
+		t.Fatalf("BYO observation launch bindings = %+v", launch.MachineBindings)
+	}
+	machineRef := launch.MachineBindings[0].MachineRef
 
 	listCall := model.ToolCall{ID: "call_observe-byo-list", Name: "list_machines", Input: json.RawMessage(`{}`)}
 	inspectCall := model.ToolCall{ID: "call_observe-byo-inspect", Name: "inspect_machine", Input: json.RawMessage(`{}`)}
@@ -231,23 +264,28 @@ func TestMachineObservationToolsIncludeAttachedBYOMachine(t *testing.T) {
 		Input: json.RawMessage(`{}`),
 	}
 	createPoolCall := model.ToolCall{ID: "call_observe-byo-create-pool", Name: "create_machine", Input: json.RawMessage(`{}`)}
+	alwaysAllowMixedInspectCall := model.ToolCall{
+		ID:    "call_observe-byo-always-allow-mixed-inspect",
+		Name:  "inspect_machine",
+		Input: json.RawMessage(`{}`),
+	}
 	toolCalls, lock, admitted, contextRecord := recordMachineToolCallsForDirectStoreTest(
 		t,
 		ctx,
 		fixture.Store,
-		fixture.Launch.Agent.ID,
+		launch.Agent.ID,
 		fixture.UserID,
-		fixture.Config.ID,
+		config.ID,
 		"observe-byo",
-		[]model.ToolCall{listCall, inspectCall, mixedInspectCall, createPoolCall},
+		[]model.ToolCall{listCall, inspectCall, mixedInspectCall, createPoolCall, alwaysAllowMixedInspectCall},
 		fixture.Now.Add(7*time.Second),
 	)
-	for _, index := range []int{0, 3} {
+	for _, index := range []int{0, 3, 4} {
 		if _, err := fixture.Store.Execution().MarkToolCallReady(
 			ctx,
 			executionstore.MarkToolCallReadyInput{
 				ProjectID:     toolsTestProjectID,
-				AgentID:       fixture.Launch.Agent.ID,
+				AgentID:       launch.Agent.ID,
 				ID:            toolCalls[index].ID,
 				RuntimeLockID: lock.ID,
 			},
@@ -257,7 +295,7 @@ func TestMachineObservationToolsIncludeAttachedBYOMachine(t *testing.T) {
 	}
 	turn := Turn{
 		ProjectID:          toolsTestProjectID,
-		AgentID:            fixture.Launch.Agent.ID,
+		AgentID:            launch.Agent.ID,
 		SourceEventID:      admitted.Events[0].ID,
 		RuntimeLockID:      lock.ID,
 		ModelCallContextID: contextRecord.ID,
@@ -296,7 +334,7 @@ func TestMachineObservationToolsIncludeAttachedBYOMachine(t *testing.T) {
 	interaction, found, err := fixture.Store.Execution().GetAgentInteractionByToolCallKind(
 		ctx,
 		toolsTestProjectID,
-		fixture.Launch.Agent.ID,
+		launch.Agent.ID,
 		toolCalls[1].ID,
 		"permission",
 	)
@@ -317,7 +355,7 @@ func TestMachineObservationToolsIncludeAttachedBYOMachine(t *testing.T) {
 		ctx,
 		executionstore.ResolveAgentInteractionInput{
 			ProjectID: toolsTestProjectID,
-			AgentID:   fixture.Launch.Agent.ID,
+			AgentID:   launch.Agent.ID,
 			ID:        interaction.ID,
 			Resolution: interactionform.Resolution{
 				Answers: []interactionform.Answer{{
@@ -342,7 +380,7 @@ func TestMachineObservationToolsIncludeAttachedBYOMachine(t *testing.T) {
 		fixture.Store,
 		executionstore.ExecuteToolCallInput{
 			ProjectID:     toolsTestProjectID,
-			AgentID:       fixture.Launch.Agent.ID,
+			AgentID:       launch.Agent.ID,
 			ToolCallID:    toolCalls[3].ID,
 			RuntimeLockID: lock.ID,
 		},
@@ -369,6 +407,25 @@ func TestMachineObservationToolsIncludeAttachedBYOMachine(t *testing.T) {
 	if mixedBody["error_code"] != ErrMachineSelectionRequired.Error() ||
 		mixedBody["error"] != "machine_ref is required when multiple machines are available" {
 		t.Fatalf("mixed-source inspect_machine result = %+v", mixedBody)
+	}
+	alwaysAllowTurn := turn
+	alwaysAllowTurn.Tools = map[string]ToolSpec{
+		"inspect_machine": {
+			Permission: toolpermission.DefaultSelection(toolpermission.ModeAlwaysAllow),
+		},
+	}
+	executor.Now = func() time.Time { return fixture.Now.Add(10 * time.Second) }
+	alwaysAllowMixedResult, err := executor.Dispatch(ctx, alwaysAllowTurn, alwaysAllowMixedInspectCall)
+	if err != nil {
+		t.Fatalf("dispatch always-allow mixed-source inspect_machine: %v", err)
+	}
+	alwaysAllowMixedBody := toolResultMapFromTestParts(t, alwaysAllowMixedResult.ContentParts)
+	if !reflect.DeepEqual(alwaysAllowMixedBody, mixedBody) {
+		t.Fatalf(
+			"always-allow mixed-source inspect_machine result = %+v, want %+v",
+			alwaysAllowMixedBody,
+			mixedBody,
+		)
 	}
 }
 

--- a/internal/harness/tools/machine_tools.go
+++ b/internal/harness/tools/machine_tools.go
@@ -221,9 +221,15 @@ func inspectMachine(
 		}
 	}
 	if err != nil {
+		if errors.Is(err, ErrMachineSelectionRequired) {
+			unavailable, resultErr := machineUnavailableToolResult(err)
+			if resultErr != nil {
+				return nil, resultErr
+			}
+			return failInTransaction(unavailable.Content, unavailable.Cause), nil
+		}
 		if !errors.Is(err, storeerr.ErrNotFound) &&
-			!errors.Is(err, ErrNoMachine) &&
-			!errors.Is(err, ErrMachineSelectionRequired) {
+			!errors.Is(err, ErrNoMachine) {
 			return nil, err
 		}
 		return failMachineTransaction("inspect_machine_failed", err, false)
@@ -449,6 +455,7 @@ type machineObservationPayload struct {
 	Description            string    `json:"description"`
 	Cwd                    string    `json:"cwd"`
 	Executable             bool      `json:"executable"`
+	ProjectGrantMissing    bool      `json:"project_grant_missing,omitempty"`
 	LifecycleReasonCode    string    `json:"lifecycle_reason_code"`
 	LifecycleReasonMessage string    `json:"lifecycle_reason_message"`
 	CreatedAt              time.Time `json:"created_at"`
@@ -503,7 +510,10 @@ func machineObservation(record executionstore.PoolMachineRecord) machineObservat
 	}
 	return machineObservationPayload{
 		MachineRef:             record.Binding.MachineRef,
+		SourceKind:             string(record.Machine.SourceKind),
+		BindingKind:            string(record.Binding.BindingKind),
 		BindingState:           string(record.Binding.State),
+		DisplayName:            record.Machine.DisplayName,
 		MachinePoolName:        record.MachinePoolName,
 		LifecycleState:         string(record.Machine.LifecycleState),
 		ConnectionState:        string(record.Machine.ConnectionState),
@@ -521,33 +531,41 @@ func machineObservation(record executionstore.PoolMachineRecord) machineObservat
 func agentMachineObservation(
 	record executionstore.AgentMachineObservationRecord,
 ) machineObservationPayload {
-	return machineObservationPayload{
-		MachineRef:             record.MachineRef,
-		SourceKind:             string(record.SourceKind),
-		BindingKind:            string(record.BindingKind),
-		BindingState:           string(record.BindingState),
-		DisplayName:            record.DisplayName,
-		MachinePoolName:        record.MachinePoolName,
-		LifecycleState:         string(record.LifecycleState),
-		ConnectionState:        string(record.ConnectionState),
-		ConnectionStateReason:  record.ConnectionStateReason,
-		Description:            record.Description,
-		Cwd:                    record.Cwd,
-		Executable:             record.Executable,
-		LifecycleReasonCode:    record.LifecycleReasonCode,
-		LifecycleReasonMessage: record.LifecycleReasonMessage,
-		CreatedAt:              record.CreatedAt,
-		UpdatedAt:              record.UpdatedAt,
+	payload := machineObservationPayload{
+		MachineRef:          record.MachineRef,
+		BindingKind:         string(record.BindingKind),
+		BindingState:        string(record.BindingState),
+		Description:         record.Description,
+		Executable:          record.Executable,
+		ProjectGrantMissing: record.ProjectGrantMissing,
+		CreatedAt:           record.BindingCreatedAt,
+		UpdatedAt:           record.BindingUpdatedAt,
 	}
+	if record.ProjectGrantMissing {
+		return payload
+	}
+	payload.SourceKind = string(record.SourceKind)
+	payload.DisplayName = record.DisplayName
+	payload.MachinePoolName = record.MachinePoolName
+	payload.LifecycleState = string(record.LifecycleState)
+	payload.ConnectionState = string(record.ConnectionState)
+	payload.ConnectionStateReason = record.ConnectionStateReason
+	payload.Cwd = record.Cwd
+	payload.LifecycleReasonCode = record.LifecycleReasonCode
+	payload.LifecycleReasonMessage = record.LifecycleReasonMessage
+	return payload
 }
 
 func agentMachineInspection(
 	record executionstore.AgentMachineObservationRecord,
 ) machineInspectionPayload {
-	return machineInspectionPayload{
+	payload := machineInspectionPayload{
 		machineObservationPayload: agentMachineObservation(record),
-		FailureReport:             record.FailureReport,
 	}
+	if !record.ProjectGrantMissing {
+		payload.FailureReport = record.FailureReport
+	}
+	return payload
 }
 
 func machineExecutable(record executionstore.PoolMachineRecord) bool {

--- a/internal/harness/tools/machine_tools.go
+++ b/internal/harness/tools/machine_tools.go
@@ -185,13 +185,13 @@ func listMachines(
 	); err != nil {
 		return nil, err
 	}
-	machines, err := call.Reader.ListPoolMachines(ctx)
+	machines, err := call.Reader.ListAgentMachineObservations(ctx)
 	if err != nil {
 		return nil, err
 	}
 	machineResults := make([]machineObservationPayload, 0, len(machines))
 	for _, machine := range machines {
-		machineResults = append(machineResults, machineObservation(machine))
+		machineResults = append(machineResults, agentMachineObservation(machine))
 	}
 	content, err := structuredToolResultContent(
 		machineListResult{Machines: machineResults},
@@ -210,12 +210,12 @@ func inspectMachine(
 	if err != nil {
 		return nil, err
 	}
-	var record executionstore.PoolMachineRecord
+	var record executionstore.AgentMachineObservationRecord
 	if input.MachineRef != "" {
-		record, err = call.Reader.GetPoolMachineByRef(ctx, input.MachineRef)
+		record, err = call.Reader.GetAgentMachineObservationByRef(ctx, input.MachineRef)
 	} else {
-		var machines []executionstore.PoolMachineRecord
-		machines, err = call.Reader.ListPoolMachines(ctx)
+		var machines []executionstore.AgentMachineObservationRecord
+		machines, err = call.Reader.ListAgentMachineObservations(ctx)
 		if err == nil {
 			record, err = selectOnlyMachine(machines)
 		}
@@ -230,7 +230,7 @@ func inspectMachine(
 	}
 	authorizationInput, err := machineObservationAuthorizationInput(
 		machineObservationInspect,
-		record.Binding.MachineRef,
+		record.MachineRef,
 	)
 	if err != nil {
 		return nil, err
@@ -244,7 +244,7 @@ func inspectMachine(
 	); err != nil {
 		return nil, err
 	}
-	content, err := structuredToolResultContent(machineInspection(record))
+	content, err := structuredToolResultContent(agentMachineInspection(record))
 	if err != nil {
 		return nil, err
 	}
@@ -424,21 +424,25 @@ func resolveMachineRefRequest(raw json.RawMessage, optional bool) (machineRefReq
 	return input, nil
 }
 
-func selectOnlyMachine(machines []executionstore.PoolMachineRecord) (executionstore.PoolMachineRecord, error) {
+func selectOnlyMachine[T any](machines []T) (T, error) {
+	var zero T
 	switch len(machines) {
 	case 0:
-		return executionstore.PoolMachineRecord{}, ErrNoMachine
+		return zero, ErrNoMachine
 	case 1:
 		return machines[0], nil
 	default:
-		return executionstore.PoolMachineRecord{}, ErrMachineSelectionRequired
+		return zero, ErrMachineSelectionRequired
 	}
 }
 
 type machineObservationPayload struct {
 	MachineRef             string    `json:"machine_ref"`
-	MachinePoolName        string    `json:"machine_pool_name"`
+	SourceKind             string    `json:"source_kind,omitempty"`
+	BindingKind            string    `json:"binding_kind,omitempty"`
 	BindingState           string    `json:"binding_state"`
+	DisplayName            string    `json:"display_name,omitempty"`
+	MachinePoolName        string    `json:"machine_pool_name,omitempty"`
 	LifecycleState         string    `json:"lifecycle_state"`
 	ConnectionState        string    `json:"connection_state"`
 	ConnectionStateReason  string    `json:"connection_state_reason,omitempty"`
@@ -499,8 +503,8 @@ func machineObservation(record executionstore.PoolMachineRecord) machineObservat
 	}
 	return machineObservationPayload{
 		MachineRef:             record.Binding.MachineRef,
-		MachinePoolName:        record.MachinePoolName,
 		BindingState:           string(record.Binding.State),
+		MachinePoolName:        record.MachinePoolName,
 		LifecycleState:         string(record.Machine.LifecycleState),
 		ConnectionState:        string(record.Machine.ConnectionState),
 		ConnectionStateReason:  record.Machine.ConnectionStateReason,
@@ -514,9 +518,34 @@ func machineObservation(record executionstore.PoolMachineRecord) machineObservat
 	}
 }
 
-func machineInspection(record executionstore.PoolMachineRecord) machineInspectionPayload {
+func agentMachineObservation(
+	record executionstore.AgentMachineObservationRecord,
+) machineObservationPayload {
+	return machineObservationPayload{
+		MachineRef:             record.MachineRef,
+		SourceKind:             string(record.SourceKind),
+		BindingKind:            string(record.BindingKind),
+		BindingState:           string(record.BindingState),
+		DisplayName:            record.DisplayName,
+		MachinePoolName:        record.MachinePoolName,
+		LifecycleState:         string(record.LifecycleState),
+		ConnectionState:        string(record.ConnectionState),
+		ConnectionStateReason:  record.ConnectionStateReason,
+		Description:            record.Description,
+		Cwd:                    record.Cwd,
+		Executable:             record.Executable,
+		LifecycleReasonCode:    record.LifecycleReasonCode,
+		LifecycleReasonMessage: record.LifecycleReasonMessage,
+		CreatedAt:              record.CreatedAt,
+		UpdatedAt:              record.UpdatedAt,
+	}
+}
+
+func agentMachineInspection(
+	record executionstore.AgentMachineObservationRecord,
+) machineInspectionPayload {
 	return machineInspectionPayload{
-		machineObservationPayload: machineObservation(record),
+		machineObservationPayload: agentMachineObservation(record),
 		FailureReport:             record.FailureReport,
 	}
 }

--- a/internal/harness/tools/machine_tools_test.go
+++ b/internal/harness/tools/machine_tools_test.go
@@ -155,11 +155,21 @@ func TestSelectOnlyMachine(t *testing.T) {
 func TestMachineObservationIncludesMachinePoolName(t *testing.T) {
 	machineCwd := "/pool"
 	record := executionstore.PoolMachineRecord{
-		Binding:         executionstore.AgentMachineBindingRecord{MachineRef: "mchr-pool01"},
-		Machine:         executionstore.MachineRecord{Cwd: machineCwd},
+		Binding: executionstore.AgentMachineBindingRecord{
+			MachineRef:  "mchr-pool01",
+			BindingKind: executionstore.MachineBindingKindPool,
+		},
+		Machine: executionstore.MachineRecord{
+			SourceKind:  executionstore.MachineSourceKindPool,
+			DisplayName: "Build machine",
+			Cwd:         machineCwd,
+		},
 		MachinePoolName: "Build Pool",
 	}
 	got := machineObservation(record)
+	if got.SourceKind != "pool" || got.BindingKind != "pool" || got.DisplayName != "Build machine" {
+		t.Fatalf("pool observation identity = %+v", got)
+	}
 	if got.MachinePoolName != "Build Pool" {
 		t.Fatalf("machine_pool_name = %q, want Build Pool", got.MachinePoolName)
 	}
@@ -189,6 +199,59 @@ func TestAgentMachineObservationIdentifiesBYOBinding(t *testing.T) {
 	}
 	if strings.Contains(string(encoded), "machine_pool_name") {
 		t.Fatalf("BYO observation = %s, want machine_pool_name omitted", encoded)
+	}
+}
+
+func TestAgentMachineObservationRedactsMachineWithoutProjectGrant(t *testing.T) {
+	record := executionstore.AgentMachineObservationRecord{
+		MachineRef:             "mchr-byo001",
+		SourceKind:             executionstore.MachineSourceKindBYO,
+		BindingKind:            executionstore.MachineBindingKindExplicit,
+		BindingState:           executionstore.AgentMachineBindingStateAttached,
+		DisplayName:            "Developer laptop",
+		MachinePoolName:        "Private pool",
+		LifecycleState:         executionstore.MachineLifecycleStateActive,
+		ConnectionState:        executionstore.MachineConnectionStateOnline,
+		ConnectionStateReason:  "connected",
+		Description:            "developer machine",
+		Cwd:                    "/workspace",
+		ProjectGrantMissing:    true,
+		LifecycleReasonCode:    "healthy",
+		LifecycleReasonMessage: "ready",
+		FailureReport:          json.RawMessage(`{"stage":"daemon_install"}`),
+	}
+	encoded, err := json.Marshal(agentMachineInspection(record))
+	if err != nil {
+		t.Fatalf("marshal ungranted machine observation: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(encoded, &got); err != nil {
+		t.Fatalf("decode ungranted machine observation: %v", err)
+	}
+	if got["project_grant_missing"] != true || got["executable"] != false {
+		t.Fatalf("ungranted machine observation = %s", encoded)
+	}
+	for _, field := range []string{
+		"source_kind",
+		"display_name",
+		"machine_pool_name",
+		"connection_state_reason",
+		"failure_report",
+	} {
+		if _, ok := got[field]; ok {
+			t.Fatalf("ungranted machine observation exposed %s: %s", field, encoded)
+		}
+	}
+	for _, field := range []string{
+		"lifecycle_state",
+		"connection_state",
+		"cwd",
+		"lifecycle_reason_code",
+		"lifecycle_reason_message",
+	} {
+		if got[field] != "" {
+			t.Fatalf("ungranted machine observation exposed %s: %s", field, encoded)
+		}
 	}
 }
 

--- a/internal/harness/tools/machine_tools_test.go
+++ b/internal/harness/tools/machine_tools_test.go
@@ -168,20 +168,44 @@ func TestMachineObservationIncludesMachinePoolName(t *testing.T) {
 	}
 }
 
+func TestAgentMachineObservationIdentifiesBYOBinding(t *testing.T) {
+	record := executionstore.AgentMachineObservationRecord{
+		MachineRef:      "mchr-byo001",
+		SourceKind:      executionstore.MachineSourceKindBYO,
+		BindingKind:     executionstore.MachineBindingKindExplicit,
+		BindingState:    executionstore.AgentMachineBindingStateAttached,
+		DisplayName:     "Developer laptop",
+		LifecycleState:  executionstore.MachineLifecycleStateActive,
+		ConnectionState: executionstore.MachineConnectionStateOnline,
+		Executable:      true,
+	}
+	got := agentMachineObservation(record)
+	if got.SourceKind != "byo" || got.BindingKind != "explicit" || got.DisplayName != "Developer laptop" {
+		t.Fatalf("BYO observation identity = %+v", got)
+	}
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal BYO observation: %v", err)
+	}
+	if strings.Contains(string(encoded), "machine_pool_name") {
+		t.Fatalf("BYO observation = %s, want machine_pool_name omitted", encoded)
+	}
+}
+
 func TestMachineInspectionIncludesFailureReport(t *testing.T) {
 	failure := json.RawMessage(`{"stage":"daemon_install","exit_status":7,"output_tail":"failed"}`)
-	record := executionstore.PoolMachineRecord{
-		Binding:       executionstore.AgentMachineBindingRecord{MachineRef: "mchr-pool01"},
+	record := executionstore.AgentMachineObservationRecord{
+		MachineRef:    "mchr-pool01",
 		FailureReport: failure,
 	}
-	inspected, err := json.Marshal(machineInspection(record))
+	inspected, err := json.Marshal(agentMachineInspection(record))
 	if err != nil {
 		t.Fatalf("marshal machine inspection: %v", err)
 	}
 	if !strings.Contains(string(inspected), `"failure_report":`+string(failure)) {
 		t.Fatalf("machine inspection = %s, want failure report", inspected)
 	}
-	listed, err := json.Marshal(machineObservation(record))
+	listed, err := json.Marshal(agentMachineObservation(record))
 	if err != nil {
 		t.Fatalf("marshal machine observation: %v", err)
 	}

--- a/internal/harness/tools/permission_modes.go
+++ b/internal/harness/tools/permission_modes.go
@@ -310,7 +310,7 @@ func inspectMachinePermissionChallenge(
 		if executor.Store == nil {
 			return toolpermission.Request{}, fmt.Errorf("tool executor store is required")
 		}
-		machines, err := executor.Store.Execution().ListPoolMachines(
+		machines, err := executor.Store.Execution().ListAgentMachineObservations(
 			ctx,
 			turn.ProjectID,
 			turn.AgentID,
@@ -322,7 +322,7 @@ func inspectMachinePermissionChallenge(
 		if err != nil {
 			return toolpermission.Request{}, executor.machinePreparationError(err)
 		}
-		machineRef = machine.Binding.MachineRef
+		machineRef = machine.MachineRef
 	}
 	authorizationInput, err := machineObservationAuthorizationInput(
 		machineObservationInspect,

--- a/internal/storage/executionstore/agent_machine_observations_store.go
+++ b/internal/storage/executionstore/agent_machine_observations_store.go
@@ -24,11 +24,12 @@ type AgentMachineObservationRecord struct {
 	Description            string                   `json:"description"`
 	Cwd                    string                   `json:"cwd"`
 	Executable             bool                     `json:"executable"`
+	ProjectGrantMissing    bool                     `json:"project_grant_missing,omitempty"`
 	LifecycleReasonCode    string                   `json:"lifecycle_reason_code"`
 	LifecycleReasonMessage string                   `json:"lifecycle_reason_message"`
 	FailureReport          json.RawMessage          `json:"failure_report,omitempty"`
-	CreatedAt              time.Time                `json:"created_at"`
-	UpdatedAt              time.Time                `json:"updated_at"`
+	BindingCreatedAt       time.Time                `json:"binding_created_at"`
+	BindingUpdatedAt       time.Time                `json:"binding_updated_at"`
 }
 
 func (s *Store) ListAgentMachineObservations(
@@ -127,11 +128,12 @@ func selectAgentMachineObservations(
 			Description:            row.Description,
 			Cwd:                    row.EffectiveCwd,
 			Executable:             row.Executable,
+			ProjectGrantMissing:    row.ProjectGrantMissing,
 			LifecycleReasonCode:    row.LifecycleReasonCode,
 			LifecycleReasonMessage: row.LifecycleReasonMessage,
 			FailureReport:          rawMessageFromSQLCPtr(row.FailureReport),
-			CreatedAt:              row.CreatedAt,
-			UpdatedAt:              row.UpdatedAt,
+			BindingCreatedAt:       row.CreatedAt,
+			BindingUpdatedAt:       row.UpdatedAt,
 		})
 	}
 	return records, nil

--- a/internal/storage/executionstore/agent_machine_observations_store.go
+++ b/internal/storage/executionstore/agent_machine_observations_store.go
@@ -1,0 +1,138 @@
+package executionstore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
+	"github.com/omnara-ai/omnara/internal/storage/storeerr"
+)
+
+type AgentMachineObservationRecord struct {
+	MachineRef             string                   `json:"machine_ref"`
+	SourceKind             MachineSourceKind        `json:"source_kind"`
+	BindingKind            AgentMachineBindingKind  `json:"binding_kind"`
+	BindingState           AgentMachineBindingState `json:"binding_state"`
+	DisplayName            string                   `json:"display_name"`
+	MachinePoolName        string                   `json:"machine_pool_name,omitempty"`
+	LifecycleState         MachineLifecycleState    `json:"lifecycle_state"`
+	ConnectionState        MachineConnectionState   `json:"connection_state"`
+	ConnectionStateReason  string                   `json:"connection_state_reason,omitempty"`
+	Description            string                   `json:"description"`
+	Cwd                    string                   `json:"cwd"`
+	Executable             bool                     `json:"executable"`
+	LifecycleReasonCode    string                   `json:"lifecycle_reason_code"`
+	LifecycleReasonMessage string                   `json:"lifecycle_reason_message"`
+	FailureReport          json.RawMessage          `json:"failure_report,omitempty"`
+	CreatedAt              time.Time                `json:"created_at"`
+	UpdatedAt              time.Time                `json:"updated_at"`
+}
+
+func (s *Store) ListAgentMachineObservations(
+	ctx context.Context,
+	projectID, agentID ID,
+) ([]AgentMachineObservationRecord, error) {
+	if isNilID(projectID) || isNilID(agentID) {
+		return nil, errors.New("project and agent are required")
+	}
+	return selectAgentMachineObservations(ctx, s.q, projectID, agentID, nil, false)
+}
+
+func (r *ToolCallReader) ListAgentMachineObservations(
+	ctx context.Context,
+) ([]AgentMachineObservationRecord, error) {
+	return selectAgentMachineObservations(
+		ctx,
+		r.transaction.q,
+		r.transaction.input.ProjectID,
+		r.transaction.input.AgentID,
+		nil,
+		false,
+	)
+}
+
+func (r *ToolCallReader) GetAgentMachineObservationByRef(
+	ctx context.Context,
+	machineRef string,
+) (AgentMachineObservationRecord, error) {
+	if machineRef == "" {
+		return AgentMachineObservationRecord{}, errors.New("machine ref is required")
+	}
+	return getAgentMachineObservationByRef(
+		ctx,
+		r.transaction.q,
+		r.transaction.input.ProjectID,
+		r.transaction.input.AgentID,
+		machineRef,
+	)
+}
+
+func getAgentMachineObservationByRef(
+	ctx context.Context,
+	q *dbsqlc.Queries,
+	projectID, agentID ID,
+	machineRef string,
+) (AgentMachineObservationRecord, error) {
+	records, err := selectAgentMachineObservations(
+		ctx,
+		q,
+		projectID,
+		agentID,
+		&machineRef,
+		true,
+	)
+	if err != nil {
+		return AgentMachineObservationRecord{}, err
+	}
+	if len(records) == 0 {
+		return AgentMachineObservationRecord{}, storeerr.ErrNotFound
+	}
+	return records[0], nil
+}
+
+func selectAgentMachineObservations(
+	ctx context.Context,
+	q *dbsqlc.Queries,
+	projectID, agentID ID,
+	machineRef *string,
+	includeReleasedPool bool,
+) ([]AgentMachineObservationRecord, error) {
+	rows, err := q.SelectAgentMachineObservations(
+		ctx,
+		dbsqlc.SelectAgentMachineObservationsParams{
+			ProjectID:           projectID,
+			AgentID:             agentID,
+			MachineRef:          machineRef,
+			IncludeReleasedPool: includeReleasedPool,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("select agent machine observations: %w", err)
+	}
+	records := make([]AgentMachineObservationRecord, 0, len(rows))
+	for _, row := range rows {
+		records = append(records, AgentMachineObservationRecord{
+			MachineRef:             row.MachineRef,
+			SourceKind:             MachineSourceKind(row.SourceKind),
+			BindingKind:            AgentMachineBindingKind(row.BindingKind),
+			BindingState:           AgentMachineBindingState(row.BindingState),
+			DisplayName:            row.DisplayName,
+			MachinePoolName:        row.MachinePoolName,
+			LifecycleState:         MachineLifecycleState(row.LifecycleState),
+			ConnectionState:        MachineConnectionState(row.ConnectionState),
+			ConnectionStateReason:  row.ConnectionStateReason,
+			Description:            row.Description,
+			Cwd:                    row.EffectiveCwd,
+			Executable:             row.Executable,
+			LifecycleReasonCode:    row.LifecycleReasonCode,
+			LifecycleReasonMessage: row.LifecycleReasonMessage,
+			FailureReport:          rawMessageFromSQLCPtr(row.FailureReport),
+			CreatedAt:              row.CreatedAt,
+			UpdatedAt:              row.UpdatedAt,
+		})
+	}
+	return records, nil
+}

--- a/internal/storage/executionstore/execution_resources_integration_test.go
+++ b/internal/storage/executionstore/execution_resources_integration_test.go
@@ -135,6 +135,177 @@ func TestInsertAgentMachineBindingRejectsDuplicateBinding(t *testing.T) {
 	}
 }
 
+func TestAgentMachineObservationsTrackAttachedBYOGrantAvailability(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	pool := openIntegrationDB(t, ctx)
+	seedMigratedDB(t, ctx, pool)
+	store := newIntegrationStore(pool)
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	user, err := store.Identity().CreateVerifiedUser(ctx, CreateVerifiedUserInput{
+		Email:       "agent-machine-observation@example.com",
+		DisplayName: "Agent Machine Observation Tester",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	agentID := mustCreateAgent(t, ctx, store, now)
+	machine := createContextMachine(
+		t,
+		ctx,
+		store,
+		testID("agent_machine_observation"),
+		user.ID,
+		now,
+	)
+	binding, err := executionstore.IntegrationInsertAgentMachineBindingTx(
+		ctx,
+		store.q,
+		executionstore.IntegrationInsertAgentMachineBindingInput{
+			ProjectID:             testProjectID,
+			AgentID:               agentID,
+			ProjectMachineGrantID: machine.GrantID,
+			MachineRef:            "mchr-obsv01",
+			BindingKind:           executionstore.MachineBindingKindExplicit,
+			Description:           "developer machine",
+			Cwd:                   "/workspace",
+		},
+	)
+	if err != nil {
+		t.Fatalf("bind BYO machine: %v", err)
+	}
+
+	observations, err := store.Execution().ListAgentMachineObservations(ctx, testProjectID, agentID)
+	if err != nil {
+		t.Fatalf("list offline BYO observation: %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("offline BYO observations = %+v, want one", observations)
+	}
+	offline := observations[0]
+	if offline.MachineRef != binding.MachineRef || offline.SourceKind != executionstore.MachineSourceKindBYO ||
+		offline.BindingKind != executionstore.MachineBindingKindExplicit ||
+		offline.BindingState != executionstore.AgentMachineBindingStateAttached ||
+		offline.DisplayName != machine.Machine.DisplayName || offline.MachinePoolName != "" ||
+		offline.ConnectionState != executionstore.MachineConnectionStateOffline || offline.Executable ||
+		offline.Description != "developer machine" || offline.Cwd != "/workspace" {
+		t.Fatalf("offline BYO observation = %+v", offline)
+	}
+
+	token, err := store.Execution().CreateBYOMachineDaemonToken(
+		ctx,
+		executionstore.CreateBYOMachineDaemonTokenInput{
+			OrgID:     testOrgID,
+			MachineID: machine.Machine.ID,
+			Name:      "observation daemon",
+		},
+	)
+	if err != nil {
+		t.Fatalf("create BYO daemon token: %v", err)
+	}
+	if _, err := store.Execution().RegisterDaemonRuntime(
+		ctx,
+		executionstore.RegisterDaemonRuntimeInput{
+			OrgID:            testOrgID,
+			MachineID:        machine.Machine.ID,
+			DaemonTokenID:    token.Record.ID,
+			DaemonInstanceID: testID("daemon_agent_machine_observation"),
+			DaemonVersion:    "1.0.0",
+			LeaseTimeout:     testDaemonRuntimeLeaseTimeout,
+		},
+	); err != nil {
+		t.Fatalf("register BYO daemon runtime: %v", err)
+	}
+	online, err := executionstore.IntegrationGetAgentMachineObservationByRef(
+		ctx,
+		store.q,
+		testProjectID,
+		agentID,
+		binding.MachineRef,
+	)
+	if err != nil {
+		t.Fatalf("inspect online BYO observation: %v", err)
+	}
+	if online.ConnectionState != executionstore.MachineConnectionStateOnline || !online.Executable {
+		t.Fatalf("online BYO observation = %+v", online)
+	}
+
+	if _, err := store.Execution().DeleteProjectMachineGrant(
+		ctx,
+		testOrgID,
+		testProjectID,
+		machine.GrantID,
+	); err != nil {
+		t.Fatalf("revoke BYO machine grant: %v", err)
+	}
+	revoked, err := executionstore.IntegrationGetAgentMachineObservationByRef(
+		ctx,
+		store.q,
+		testProjectID,
+		agentID,
+		binding.MachineRef,
+	)
+	if err != nil {
+		t.Fatalf("inspect BYO observation after grant revoke: %v", err)
+	}
+	if revoked.BindingState != executionstore.AgentMachineBindingStateAttached || revoked.Executable {
+		t.Fatalf("revoked BYO observation = %+v", revoked)
+	}
+
+	if _, _, err := store.Execution().CreateProjectMachineGrant(
+		ctx,
+		executionstore.CreateProjectMachineGrantInput{
+			OrgID:          testOrgID,
+			ProjectID:      testProjectID,
+			MachineID:      machine.Machine.ID,
+			IdempotencyKey: "idem-agent-machine-observation-regrant",
+		},
+	); err != nil {
+		t.Fatalf("regrant BYO machine: %v", err)
+	}
+	regranted, err := executionstore.IntegrationGetAgentMachineObservationByRef(
+		ctx,
+		store.q,
+		testProjectID,
+		agentID,
+		binding.MachineRef,
+	)
+	if err != nil {
+		t.Fatalf("inspect BYO observation after regrant: %v", err)
+	}
+	if !regranted.Executable {
+		t.Fatalf("regranted BYO observation = %+v, want executable", regranted)
+	}
+
+	released, err := store.q.ReleaseExplicitAgentMachineBinding(
+		ctx,
+		dbsqlc.ReleaseExplicitAgentMachineBindingParams{
+			ProjectID: testProjectID,
+			AgentID:   agentID,
+			MachineID: machine.Machine.ID,
+		},
+	)
+	if err != nil || released != 1 {
+		t.Fatalf("release explicit binding: rows=%d err=%v", released, err)
+	}
+	observations, err = store.Execution().ListAgentMachineObservations(ctx, testProjectID, agentID)
+	if err != nil {
+		t.Fatalf("list BYO observations after release: %v", err)
+	}
+	if len(observations) != 0 {
+		t.Fatalf("released BYO observations = %+v, want none", observations)
+	}
+	if _, err := executionstore.IntegrationGetAgentMachineObservationByRef(
+		ctx,
+		store.q,
+		testProjectID,
+		agentID,
+		binding.MachineRef,
+	); !errors.Is(err, storeerr.ErrNotFound) {
+		t.Fatalf("inspect released BYO observation error = %v, want not found", err)
+	}
+}
+
 func TestReleasedAgentMachineBindingCanReattach(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/storage/executionstore/execution_resources_integration_test.go
+++ b/internal/storage/executionstore/execution_resources_integration_test.go
@@ -238,6 +238,13 @@ func TestAgentMachineObservationsTrackAttachedBYOGrantAvailability(t *testing.T)
 	); err != nil {
 		t.Fatalf("revoke BYO machine grant: %v", err)
 	}
+	observations, err = store.Execution().ListAgentMachineObservations(ctx, testProjectID, agentID)
+	if err != nil {
+		t.Fatalf("list BYO observations after grant revoke: %v", err)
+	}
+	if len(observations) != 1 || !observations[0].ProjectGrantMissing {
+		t.Fatalf("revoked BYO observations = %+v, want one grant-missing binding", observations)
+	}
 	revoked, err := executionstore.IntegrationGetAgentMachineObservationByRef(
 		ctx,
 		store.q,
@@ -248,7 +255,8 @@ func TestAgentMachineObservationsTrackAttachedBYOGrantAvailability(t *testing.T)
 	if err != nil {
 		t.Fatalf("inspect BYO observation after grant revoke: %v", err)
 	}
-	if revoked.BindingState != executionstore.AgentMachineBindingStateAttached || revoked.Executable {
+	if revoked.BindingState != executionstore.AgentMachineBindingStateAttached ||
+		!revoked.ProjectGrantMissing || revoked.Executable {
 		t.Fatalf("revoked BYO observation = %+v", revoked)
 	}
 
@@ -273,7 +281,7 @@ func TestAgentMachineObservationsTrackAttachedBYOGrantAvailability(t *testing.T)
 	if err != nil {
 		t.Fatalf("inspect BYO observation after regrant: %v", err)
 	}
-	if !regranted.Executable {
+	if regranted.ProjectGrantMissing || !regranted.Executable {
 		t.Fatalf("regranted BYO observation = %+v, want executable", regranted)
 	}
 

--- a/internal/storage/executionstore/export_integration_test.go
+++ b/internal/storage/executionstore/export_integration_test.go
@@ -323,21 +323,21 @@ func IntegrationInsertAgentMachineBindingTx(
 	return insertAgentMachineBindingTx(ctx, qtx, insertAgentMachineBindingInput(input))
 }
 
+func IntegrationGetAgentMachineObservationByRef(
+	ctx context.Context,
+	qtx *dbsqlc.Queries,
+	projectID, agentID ID,
+	machineRef string,
+) (AgentMachineObservationRecord, error) {
+	return getAgentMachineObservationByRef(ctx, qtx, projectID, agentID, machineRef)
+}
+
 func IntegrationListPoolMachinesTx(
 	ctx context.Context,
 	qtx *dbsqlc.Queries,
 	projectID, agentID ID,
 ) ([]PoolMachineRecord, error) {
 	return listPoolMachinesTx(ctx, qtx, projectID, agentID)
-}
-
-func IntegrationGetPoolMachineByRef(
-	ctx context.Context,
-	qtx *dbsqlc.Queries,
-	projectID, agentID ID,
-	machineRef string,
-) (PoolMachineRecord, error) {
-	return getPoolMachineByRef(ctx, qtx, projectID, agentID, machineRef)
 }
 
 func IntegrationPoolMachineByRefTx(

--- a/internal/storage/executionstore/pool_machines_integration_test.go
+++ b/internal/storage/executionstore/pool_machines_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/omnara-ai/omnara/internal/secrets"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
-	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
 	"github.com/omnara-ai/omnara/internal/storage/secretstore"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
 	"github.com/omnara-ai/omnara/internal/toolcatalog"
@@ -1652,6 +1651,7 @@ func TestPoolMachineToolsExcludeExplicitPoolBackedMachineSource(t *testing.T) {
 		"explicit",
 		[]poolMachineToolCallSpec{
 			{Label: "create", Name: "create_machine", Input: json.RawMessage(`{}`)},
+			{Label: "delete", Name: "delete_machine", Input: json.RawMessage(`{}`)},
 		},
 	)
 	created, err := createPoolMachineForTest(ctx, store, executionstore.ExecuteToolCallInput{
@@ -1691,42 +1691,6 @@ func TestPoolMachineToolsExcludeExplicitPoolBackedMachineSource(t *testing.T) {
 		claimed.ProvisionAttempts,
 	); err != nil {
 		t.Fatalf("complete generated machine provisioning: %v", err)
-	}
-	if err := store.q.ReleaseAgentMachineBindingsForMachine(
-		ctx,
-		dbsqlc.ReleaseAgentMachineBindingsForMachineParams{
-			OrgID:     testOrgID,
-			MachineID: created.Machine.Machine.ID,
-		},
-	); err != nil {
-		t.Fatalf("release generated pool binding: %v", err)
-	}
-	poolObservations, err := store.Execution().ListAgentMachineObservations(
-		ctx,
-		testProjectID,
-		poolAgent.ID,
-	)
-	if err != nil {
-		t.Fatalf("list released pool machine observations: %v", err)
-	}
-	if len(poolObservations) != 0 {
-		t.Fatalf("released pool machine observations = %+v, want none", poolObservations)
-	}
-	releasedPoolObservation, err := executionstore.IntegrationGetAgentMachineObservationByRef(
-		ctx,
-		store.q,
-		testProjectID,
-		poolAgent.ID,
-		created.Machine.Binding.MachineRef,
-	)
-	if err != nil {
-		t.Fatalf("inspect released pool machine: %v", err)
-	}
-	if releasedPoolObservation.SourceKind != executionstore.MachineSourceKindPool ||
-		releasedPoolObservation.BindingKind != executionstore.MachineBindingKindPool ||
-		releasedPoolObservation.BindingState != executionstore.AgentMachineBindingStateReleased ||
-		releasedPoolObservation.MachinePoolName != machinePool.Name || releasedPoolObservation.Executable {
-		t.Fatalf("released pool machine observation = %+v", releasedPoolObservation)
 	}
 	generatedGrant := getProjectMachineGrantByMachineForTest(t, ctx, store, testOrgID, testProjectID, created.Machine.Machine.ID)
 	explicitAgent, err := store.Execution().CreateAgentFixture(
@@ -1822,21 +1786,88 @@ func TestPoolMachineToolsExcludeExplicitPoolBackedMachineSource(t *testing.T) {
 	if afterArchive.LifecycleState != "active" {
 		t.Fatalf("explicit pool-backed machine after archive = %+v", afterArchive)
 	}
-	if _, err := store.pool.Exec(
-		ctx,
-		`UPDATE machines SET lifecycle_changed_at = statement_timestamp() - interval '6 minutes' WHERE org_id = $1 AND id = $2`,
-		testOrgID,
-		created.Machine.Machine.ID,
-	); err != nil {
-		t.Fatalf("age pool-backed machine lifecycle: %v", err)
+	if _, err := deletePoolMachineForTest(ctx, store, executionstore.ExecuteToolCallInput{
+		ProjectID:     testProjectID,
+		AgentID:       poolAgent.ID,
+		ToolCallID:    toolCalls["delete"],
+		RuntimeLockID: lock.ID,
+	}, executionstore.DeletePoolMachineInput{
+		MachineRef: created.Machine.Binding.MachineRef,
+	}); err != nil {
+		t.Fatalf("delete generated pool machine: %v", err)
 	}
 	cleanup, err := store.Execution().ListPoolMachinesForCleanup(ctx, executionstore.DefaultPoolMachineProvisionFailureLimit, 10)
 	if err != nil {
-		t.Fatalf("list cleanup after explicit agent archived: %v", err)
+		t.Fatalf("list generated pool machine cleanup: %v", err)
 	}
 	if len(cleanup) != 1 || cleanup[0].Machine.ID != created.Machine.Machine.ID ||
-		cleanup[0].ReasonCode != "startup_or_daemon_bootstrap_failed" {
+		cleanup[0].ReasonCode != "deleting_retry" {
 		t.Fatalf("pool-backed machine cleanup = %+v", cleanup)
+	}
+	deleting, ok, err := store.Execution().ClaimPoolMachineDeletion(ctx, executionstore.MachineDeletingInput{
+		OrgID:                    testOrgID,
+		MachineID:                created.Machine.Machine.ID,
+		LifecycleReasonCode:      cleanup[0].ReasonCode,
+		LifecycleReasonMessage:   cleanup[0].ReasonMessage,
+		ExpectedLifecycleVersion: cleanup[0].Machine.LifecycleVersion,
+	})
+	if err != nil || !ok {
+		t.Fatalf("claim generated pool machine deletion: ok=%v err=%v", ok, err)
+	}
+	if err := store.Execution().CompletePoolMachineDeletion(
+		ctx,
+		testOrgID,
+		created.Machine.Machine.ID,
+		deleting.Machine.DeleteAttempts,
+	); err != nil {
+		t.Fatalf("complete generated pool machine deletion: %v", err)
+	}
+	deletedMachine, err := store.Execution().GetMachine(ctx, testOrgID, created.Machine.Machine.ID)
+	if err != nil {
+		t.Fatalf("load deleted pool-backed machine: %v", err)
+	}
+	if deletedMachine.LifecycleState != executionstore.MachineLifecycleStateDeleted || deletedMachine.DeletedAt == nil {
+		t.Fatalf("deleted pool-backed machine = %+v", deletedMachine)
+	}
+	if count := countProjectMachineGrantsForMachineForTest(
+		t,
+		ctx,
+		store,
+		testOrgID,
+		testProjectID,
+		created.Machine.Machine.ID,
+	); count != 0 {
+		t.Fatalf("deleted pool-backed machine grants = %d, want 0", count)
+	}
+	poolObservations, err := store.Execution().ListAgentMachineObservations(
+		ctx,
+		testProjectID,
+		poolAgent.ID,
+	)
+	if err != nil {
+		t.Fatalf("list released pool machine observations: %v", err)
+	}
+	if len(poolObservations) != 0 {
+		t.Fatalf("released pool machine observations = %+v, want none", poolObservations)
+	}
+	releasedPoolObservation, err := executionstore.IntegrationGetAgentMachineObservationByRef(
+		ctx,
+		store.q,
+		testProjectID,
+		poolAgent.ID,
+		created.Machine.Binding.MachineRef,
+	)
+	if err != nil {
+		t.Fatalf("inspect released pool machine: %v", err)
+	}
+	if releasedPoolObservation.SourceKind != executionstore.MachineSourceKindPool ||
+		releasedPoolObservation.BindingKind != executionstore.MachineBindingKindPool ||
+		releasedPoolObservation.BindingState != executionstore.AgentMachineBindingStateReleased ||
+		releasedPoolObservation.ProjectGrantMissing ||
+		releasedPoolObservation.MachinePoolName != machinePool.Name ||
+		releasedPoolObservation.LifecycleState != executionstore.MachineLifecycleStateDeleted ||
+		releasedPoolObservation.Executable {
+		t.Fatalf("released pool machine observation = %+v", releasedPoolObservation)
 	}
 }
 

--- a/internal/storage/executionstore/pool_machines_integration_test.go
+++ b/internal/storage/executionstore/pool_machines_integration_test.go
@@ -1701,6 +1701,33 @@ func TestPoolMachineToolsExcludeExplicitPoolBackedMachineSource(t *testing.T) {
 	); err != nil {
 		t.Fatalf("release generated pool binding: %v", err)
 	}
+	poolObservations, err := store.Execution().ListAgentMachineObservations(
+		ctx,
+		testProjectID,
+		poolAgent.ID,
+	)
+	if err != nil {
+		t.Fatalf("list released pool machine observations: %v", err)
+	}
+	if len(poolObservations) != 0 {
+		t.Fatalf("released pool machine observations = %+v, want none", poolObservations)
+	}
+	releasedPoolObservation, err := executionstore.IntegrationGetAgentMachineObservationByRef(
+		ctx,
+		store.q,
+		testProjectID,
+		poolAgent.ID,
+		created.Machine.Binding.MachineRef,
+	)
+	if err != nil {
+		t.Fatalf("inspect released pool machine: %v", err)
+	}
+	if releasedPoolObservation.SourceKind != executionstore.MachineSourceKindPool ||
+		releasedPoolObservation.BindingKind != executionstore.MachineBindingKindPool ||
+		releasedPoolObservation.BindingState != executionstore.AgentMachineBindingStateReleased ||
+		releasedPoolObservation.MachinePoolName != machinePool.Name || releasedPoolObservation.Executable {
+		t.Fatalf("released pool machine observation = %+v", releasedPoolObservation)
+	}
 	generatedGrant := getProjectMachineGrantByMachineForTest(t, ctx, store, testOrgID, testProjectID, created.Machine.Machine.ID)
 	explicitAgent, err := store.Execution().CreateAgentFixture(
 		ctx,
@@ -1723,18 +1750,25 @@ func TestPoolMachineToolsExcludeExplicitPoolBackedMachineSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create explicit-kind pool-backed binding: %v", err)
 	}
+	explicitObservations, err := store.Execution().ListAgentMachineObservations(
+		ctx,
+		testProjectID,
+		explicitAgent.ID,
+	)
+	if err != nil {
+		t.Fatalf("list explicit pool-backed machine observations: %v", err)
+	}
+	if len(explicitObservations) != 1 || explicitObservations[0].MachineRef != explicitBinding.MachineRef ||
+		explicitObservations[0].SourceKind != executionstore.MachineSourceKindPool ||
+		explicitObservations[0].BindingKind != executionstore.MachineBindingKindExplicit {
+		t.Fatalf("explicit pool-backed machine observations = %+v", explicitObservations)
+	}
 	listed, err := executionstore.IntegrationListPoolMachinesTx(ctx, store.q, testProjectID, explicitAgent.ID)
 	if err != nil {
 		t.Fatalf("list pool machines for explicit agent: %v", err)
 	}
 	if len(listed) != 0 {
 		t.Fatalf("explicit pool-backed machine source should not list as pool tool machine: %+v", listed)
-	}
-	if _, err := executionstore.IntegrationGetPoolMachineByRef(ctx, store.q, testProjectID, explicitAgent.ID, explicitBinding.MachineRef); !errors.Is(
-		err,
-		storeerr.ErrNotFound,
-	) {
-		t.Fatalf("get explicit pool-backed machine as pool machine error = %v, want not found", err)
 	}
 	explicitLock, err := store.Execution().AcquireAgentRuntimeLock(
 		ctx,

--- a/internal/storage/executionstore/pool_machines_store.go
+++ b/internal/storage/executionstore/pool_machines_store.go
@@ -461,21 +461,6 @@ func listMachinePoolSources(
 	return out, nil
 }
 
-func (r *ToolCallReader) ListPoolMachines(ctx context.Context) ([]PoolMachineRecord, error) {
-	t := r.transaction
-	return listPoolMachinesTx(ctx, t.q, t.input.ProjectID, t.input.AgentID)
-}
-
-func (s *Store) ListPoolMachines(
-	ctx context.Context,
-	projectID, agentID ID,
-) ([]PoolMachineRecord, error) {
-	if isNilID(projectID) || isNilID(agentID) {
-		return nil, errors.New("project and agent are required")
-	}
-	return listPoolMachinesTx(ctx, s.q, projectID, agentID)
-}
-
 func listPoolMachinesTx(
 	ctx context.Context,
 	q *dbsqlc.Queries,
@@ -497,53 +482,6 @@ func listPoolMachinesTx(
 		out = append(out, poolMachineRecordFromSQLC(row))
 	}
 	return out, nil
-}
-
-func (r *ToolCallReader) GetPoolMachineByRef(
-	ctx context.Context,
-	machineRef string,
-) (PoolMachineRecord, error) {
-	if machineRef == "" {
-		return PoolMachineRecord{}, errors.New("machine ref is required")
-	}
-	t := r.transaction
-	return getPoolMachineByRef(
-		ctx,
-		t.q,
-		t.input.ProjectID,
-		t.input.AgentID,
-		machineRef,
-	)
-}
-
-func (s *Store) GetPoolMachineByRef(
-	ctx context.Context,
-	projectID, agentID ID,
-	machineRef string,
-) (PoolMachineRecord, error) {
-	if isNilID(projectID) || isNilID(agentID) {
-		return PoolMachineRecord{}, errors.New("project and agent are required")
-	}
-	if machineRef == "" {
-		return PoolMachineRecord{}, errors.New("machine ref is required")
-	}
-	return getPoolMachineByRef(ctx, s.q, projectID, agentID, machineRef)
-}
-
-func getPoolMachineByRef(
-	ctx context.Context,
-	q *dbsqlc.Queries,
-	projectID, agentID ID,
-	machineRef string,
-) (PoolMachineRecord, error) {
-	record, err := poolMachineByRefTx(ctx, q, projectID, agentID, machineRef)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return PoolMachineRecord{}, storeerr.ErrNotFound
-	}
-	if err != nil {
-		return PoolMachineRecord{}, fmt.Errorf("get pool machine: %w", err)
-	}
-	return record, nil
 }
 
 func poolMachineByCreateToolCallTx(

--- a/internal/storage/internal/dbsqlc/agent_machine_bindings.sql.go
+++ b/internal/storage/internal/dbsqlc/agent_machine_bindings.sql.go
@@ -405,18 +405,12 @@ JOIN machines machine ON machine.org_id = binding.org_id
   AND machine.id = binding.machine_id
   AND machine.deleted_at IS NULL
   AND machine.lifecycle_state = 'active'
+JOIN machine_connection_states connection ON connection.org_id = machine.org_id
+  AND connection.machine_id = machine.id
 WHERE binding.project_id = $1
   AND binding.agent_id = $2
   AND binding.state = 'attached'
-  AND (
-    EXISTS (
-      SELECT 1
-      FROM online_daemon_runtimes runtime
-      WHERE runtime.org_id = binding.org_id
-        AND runtime.machine_id = binding.machine_id
-    )
-    OR machine.asleep_since IS NOT NULL
-  )
+  AND connection.connection_state IN ('online', 'asleep')
 ORDER BY binding.created_at, binding.id
 `
 
@@ -908,14 +902,10 @@ SELECT binding.machine_ref,
        coalesce(machine.lifecycle_reason_code, '') AS lifecycle_reason_code,
        machine.lifecycle_reason_message,
        coalesce(pool.name, '') AS machine_pool_name,
+       (binding.state = 'attached' AND pmgrant.id IS NULL)::boolean AS project_grant_missing,
        coalesce((
          binding.state = 'attached'
-         AND EXISTS (
-           SELECT 1
-           FROM project_machine_grants pmgrant
-           WHERE pmgrant.project_id = binding.project_id
-             AND pmgrant.machine_id = binding.machine_id
-         )
+         AND pmgrant.id IS NOT NULL
          AND machine.deleted_at IS NULL
          AND machine.lifecycle_state = 'active'
          AND connection.connection_state IN ('online', 'asleep')
@@ -923,6 +913,9 @@ SELECT binding.machine_ref,
 FROM agent_machine_bindings binding
 JOIN machines machine ON machine.org_id = binding.org_id
   AND machine.id = binding.machine_id
+LEFT JOIN project_machine_grants pmgrant ON pmgrant.org_id = binding.org_id
+  AND pmgrant.project_id = binding.project_id
+  AND pmgrant.machine_id = binding.machine_id
 JOIN machine_connection_states connection ON connection.org_id = machine.org_id
   AND connection.machine_id = machine.id
 LEFT JOIN daemon_runtimes current_runtime ON current_runtime.org_id = machine.org_id
@@ -969,6 +962,7 @@ type SelectAgentMachineObservationsRow struct {
 	LifecycleReasonCode    string
 	LifecycleReasonMessage string
 	MachinePoolName        string
+	ProjectGrantMissing    bool
 	Executable             bool
 }
 
@@ -1003,6 +997,7 @@ func (q *Queries) SelectAgentMachineObservations(ctx context.Context, arg Select
 			&i.LifecycleReasonCode,
 			&i.LifecycleReasonMessage,
 			&i.MachinePoolName,
+			&i.ProjectGrantMissing,
 			&i.Executable,
 		); err != nil {
 			return nil, err

--- a/internal/storage/internal/dbsqlc/agent_machine_bindings.sql.go
+++ b/internal/storage/internal/dbsqlc/agent_machine_bindings.sql.go
@@ -891,6 +891,130 @@ func (q *Queries) ReleaseExplicitAgentMachineBindingsForAgent(ctx context.Contex
 	return err
 }
 
+const selectAgentMachineObservations = `-- name: SelectAgentMachineObservations :many
+SELECT binding.machine_ref,
+       binding.binding_kind,
+       binding.state AS binding_state,
+       binding.description,
+       coalesce(nullif(binding.cwd, ''), machine.cwd, '') AS effective_cwd,
+       binding.created_at,
+       binding.updated_at,
+       machine.source_kind,
+       machine.display_name,
+       machine.lifecycle_state,
+       machine.failure_report,
+       connection.connection_state,
+       coalesce(current_runtime.state_reason_code, '') AS connection_state_reason,
+       coalesce(machine.lifecycle_reason_code, '') AS lifecycle_reason_code,
+       machine.lifecycle_reason_message,
+       coalesce(pool.name, '') AS machine_pool_name,
+       coalesce((
+         binding.state = 'attached'
+         AND EXISTS (
+           SELECT 1
+           FROM project_machine_grants pmgrant
+           WHERE pmgrant.project_id = binding.project_id
+             AND pmgrant.machine_id = binding.machine_id
+         )
+         AND machine.deleted_at IS NULL
+         AND machine.lifecycle_state = 'active'
+         AND connection.connection_state IN ('online', 'asleep')
+       ), false)::boolean AS executable
+FROM agent_machine_bindings binding
+JOIN machines machine ON machine.org_id = binding.org_id
+  AND machine.id = binding.machine_id
+JOIN machine_connection_states connection ON connection.org_id = machine.org_id
+  AND connection.machine_id = machine.id
+LEFT JOIN daemon_runtimes current_runtime ON current_runtime.org_id = machine.org_id
+  AND current_runtime.id = machine.current_daemon_runtime_id
+LEFT JOIN machine_pools pool ON pool.org_id = machine.org_id
+  AND pool.id = machine.machine_pool_id
+WHERE binding.project_id = $1
+  AND binding.agent_id = $2
+  AND ($3::text IS NULL OR binding.machine_ref = $3::text)
+  AND (
+    binding.state = 'attached'
+    OR (
+      $4::boolean
+      AND $3::text IS NOT NULL
+      AND binding.state = 'released'
+      AND binding.binding_kind = 'pool'
+      AND machine.source_kind = 'pool'
+    )
+  )
+ORDER BY binding.created_at, binding.id
+`
+
+type SelectAgentMachineObservationsParams struct {
+	ProjectID           uuid.UUID
+	AgentID             uuid.UUID
+	MachineRef          *string
+	IncludeReleasedPool bool
+}
+
+type SelectAgentMachineObservationsRow struct {
+	MachineRef             string
+	BindingKind            string
+	BindingState           string
+	Description            string
+	EffectiveCwd           string
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
+	SourceKind             string
+	DisplayName            string
+	LifecycleState         string
+	FailureReport          *json.RawMessage
+	ConnectionState        string
+	ConnectionStateReason  string
+	LifecycleReasonCode    string
+	LifecycleReasonMessage string
+	MachinePoolName        string
+	Executable             bool
+}
+
+func (q *Queries) SelectAgentMachineObservations(ctx context.Context, arg SelectAgentMachineObservationsParams) ([]SelectAgentMachineObservationsRow, error) {
+	rows, err := q.db.Query(ctx, selectAgentMachineObservations,
+		arg.ProjectID,
+		arg.AgentID,
+		arg.MachineRef,
+		arg.IncludeReleasedPool,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []SelectAgentMachineObservationsRow{}
+	for rows.Next() {
+		var i SelectAgentMachineObservationsRow
+		if err := rows.Scan(
+			&i.MachineRef,
+			&i.BindingKind,
+			&i.BindingState,
+			&i.Description,
+			&i.EffectiveCwd,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.SourceKind,
+			&i.DisplayName,
+			&i.LifecycleState,
+			&i.FailureReport,
+			&i.ConnectionState,
+			&i.ConnectionStateReason,
+			&i.LifecycleReasonCode,
+			&i.LifecycleReasonMessage,
+			&i.MachinePoolName,
+			&i.Executable,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const selectPoolMachines = `-- name: SelectPoolMachines :many
 SELECT binding.id,
        binding.org_id,

--- a/internal/storage/queries/agent_machine_bindings.sql
+++ b/internal/storage/queries/agent_machine_bindings.sql
@@ -258,18 +258,12 @@ JOIN machines machine ON machine.org_id = binding.org_id
   AND machine.id = binding.machine_id
   AND machine.deleted_at IS NULL
   AND machine.lifecycle_state = 'active'
+JOIN machine_connection_states connection ON connection.org_id = machine.org_id
+  AND connection.machine_id = machine.id
 WHERE binding.project_id = sqlc.arg(project_id)
   AND binding.agent_id = sqlc.arg(agent_id)
   AND binding.state = 'attached'
-  AND (
-    EXISTS (
-      SELECT 1
-      FROM online_daemon_runtimes runtime
-      WHERE runtime.org_id = binding.org_id
-        AND runtime.machine_id = binding.machine_id
-    )
-    OR machine.asleep_since IS NOT NULL
-  )
+  AND connection.connection_state IN ('online', 'asleep')
 ORDER BY binding.created_at, binding.id;
 
 -- name: SelectAgentMachineObservations :many
@@ -289,14 +283,10 @@ SELECT binding.machine_ref,
        coalesce(machine.lifecycle_reason_code, '') AS lifecycle_reason_code,
        machine.lifecycle_reason_message,
        coalesce(pool.name, '') AS machine_pool_name,
+       (binding.state = 'attached' AND pmgrant.id IS NULL)::boolean AS project_grant_missing,
        coalesce((
          binding.state = 'attached'
-         AND EXISTS (
-           SELECT 1
-           FROM project_machine_grants pmgrant
-           WHERE pmgrant.project_id = binding.project_id
-             AND pmgrant.machine_id = binding.machine_id
-         )
+         AND pmgrant.id IS NOT NULL
          AND machine.deleted_at IS NULL
          AND machine.lifecycle_state = 'active'
          AND connection.connection_state IN ('online', 'asleep')
@@ -304,6 +294,9 @@ SELECT binding.machine_ref,
 FROM agent_machine_bindings binding
 JOIN machines machine ON machine.org_id = binding.org_id
   AND machine.id = binding.machine_id
+LEFT JOIN project_machine_grants pmgrant ON pmgrant.org_id = binding.org_id
+  AND pmgrant.project_id = binding.project_id
+  AND pmgrant.machine_id = binding.machine_id
 JOIN machine_connection_states connection ON connection.org_id = machine.org_id
   AND connection.machine_id = machine.id
 LEFT JOIN daemon_runtimes current_runtime ON current_runtime.org_id = machine.org_id

--- a/internal/storage/queries/agent_machine_bindings.sql
+++ b/internal/storage/queries/agent_machine_bindings.sql
@@ -272,6 +272,59 @@ WHERE binding.project_id = sqlc.arg(project_id)
   )
 ORDER BY binding.created_at, binding.id;
 
+-- name: SelectAgentMachineObservations :many
+SELECT binding.machine_ref,
+       binding.binding_kind,
+       binding.state AS binding_state,
+       binding.description,
+       coalesce(nullif(binding.cwd, ''), machine.cwd, '') AS effective_cwd,
+       binding.created_at,
+       binding.updated_at,
+       machine.source_kind,
+       machine.display_name,
+       machine.lifecycle_state,
+       machine.failure_report,
+       connection.connection_state,
+       coalesce(current_runtime.state_reason_code, '') AS connection_state_reason,
+       coalesce(machine.lifecycle_reason_code, '') AS lifecycle_reason_code,
+       machine.lifecycle_reason_message,
+       coalesce(pool.name, '') AS machine_pool_name,
+       coalesce((
+         binding.state = 'attached'
+         AND EXISTS (
+           SELECT 1
+           FROM project_machine_grants pmgrant
+           WHERE pmgrant.project_id = binding.project_id
+             AND pmgrant.machine_id = binding.machine_id
+         )
+         AND machine.deleted_at IS NULL
+         AND machine.lifecycle_state = 'active'
+         AND connection.connection_state IN ('online', 'asleep')
+       ), false)::boolean AS executable
+FROM agent_machine_bindings binding
+JOIN machines machine ON machine.org_id = binding.org_id
+  AND machine.id = binding.machine_id
+JOIN machine_connection_states connection ON connection.org_id = machine.org_id
+  AND connection.machine_id = machine.id
+LEFT JOIN daemon_runtimes current_runtime ON current_runtime.org_id = machine.org_id
+  AND current_runtime.id = machine.current_daemon_runtime_id
+LEFT JOIN machine_pools pool ON pool.org_id = machine.org_id
+  AND pool.id = machine.machine_pool_id
+WHERE binding.project_id = sqlc.arg(project_id)
+  AND binding.agent_id = sqlc.arg(agent_id)
+  AND (sqlc.narg(machine_ref)::text IS NULL OR binding.machine_ref = sqlc.narg(machine_ref)::text)
+  AND (
+    binding.state = 'attached'
+    OR (
+      sqlc.arg(include_released_pool)::boolean
+      AND sqlc.narg(machine_ref)::text IS NOT NULL
+      AND binding.state = 'released'
+      AND binding.binding_kind = 'pool'
+      AND machine.source_kind = 'pool'
+    )
+  )
+ORDER BY binding.created_at, binding.id;
+
 -- name: ListAgentMachineBindings :many
 SELECT binding.id, binding.org_id, binding.project_id, binding.agent_id,
        binding.create_tool_call_id, binding.delete_tool_call_id, binding.machine_id,

--- a/internal/toolcatalog/catalog.go
+++ b/internal/toolcatalog/catalog.go
@@ -34,8 +34,8 @@ const (
 	listProcessesToolDescription  = "List active processes in the current agent."
 	createMachineToolDescription  = "Request another pool-backed machine for this agent. machine_pool_name is only needed when multiple machine pools are available."
 	deleteMachineToolDescription  = "Request deletion of a pool-backed machine."
-	listMachinesToolDescription   = "List pool-backed machines currently associated with this agent."
-	inspectMachineToolDescription = "Inspect a pool-backed machine. machine_ref is only needed when multiple machines are available."
+	listMachinesToolDescription   = "List BYO and pool-backed machines currently associated with this agent."
+	inspectMachineToolDescription = "Inspect a BYO or pool-backed machine. machine_ref is only needed when multiple machines are available."
 	askQuestionToolDescription    = "Ask the human user one or more multiple-choice questions. " +
 		"Omnara appends a text-capable Other choice to every question for free-form user responses."
 	sendIntegrationMessageToolDescription = "Send a user-visible message to the current integration target. " +
@@ -83,7 +83,7 @@ func buildDefaultCatalog() (Catalog, error) {
 	}
 	deleteMachineRef := map[string]any{
 		"type":        "string",
-		"description": "Exact machine_ref of the machine to delete. Use list_machines first if you need the ref.",
+		"description": "Exact machine_ref of the pool-backed machine to delete. Use list_machines first if you need the ref.",
 	}
 	machinePoolName := map[string]any{
 		"type":        "string",


### PR DESCRIPTION
- fixes OMN2-266 by replacing the pool-only read path behind `list_machines` and `inspect_machine` with unified observations over agent machine bindings
- includes attached BYO and pool-backed machines in tool results, with source, binding, display, and executable-state metadata
- preserves ref-based inspection of released pool bindings for deletion lifecycles while keeping released bindings out of machine lists
- updates tool contracts and docs, with coverage for BYO-only and mixed BYO plus pool selection flows