### PR TITLE
fix: prevent caching missing frontend assets

### DIFF
--- a/frontend/apps/web/nginx.conf
+++ b/frontend/apps/web/nginx.conf
@@ -53,6 +53,7 @@ server {
     location @omnara_not_found {
         types {}
         default_type application/json;
+        add_header Cache-Control "no-store" always;
         return 404 '{"error":"not found"}';
     }
 }

--- a/internal/httpapi/routes.go
+++ b/internal/httpapi/routes.go
@@ -81,5 +81,6 @@ func openAPIErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
 }
 
 func (s *Server) notFound(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
 	apierror.Write(w, openapi.ErrorCodeNotFound)
 }

--- a/internal/httpapi/spa_test.go
+++ b/internal/httpapi/spa_test.go
@@ -118,6 +118,9 @@ func TestServerServesSPA(t *testing.T) {
 		if strings.Contains(rec.Body.String(), `id="root"`) {
 			t.Fatalf("GET %s returned the HTML shell", path)
 		}
+		if rec.Header().Get("Cache-Control") != "no-store" {
+			t.Fatalf("GET %s Cache-Control = %q, want no-store", path, rec.Header().Get("Cache-Control"))
+		}
 	}
 }
 


### PR DESCRIPTION
- return `Cache-Control: no-store` from both Nginx and embedded-SPA 404 paths so transient asset misses during frontend version transitions are not retained by browsers or Cloudflare
- preserve the existing `no-cache` policy for HTML and immutable caching for successful hashed assets, leaving normal request performance unchanged
- add regression coverage for representative missing static and hidden paths in the embedded-SPA server
- scope this PR to the repository-side hardening for OMN2-263; ECS blue/green deployment changes will follow separately
