### PR TITLE
feat: handle machine storage exhaustion

### DIFF
--- a/internal/daemonprotocol/protocol.go
+++ b/internal/daemonprotocol/protocol.go
@@ -474,6 +474,8 @@ const (
 )
 
 const (
+	ProcessReasonMachineStorageExhausted      = "machine_storage_exhausted"
+	ProcessMessageMachineStorageExhausted     = "the machine ran out of writable storage"
 	ProcessActionReasonAlreadyStopped         = "already_stopped"
 	ProcessActionReasonOutcomeUnknown         = "action_outcome_unknown"
 	ProcessActionReasonRunnerUnavailable      = "runner_unavailable"

--- a/internal/httpapi/daemon_routes.go
+++ b/internal/httpapi/daemon_routes.go
@@ -111,7 +111,8 @@ func (s *Server) applyDaemonReportedEventForProcess(
 	body daemonReportedEvent,
 	missingProcessErr error,
 ) (bool, error) {
-	if process.ExecutionGrantedAt == nil {
+	storageExhausted := isStorageExhaustionEvent(body)
+	if process.ExecutionGrantedAt == nil && !storageExhausted {
 		return false, fmt.Errorf(
 			"%w: process was not accepted",
 			errDaemonReportValidation,
@@ -150,6 +151,7 @@ func (s *Server) applyDaemonReportedEventForProcess(
 				Result:             body.Result,
 				SourceStartedAt:    body.StartedAt,
 				SourceEndedAt:      body.EndedAt,
+				StorageExhausted:   storageExhausted,
 			},
 		)
 		if err != nil {
@@ -213,6 +215,20 @@ func (s *Server) applyDaemonReportedEventForProcess(
 	default:
 		return false, errors.New("unsupported daemon reported event type")
 	}
+}
+
+func isStorageExhaustionEvent(body daemonReportedEvent) bool {
+	return body.Type == daemonprotocol.EventProcessFinished &&
+		body.ProcessActionID == "" &&
+		body.State == daemonprotocol.ProcessStateFailed &&
+		body.ExitCode == nil &&
+		body.ExitSignal == "" &&
+		body.StateReasonCode == daemonprotocol.ProcessReasonMachineStorageExhausted &&
+		body.StateReasonMessage == daemonprotocol.ProcessMessageMachineStorageExhausted &&
+		(len(body.Result) == 0 || string(body.Result) == "null") &&
+		body.StartedAt.IsZero() &&
+		body.EndedAt.IsZero() &&
+		body.ObservedAt.IsZero()
 }
 
 func (s *Server) applyDaemonReportedEventForMachineWithContext(

--- a/internal/httpapi/machine_routes_integration_test.go
+++ b/internal/httpapi/machine_routes_integration_test.go
@@ -1115,6 +1115,105 @@ func TestMachineDaemonReportProcessStartedCompletesStartToolCall(t *testing.T) {
 	}
 }
 
+func TestMachineDaemonStorageExhaustionFailsQueuedProcess(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	pool := openIntegrationDB(t, ctx)
+	handler := newIntegrationServer(pool)
+	project := bootstrapPublicHTTPProject(t, handler, "daemon-storage-queued")
+	store := newIntegrationStore(pool)
+	process := createDaemonProcessFixtureWithToolCalls(
+		t,
+		ctx,
+		pool,
+		store,
+		project,
+		time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC),
+		"daemon-storage-queued",
+		"run_command",
+		[]model.ToolCall{{ID: "call_storage_late_read", Name: "read_process", Input: json.RawMessage(`{}`)}},
+	)
+	event := daemonReportedEvent{
+		Type:               daemonprotocol.EventProcessFinished,
+		ProcessID:          process.ProcessID,
+		State:              daemonprotocol.ProcessStateFailed,
+		StateReasonCode:    daemonprotocol.ProcessReasonMachineStorageExhausted,
+		StateReasonMessage: daemonprotocol.ProcessMessageMachineStorageExhausted,
+	}
+	cleanupOnly, err := applyDaemonReportDispositionForTest(
+		t,
+		ctx,
+		store,
+		project,
+		process,
+		event,
+	)
+	if err != nil || cleanupOnly {
+		t.Fatalf("storage report: cleanup_only=%t err=%v", cleanupOnly, err)
+	}
+	updated, err := store.Execution().GetProcess(
+		ctx,
+		project.ProjectUUID,
+		process.AgentUUID,
+		process.ProcessUUID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.State != executionstore.ProcessStateFailed ||
+		updated.ExecutionGrantedAt != nil ||
+		updated.SourceStartedAt != nil ||
+		updated.SourceEndedAt != nil ||
+		updated.StateReasonCode != daemonprotocol.ProcessReasonMachineStorageExhausted {
+		t.Fatalf("queued process after storage report = %+v", updated)
+	}
+	toolCall, err := store.Execution().GetToolCall(
+		ctx,
+		project.ProjectUUID,
+		process.AgentUUID,
+		process.ToolCallUUID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if toolCall.State != "completed" || !strings.Contains(
+		string(toolCall.ResultContentParts),
+		daemonprotocol.ProcessReasonMachineStorageExhausted,
+	) {
+		t.Fatalf("queued process tool result = %+v", toolCall)
+	}
+	lateReadToolCall := process.toolCall(t, "call_storage_late_read")
+	if _, err := storagetest.CreateProcessActionForToolCall(
+		ctx,
+		store,
+		executionstore.ExecuteToolCallInput{
+			ProjectID:     project.ProjectUUID,
+			AgentID:       process.AgentUUID,
+			ToolCallID:    lateReadToolCall.ID,
+			RuntimeLockID: process.RuntimeLock.ID,
+		},
+		executionstore.CreateProcessActionInput{
+			ProcessID:  process.ProcessUUID,
+			ActionKind: executionstore.ProcessActionKindRead,
+			Payload:    json.RawMessage(`{"cursor":0}`),
+		},
+	); !errors.Is(err, storeerr.ErrProcessTerminal) {
+		t.Fatalf("late storage-exhausted read error = %v, want ErrProcessTerminal", err)
+	}
+	cleanupOnly, err = applyDaemonReportDispositionForTest(
+		t,
+		ctx,
+		store,
+		project,
+		process,
+		event,
+	)
+	if err != nil {
+		t.Fatalf("replayed storage report: cleanup_only=%t err=%v", cleanupOnly, err)
+	}
+}
+
 func TestMachineDaemonRuntimeRegistrationClosesQueuedPreparation(
 	t *testing.T,
 ) {
@@ -2383,6 +2482,118 @@ func TestMachineDaemonReportProcessFinishedPreservesOutstandingReads(
 			found,
 			acceptedUpdated,
 		)
+	}
+}
+
+func TestMachineDaemonLateStorageExhaustionSettlesAcceptedAction(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	pool := openIntegrationDB(t, ctx)
+	handler := newIntegrationServer(pool)
+	project := bootstrapPublicHTTPProject(t, handler, "daemon-storage-action")
+	store := newIntegrationStore(pool)
+	now := time.Date(2026, 8, 17, 13, 0, 0, 0, time.UTC)
+	process := createDaemonAcceptedProcessFixtureWithToolCalls(
+		t,
+		ctx,
+		pool,
+		store,
+		project,
+		now,
+		"daemon-storage-action",
+		[]model.ToolCall{{ID: "call_storage_action", Name: "write_process", Input: json.RawMessage(`{}`)}},
+	)
+	if _, err := store.Execution().MarkProcessStarted(
+		ctx,
+		executionstore.MarkProcessStartedInput{
+			Authority:       process.authority(),
+			ProjectID:       project.ProjectUUID,
+			AgentID:         process.AgentUUID,
+			ID:              process.ProcessUUID,
+			SourceStartedAt: now.Add(time.Second),
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	toolCall := process.toolCall(t, "call_storage_action")
+	action, err := storagetest.CreateProcessActionForToolCall(
+		ctx,
+		store,
+		executionstore.ExecuteToolCallInput{
+			ProjectID:     project.ProjectUUID,
+			AgentID:       process.AgentUUID,
+			ToolCallID:    toolCall.ID,
+			RuntimeLockID: process.RuntimeLock.ID,
+		},
+		executionstore.CreateProcessActionInput{
+			ProcessID:  process.ProcessUUID,
+			ActionKind: executionstore.ProcessActionKindWrite,
+			Payload:    json.RawMessage(`{"data":"x"}`),
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, found, err := acceptDaemonProcessActionOfferForTest(
+		ctx,
+		store,
+		process.authority(),
+		process.ProcessUUID,
+		action.ID,
+	); err != nil || !found {
+		t.Fatalf("accept action: found=%t err=%v", found, err)
+	}
+	exitCode := 0
+	applyDaemonReportForTest(
+		t,
+		ctx,
+		store,
+		project,
+		process,
+		daemonReportedEvent{
+			Type:      daemonprotocol.EventProcessFinished,
+			ProcessID: process.ProcessID,
+			State:     daemonprotocol.ProcessStateExited,
+			ExitCode:  &exitCode,
+			EndedAt:   now.Add(2 * time.Second),
+			Result:    json.RawMessage(`{"output":"done","cursor":0,"next_cursor":4,"truncated":false}`),
+		},
+	)
+	applyDaemonReportForTest(
+		t,
+		ctx,
+		store,
+		project,
+		process,
+		daemonReportedEvent{
+			Type:               daemonprotocol.EventProcessFinished,
+			ProcessID:          process.ProcessID,
+			State:              daemonprotocol.ProcessStateFailed,
+			StateReasonCode:    daemonprotocol.ProcessReasonMachineStorageExhausted,
+			StateReasonMessage: daemonprotocol.ProcessMessageMachineStorageExhausted,
+		},
+	)
+	updatedProcess, err := store.Execution().GetProcess(
+		ctx,
+		project.ProjectUUID,
+		process.AgentUUID,
+		process.ProcessUUID,
+	)
+	if err != nil || updatedProcess.SourceStartedAt == nil ||
+		updatedProcess.SourceEndedAt == nil ||
+		updatedProcess.SourceEndedAt.Before(*updatedProcess.SourceStartedAt) {
+		t.Fatalf("started process timestamps after storage failure = %+v, err=%v", updatedProcess, err)
+	}
+	updated, found, err := store.Execution().GetProcessActionByToolCall(
+		ctx,
+		project.ProjectUUID,
+		process.AgentUUID,
+		toolCall.ID,
+	)
+	if err != nil || !found || updated.State != executionstore.ProcessActionStateUnknown ||
+		updated.StateReasonCode != daemonprotocol.ProcessReasonMachineStorageExhausted {
+		t.Fatalf("accepted action after storage failure = %+v, found=%t err=%v", updated, found, err)
 	}
 }
 

--- a/internal/machinedaemon/action_queue_test.go
+++ b/internal/machinedaemon/action_queue_test.go
@@ -311,3 +311,28 @@ func TestActionQueueWaitsForReconciledPredecessorReport(t *testing.T) {
 	default:
 	}
 }
+
+func TestActionQueueSkipsForgottenAction(t *testing.T) {
+	const (
+		processID = "prc_forgotten_action"
+		actionID  = "act_forgotten_action"
+	)
+	client := New(Config{}, nil, nil)
+	transport := newDaemonSocketTransport(
+		&client,
+		DaemonRuntime{},
+		localStartupState{},
+	)
+	queue := &acceptedActionQueue{pending: []string{actionID}}
+	transport.actionQueues[processID] = queue
+	transport.runActionQueue(context.Background(), processID, queue)
+
+	if !transport.idle() {
+		t.Fatal("forgotten action retained transport state")
+	}
+	select {
+	case err := <-transport.fatal:
+		t.Fatalf("forgotten action failed the transport: %v", err)
+	default:
+	}
+}

--- a/internal/machinedaemon/client_sleep.go
+++ b/internal/machinedaemon/client_sleep.go
@@ -29,7 +29,13 @@ func (c *Client) sleepEnabled() bool {
 
 func (c *Client) daemonIdle(ctx context.Context) bool {
 	c.processMu.RLock()
-	busy := len(c.processes) > 0
+	busy := false
+	for _, runtime := range c.processes {
+		if runtime != nil && !runtime.cleanupOnly {
+			busy = true
+			break
+		}
+	}
 	c.processMu.RUnlock()
 	if busy {
 		return false

--- a/internal/machinedaemon/client_socket.go
+++ b/internal/machinedaemon/client_socket.go
@@ -27,6 +27,7 @@ const daemonSocketReadLimitBytes = daemonprotocol.MaxMessageBytes
 type pendingProcess struct {
 	runtime            *processRuntime
 	accepted           bool
+	closing            bool
 	terminationReason  string
 	terminationApplied bool
 }
@@ -355,6 +356,11 @@ func (c *Client) verifyProcessSupervisors(ctx context.Context) error {
 			)
 			continue
 		}
+		if runtime, found := c.localProcess(process.ProcessID); found &&
+			runtime.cleanupOnly &&
+			runtime.supervisorInstanceID == process.SupervisorInstanceID {
+			continue
+		}
 		switch process.Phase {
 		case statedb.ProcessPrepared,
 			statedb.ProcessAccepted,
@@ -544,33 +550,58 @@ func (t *daemonSocketTransport) closeRejectedProcessOffer(
 ) {
 	t.mu.Lock()
 	pending := t.pendingProcesses[processID]
-	if pending != nil {
-		delete(t.pendingProcesses, processID)
-	}
-	t.mu.Unlock()
-	if pending == nil {
+	switch {
+	case pending == nil:
+		t.mu.Unlock()
 		return
-	}
-	if pending.runtime == nil {
+	case pending.runtime == nil:
+		delete(t.pendingProcesses, processID)
+		t.mu.Unlock()
 		t.fail(fmt.Errorf(
 			"server rejected process %s before its local preparation completed",
 			processID,
 		))
 		return
+	case pending.closing:
+		t.mu.Unlock()
+		return
 	}
+	pending.closing = true
+	t.mu.Unlock()
 	t.launchWorker(func() {
-		if err := t.client.closeRejectedPreparation(
+		cleanupPending, err := t.client.closeRejectedPreparation(
 			ctx,
 			processID,
 			pending.runtime.supervisorInstanceID,
 			pending.runtime,
-		); err != nil {
+			nil,
+		)
+		if cleanupPending {
+			t.client.addProcess(&processRuntime{
+				processID:            processID,
+				supervisorInstanceID: pending.runtime.supervisorInstanceID,
+				cleanupOnly:          true,
+			})
+			t.client.log.Warn(
+				"rejected process preparation cleanup remains pending",
+				"process_id",
+				processID,
+				"error",
+				err,
+			)
+		} else if err != nil {
 			t.fail(fmt.Errorf(
 				"close rejected process preparation %s: %w",
 				processID,
 				err,
 			))
+			return
 		}
+		t.mu.Lock()
+		if t.pendingProcesses[processID] == pending {
+			delete(t.pendingProcesses, processID)
+		}
+		t.mu.Unlock()
 	})
 }
 
@@ -599,9 +630,6 @@ func (t *daemonSocketTransport) offerProcess(
 	ctx context.Context,
 	offer daemonprotocol.ProcessOffer,
 ) {
-	if _, exists := t.client.localProcess(offer.ProcessID); exists {
-		return
-	}
 	assignment := ProcessAssignment{
 		ID: offer.ProcessID,
 		Process: Process{
@@ -622,6 +650,10 @@ func (t *daemonSocketTransport) offerProcess(
 		t.mu.Unlock()
 		return
 	}
+	if _, exists := t.client.localProcess(offer.ProcessID); exists {
+		t.mu.Unlock()
+		return
+	}
 	pending = &pendingProcess{}
 	t.pendingProcesses[offer.ProcessID] = pending
 	t.mu.Unlock()
@@ -633,10 +665,9 @@ func (t *daemonSocketTransport) offerProcess(
 			assignment,
 		)
 		if err != nil {
-			t.mu.Lock()
-			delete(t.pendingProcesses, assignment.ID)
-			t.mu.Unlock()
-			if errors.Is(err, errUnresolvedProcessPreparation) {
+			if runtime != nil && runtime.cleanupOnly {
+				t.client.addProcess(runtime)
+			} else if errors.Is(err, errUnresolvedProcessPreparation) {
 				t.fail(fmt.Errorf(
 					"process preparation %s retained unresolved local state: %w",
 					assignment.ID,
@@ -650,18 +681,40 @@ func (t *daemonSocketTransport) offerProcess(
 				"error",
 				err,
 			)
+			t.mu.Lock()
+			if t.pendingProcesses[assignment.ID] == pending {
+				delete(t.pendingProcesses, assignment.ID)
+			}
+			t.mu.Unlock()
 			return
 		}
 		t.mu.Lock()
 		current := t.pendingProcesses[assignment.ID]
 		if current != pending {
 			t.mu.Unlock()
-			if err := t.client.closeRejectedPreparation(
+			cleanupPending, err := t.client.closeRejectedPreparation(
 				ctx,
 				assignment.ID,
 				runtime.supervisorInstanceID,
 				runtime,
-			); err != nil {
+				nil,
+			)
+			if cleanupPending {
+				t.client.addProcess(&processRuntime{
+					processID:            assignment.ID,
+					supervisorInstanceID: runtime.supervisorInstanceID,
+					cleanupOnly:          true,
+				})
+				t.client.log.Warn(
+					"superseded process preparation cleanup remains pending",
+					"process_id",
+					assignment.ID,
+					"error",
+					err,
+				)
+				return
+			}
+			if err != nil {
 				t.fail(fmt.Errorf(
 					"close superseded process preparation %s: %w",
 					assignment.ID,
@@ -778,7 +831,8 @@ func (t *daemonSocketTransport) offerAction(
 	offer daemonprotocol.ActionOffer,
 ) {
 	if offer.ActionKind != daemonprotocol.ProcessActionRead {
-		if _, exists := t.client.localProcess(offer.ProcessID); !exists {
+		runtime, exists := t.client.localProcess(offer.ProcessID)
+		if !exists || runtime.cleanupOnly || runtime.runner == nil {
 			return
 		}
 	}
@@ -938,7 +992,7 @@ func (t *daemonSocketTransport) runAcceptedAction(
 		}
 	} else {
 		runtime, ok := t.client.localProcess(processID)
-		if !ok {
+		if !ok || runtime.cleanupOnly || runtime.runner == nil {
 			return fmt.Errorf(
 				"accepted action %s lost its live supervisor",
 				actionID,
@@ -1211,7 +1265,7 @@ func (t *daemonSocketTransport) terminateProcess(
 	}
 	runtime, ok := t.client.localProcess(processID)
 	t.mu.Unlock()
-	if !ok {
+	if !ok || runtime.cleanupOnly || runtime.runner == nil {
 		return
 	}
 	t.launchWorker(func() {

--- a/internal/machinedaemon/client_socket.go
+++ b/internal/machinedaemon/client_socket.go
@@ -172,8 +172,8 @@ func (t *daemonSocketTransport) Run(ctx context.Context) (bool, error) {
 	t.launchWorker(func() {
 		t.client.finalizeReleasedProcessesLoop(runCtx)
 	})
-
 	t.resumeStartupActions(runCtx)
+	t.reportReadyStorageFailures(runCtx)
 
 	heartbeatDelay, err := nextHeartbeatDelay(t.runtime)
 	if err != nil {
@@ -224,6 +224,7 @@ func (t *daemonSocketTransport) Run(ctx context.Context) (bool, error) {
 			if err := t.client.verifyProcessSupervisors(runCtx); err != nil {
 				return heartbeatAcknowledged, err
 			}
+			t.reportReadyStorageFailures(runCtx)
 			if !t.enqueue(daemonprotocol.Message{
 				Type:             daemonprotocol.MessageHeartbeat,
 				DaemonInstanceID: t.client.instanceID,
@@ -290,6 +291,9 @@ func (t *daemonSocketTransport) resumeStartupActions(ctx context.Context) {
 			t.startup.Actions[j].action.Seq
 	})
 	for _, action := range t.startup.Actions {
+		if processRuntimeStorageExhaustionReady(t.startup.Runners[action.processID]) {
+			continue
+		}
 		accepted := pendingAction{
 			processID: action.processID,
 			action:    action.action,
@@ -333,6 +337,27 @@ func (t *daemonSocketTransport) stopAndWait(cancel context.CancelFunc) {
 	t.workers.Wait()
 }
 
+func (t *daemonSocketTransport) reportReadyStorageFailures(ctx context.Context) {
+	for _, runtime := range t.client.storageFailureRuntimes() {
+		t.launchWorker(func() {
+			_, err := t.client.handleAcceptedStorageFailure(
+				ctx,
+				t,
+				runtime,
+				errStorageExhaustionTerminalReady,
+			)
+			if err != nil &&
+				ctx.Err() == nil {
+				t.fail(fmt.Errorf(
+					"report storage exhaustion for process %s: %w",
+					runtime.processID,
+					err,
+				))
+			}
+		})
+	}
+}
+
 // An unlocked supervisor is ambiguous until PostgreSQL authorizes cleanup;
 // afterward the same row only tracks pending local cleanup.
 func (c *Client) verifyProcessSupervisors(ctx context.Context) error {
@@ -357,9 +382,16 @@ func (c *Client) verifyProcessSupervisors(ctx context.Context) error {
 			continue
 		}
 		if runtime, found := c.localProcess(process.ProcessID); found &&
-			runtime.cleanupOnly &&
 			runtime.supervisorInstanceID == process.SupervisorInstanceID {
-			continue
+			if runtime.cleanupOnly {
+				continue
+			}
+			if runtime.runner != nil {
+				probeCtx, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
+				// Status records a storage-ready sentinel on the IPC runner; other errors are ignored.
+				_ = runtime.runner.Status(probeCtx)
+				cancel()
+			}
 		}
 		switch process.Phase {
 		case statedb.ProcessPrepared,
@@ -665,6 +697,8 @@ func (t *daemonSocketTransport) offerProcess(
 			assignment,
 		)
 		if err != nil {
+			storageFailure := isStorageExhaustion(err) &&
+				!errors.Is(err, errUnresolvedProcessPreparation)
 			if runtime != nil && runtime.cleanupOnly {
 				t.client.addProcess(runtime)
 			} else if errors.Is(err, errUnresolvedProcessPreparation) {
@@ -681,6 +715,19 @@ func (t *daemonSocketTransport) offerProcess(
 				"error",
 				err,
 			)
+			if storageFailure {
+				if reportErr := sendStorageExhaustionReport(
+					ctx,
+					t,
+					assignment.ID,
+				); reportErr != nil && ctx.Err() == nil {
+					t.fail(fmt.Errorf(
+						"report storage exhaustion for process %s: %w",
+						assignment.ID,
+						reportErr,
+					))
+				}
+			}
 			t.mu.Lock()
 			if t.pendingProcesses[assignment.ID] == pending {
 				delete(t.pendingProcesses, assignment.ID)
@@ -782,6 +829,25 @@ func (t *daemonSocketTransport) startAcceptedProcess(
 			} else {
 				err = pending.runtime.runner.StartOnce(ctx)
 			}
+		}
+		storageFailure, err := t.client.handleAcceptedStorageFailure(
+			ctx,
+			t,
+			pending.runtime,
+			err,
+		)
+		if storageFailure {
+			if err == nil {
+				t.mu.Lock()
+				if t.pendingProcesses[processID] == pending {
+					delete(t.pendingProcesses, processID)
+				}
+				t.mu.Unlock()
+			}
+			if err != nil {
+				t.fail(fmt.Errorf("start accepted process %s: %w", processID, err))
+			}
+			return
 		}
 		if err != nil {
 			t.fail(fmt.Errorf(
@@ -1006,11 +1072,20 @@ func (t *daemonSocketTransport) runAcceptedAction(
 				}
 				continue
 			}
-			if err != nil {
+			storageFailure, storageErr := t.client.handleAcceptedStorageFailure(
+				ctx,
+				t,
+				runtime,
+				err,
+			)
+			if storageFailure {
+				return storageErr
+			}
+			if storageErr != nil {
 				return fmt.Errorf(
 					"apply accepted process action %s: %w",
 					accepted.action.ID,
-					err,
+					storageErr,
 				)
 			}
 			break
@@ -1027,6 +1102,19 @@ func (t *daemonSocketTransport) runAcceptedAction(
 	delete(t.pendingActions, accepted.action.ID)
 	t.mu.Unlock()
 	return nil
+}
+
+func (t *daemonSocketTransport) forgetResolvedProcessActions(processID string) {
+	t.mu.Lock()
+	for actionID, action := range t.pendingActions {
+		if action.processID == processID {
+			delete(t.pendingActions, actionID)
+		}
+	}
+	if queue := t.actionQueues[processID]; queue != nil {
+		queue.pending = nil
+	}
+	t.mu.Unlock()
 }
 
 func (t *daemonSocketTransport) runAcceptedRead(

--- a/internal/machinedaemon/client_socket.go
+++ b/internal/machinedaemon/client_socket.go
@@ -1005,10 +1005,15 @@ func (t *daemonSocketTransport) runActionQueue(
 			processID,
 			actionID,
 		); err != nil {
-			if ctx.Err() == nil {
+			t.mu.Lock()
+			_, pending := t.pendingActions[actionID]
+			if pending && ctx.Err() == nil {
 				t.fail(err)
 			}
-			return
+			t.mu.Unlock()
+			if pending {
+				return
+			}
 		}
 	}
 }

--- a/internal/machinedaemon/client_socket_lifecycle_test.go
+++ b/internal/machinedaemon/client_socket_lifecycle_test.go
@@ -84,6 +84,7 @@ type recordingProcessRunner struct {
 	startCalls     chan struct{}
 	releaseStart   chan struct{}
 	releaseClose   chan struct{}
+	statusErr      error
 	terminateCalls chan string
 	terminateErr   error
 	done           chan struct{}
@@ -110,7 +111,7 @@ func (transport blockingSkillDownloadTransport) RoundTrip(
 func (runner *recordingProcessRunner) Status(
 	context.Context,
 ) error {
-	return nil
+	return runner.statusErr
 }
 
 func (runner *recordingProcessRunner) StartOnce(

--- a/internal/machinedaemon/client_socket_lifecycle_test.go
+++ b/internal/machinedaemon/client_socket_lifecycle_test.go
@@ -651,6 +651,85 @@ func TestRejectedProcessAcceptanceClosesPreparedState(
 	}
 }
 
+func TestRejectedProcessAcceptanceLockTimeoutRetainsCleanup(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	const (
+		processID            = "prc_rejected_accept_lock_timeout"
+		supervisorInstanceID = "supervisor-instance-rejected-accept-lock-timeout"
+	)
+	client := New(Config{OmnaraHome: t.TempDir()}, nil, nil)
+	client.bootstrap = daemonBootstrap{
+		InstallationID: "ins_rejected_accept_lock_timeout",
+		MachineID:      "mch_rejected_accept_lock_timeout",
+	}
+	machine, err := client.machineStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lockPath, err := machine.LifetimeLockPath(processID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock, err := localstore.TryAcquireLock(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lock.Release() }()
+	releaseClose := make(chan struct{})
+	close(releaseClose)
+	runner := &recordingProcessRunner{
+		closeCalls:   make(chan struct{}, 1),
+		releaseClose: releaseClose,
+		done:         make(chan struct{}),
+	}
+	transport := newDaemonSocketTransport(
+		&client,
+		DaemonRuntime{},
+		localStartupState{},
+	)
+	defer transport.stopAndWait(func() {})
+	transport.pendingProcesses[processID] = &pendingProcess{
+		runtime: &processRuntime{
+			processID:            processID,
+			supervisorInstanceID: supervisorInstanceID,
+			runner:               runner,
+		},
+	}
+
+	transport.handleServerError(ctx, daemonprotocol.Message{
+		Type:      "error",
+		ErrorCode: daemonprotocol.ErrorCodeProcessOfferUnavailable,
+		ProcessID: processID,
+	})
+	for {
+		runtime, found := client.localProcess(processID)
+		transport.mu.Lock()
+		pending := transport.pendingProcesses[processID]
+		transport.mu.Unlock()
+		if found && runtime.cleanupOnly && runtime.runner == nil && pending == nil {
+			break
+		}
+		if err := sleepContext(ctx, time.Millisecond); err != nil {
+			t.Fatal("lock timeout did not retain rejected preparation cleanup")
+		}
+	}
+	select {
+	case <-runner.closeCalls:
+	default:
+		t.Fatal("rejected process supervisor was not closed")
+	}
+	select {
+	case fatalErr := <-transport.fatal:
+		t.Fatalf("lock timeout forced reconnect: %v", fatalErr)
+	default:
+	}
+}
+
 func TestRejectedProcessOfferWhilePreparationFinishesClosesState(
 	t *testing.T,
 ) {

--- a/internal/machinedaemon/client_socket_lifecycle_test.go
+++ b/internal/machinedaemon/client_socket_lifecycle_test.go
@@ -30,6 +30,11 @@ type successfulPrepareLauncher struct {
 	runtime *processRuntime
 }
 
+type cleanupPendingPrepareLauncher struct {
+	runtime *processRuntime
+	calls   chan<- struct{}
+}
+
 func (launcher blockingPrepareLauncher) Prepare(
 	context.Context,
 	*Client,
@@ -62,11 +67,23 @@ func (launcher successfulPrepareLauncher) Prepare(
 	return launcher.runtime, nil
 }
 
+func (launcher cleanupPendingPrepareLauncher) Prepare(
+	context.Context,
+	*Client,
+	ProcessAssignment,
+) (*processRuntime, error) {
+	if launcher.calls != nil {
+		launcher.calls <- struct{}{}
+	}
+	return launcher.runtime, errors.New("test cleanup remains pending")
+}
+
 type recordingProcessRunner struct {
 	applied        chan ProcessAction
 	closeCalls     chan struct{}
 	startCalls     chan struct{}
 	releaseStart   chan struct{}
+	releaseClose   chan struct{}
 	terminateCalls chan string
 	terminateErr   error
 	done           chan struct{}
@@ -117,9 +134,16 @@ func (runner *recordingProcessRunner) ApplyOnce(
 	return nil
 }
 
-func (runner *recordingProcessRunner) CloseUngranted(context.Context) error {
+func (runner *recordingProcessRunner) CloseUngranted(ctx context.Context) error {
 	if runner.closeCalls != nil {
 		runner.closeCalls <- struct{}{}
+		if runner.releaseClose != nil {
+			select {
+			case <-runner.releaseClose:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
 		return nil
 	}
 	return errors.New("unexpected close")
@@ -200,6 +224,67 @@ func TestTransportShutdownWaitsForInFlightProcessPreparation(
 	transport.mu.Unlock()
 	if pending != nil {
 		t.Fatal("settled preparation remained in the old transport")
+	}
+}
+
+func TestCleanupPendingPreparationDoesNotForceReconnect(t *testing.T) {
+	t.Parallel()
+
+	const processID = "prc_cleanup_pending_prepare"
+	done := make(chan struct{})
+	close(done)
+	runtime := &processRuntime{
+		processID:            processID,
+		supervisorInstanceID: "supervisor-instance-cleanup-pending-prepare",
+		runner:               &recordingProcessRunner{done: done},
+		cleanupOnly:          true,
+	}
+	prepareCalls := make(chan struct{}, 2)
+	client := New(Config{}, nil, nil)
+	client.runnerLauncher = cleanupPendingPrepareLauncher{
+		runtime: runtime,
+		calls:   prepareCalls,
+	}
+	transport := newDaemonSocketTransport(
+		&client,
+		DaemonRuntime{},
+		localStartupState{},
+	)
+	defer transport.stopAndWait(func() {})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	transport.offerProcess(ctx, daemonprotocol.ProcessOffer{ProcessID: processID})
+	select {
+	case <-prepareCalls:
+	case <-ctx.Done():
+		t.Fatal("process preparation was not attempted")
+	}
+	for {
+		cached, found := client.localProcess(processID)
+		transport.mu.Lock()
+		pending := transport.pendingProcesses[processID]
+		transport.mu.Unlock()
+		if found && pending == nil {
+			if cached != runtime {
+				t.Fatal("cleanup runtime identity changed")
+			}
+			break
+		}
+		if err := sleepContext(ctx, time.Millisecond); err != nil {
+			t.Fatal("cleanup-pending preparation was not retained")
+		}
+	}
+	select {
+	case err := <-transport.fatal:
+		t.Fatalf("cleanup-pending preparation forced reconnect: %v", err)
+	default:
+	}
+	transport.offerProcess(ctx, daemonprotocol.ProcessOffer{ProcessID: processID})
+	transport.workers.Wait()
+	select {
+	case <-prepareCalls:
+		t.Fatal("duplicate offer restarted pending cleanup preparation")
+	default:
 	}
 }
 
@@ -503,8 +588,9 @@ func TestRejectedProcessAcceptanceClosesPreparedState(
 		t.Fatal(err)
 	}
 	runner := &recordingProcessRunner{
-		closeCalls: make(chan struct{}, 1),
-		done:       make(chan struct{}),
+		closeCalls:   make(chan struct{}, 1),
+		releaseClose: make(chan struct{}),
+		done:         make(chan struct{}),
 	}
 	transport := newDaemonSocketTransport(
 		&client,
@@ -530,6 +616,10 @@ func TestRejectedProcessAcceptanceClosesPreparedState(
 	case <-ctx.Done():
 		t.Fatal("rejected process offer did not close its supervisor")
 	}
+	if transport.idle() {
+		t.Fatal("rejected process became idle before its supervisor stopped")
+	}
+	close(runner.releaseClose)
 	for {
 		_, found, err := store.Process(ctx, processID)
 		if err != nil {
@@ -542,11 +632,16 @@ func TestRejectedProcessAcceptanceClosesPreparedState(
 			t.Fatal("rejected process state was not deleted")
 		}
 	}
-	transport.mu.Lock()
-	pending := transport.pendingProcesses[processID]
-	transport.mu.Unlock()
-	if pending != nil {
-		t.Fatal("rejected process remained pending")
+	for {
+		transport.mu.Lock()
+		pending := transport.pendingProcesses[processID]
+		transport.mu.Unlock()
+		if pending == nil {
+			break
+		}
+		if err := sleepContext(ctx, time.Millisecond); err != nil {
+			t.Fatal("rejected process remained pending")
+		}
 	}
 	select {
 	case fatalErr := <-transport.fatal:

--- a/internal/machinedaemon/reconciliation.go
+++ b/internal/machinedaemon/reconciliation.go
@@ -416,18 +416,31 @@ func (c *Client) applyProcessDisposition(
 
 	switch disposition.Disposition {
 	case daemonprotocol.ProcessDispositionClosePreparation:
-		if lock := startup.stoppedLocks[claim.ProcessID]; lock != nil {
-			if err := lock.Release(); err != nil {
-				return err
-			}
-			delete(startup.stoppedLocks, claim.ProcessID)
-		}
-		if err := c.closeRejectedPreparation(
+		lock := startup.stoppedLocks[claim.ProcessID]
+		delete(startup.stoppedLocks, claim.ProcessID)
+		cleanupPending, err := c.closeRejectedPreparation(
 			ctx,
 			claim.ProcessID,
 			claim.SupervisorInstanceID,
 			runner,
-		); err != nil {
+			lock,
+		)
+		if cleanupPending {
+			startup.Runners[claim.ProcessID] = &processRuntime{
+				processID:            claim.ProcessID,
+				supervisorInstanceID: claim.SupervisorInstanceID,
+				cleanupOnly:          true,
+			}
+			c.log.Warn(
+				"rejected process preparation cleanup remains pending",
+				"process_id",
+				claim.ProcessID,
+				"error",
+				err,
+			)
+			return nil
+		}
+		if err != nil {
 			return err
 		}
 		delete(startup.Runners, claim.ProcessID)
@@ -508,6 +521,7 @@ func (c *Client) applyProcessDisposition(
 			ctx,
 			claim.ProcessID,
 			claim.SupervisorInstanceID,
+			startup.stoppedLocks[claim.ProcessID],
 		); err != nil {
 			c.log.Warn(
 				"released process remains locally unresolved",
@@ -610,6 +624,7 @@ func (c *Client) applyActionDisposition(
 func (c *Client) recoverStoppedReleasedProcess(
 	ctx context.Context,
 	processID, supervisorInstanceID string,
+	heldLock *localstore.Lock,
 ) error {
 	stateStore, err := c.stateStore(ctx)
 	if err != nil {
@@ -624,12 +639,14 @@ func (c *Client) recoverStoppedReleasedProcess(
 	}
 	if process.Phase == statedb.ProcessPreparing ||
 		process.Phase == statedb.ProcessPrepared {
-		return c.closeRejectedPreparation(
+		_, err := c.closeRejectedPreparation(
 			ctx,
 			processID,
 			supervisorInstanceID,
 			nil,
+			heldLock,
 		)
+		return err
 	}
 
 	if err := retryWhileStateDBBusy(ctx, func() error {
@@ -834,7 +851,8 @@ func (c *Client) closeRejectedPreparation(
 	ctx context.Context,
 	processID, supervisorInstanceID string,
 	runtime *processRuntime,
-) error {
+	heldLock *localstore.Lock,
+) (bool, error) {
 	cleanupCtx, cancelCleanup := context.WithTimeout(
 		context.WithoutCancel(ctx),
 		5*time.Second,
@@ -842,7 +860,7 @@ func (c *Client) closeRejectedPreparation(
 	defer cancelCleanup()
 
 	var closeErr error
-	if runtime != nil && !runtime.runner.IsDone() {
+	if runtime != nil && runtime.runner != nil && !runtime.runner.IsDone() {
 		closeCtx, cancel := context.WithTimeout(
 			cleanupCtx,
 			2*time.Second,
@@ -856,43 +874,96 @@ func (c *Client) closeRejectedPreparation(
 			)
 		}
 	}
-	for {
-		artifactErr := c.removeRejectedProcessArtifacts(processID, supervisorInstanceID)
-		if artifactErr == nil {
-			break
+	lock := heldLock
+	if lock == nil {
+		machine, err := c.machineStore()
+		if err != nil {
+			return false, errors.Join(closeErr, err)
 		}
-		if !errors.Is(artifactErr, localstore.ErrLockHeld) {
-			return errors.Join(closeErr, artifactErr)
+		lockPath, err := machine.LifetimeLockPath(processID)
+		if err != nil {
+			return false, errors.Join(closeErr, err)
 		}
-		if err := sleepContext(cleanupCtx, 25*time.Millisecond); err != nil {
-			return errors.Join(
+		for {
+			lock, err = localstore.TryAcquireExistingLock(lockPath)
+			if errors.Is(err, os.ErrNotExist) {
+				lock, err = localstore.TryAcquireLock(lockPath)
+			}
+			if err == nil {
+				break
+			}
+			if !errors.Is(err, localstore.ErrLockHeld) {
+				return false, errors.Join(closeErr, err)
+			}
+			if err := sleepContext(cleanupCtx, 25*time.Millisecond); err != nil {
+				return false, errors.Join(
+					closeErr,
+					fmt.Errorf(
+						"wait for ungranted supervisor %s to stop: %w",
+						processID,
+						err,
+					),
+				)
+			}
+		}
+	}
+	defer func() { _ = lock.Release() }()
+
+	stateStore, err := c.stateStore(cleanupCtx)
+	if err != nil {
+		return true, errors.Join(closeErr, err)
+	}
+	process, found, err := stateStore.Process(cleanupCtx, processID)
+	if err != nil {
+		return true, errors.Join(closeErr, err)
+	}
+	if found {
+		if process.SupervisorInstanceID != supervisorInstanceID {
+			return false, errors.Join(
+				closeErr,
+				statedb.ErrSupervisorIdentityMismatch,
+			)
+		}
+		if process.ExecCommitted ||
+			(process.Phase != statedb.ProcessPreparing &&
+				process.Phase != statedb.ProcessPrepared) {
+			return false, errors.Join(
 				closeErr,
 				fmt.Errorf(
-					"wait for ungranted supervisor %s to stop: %w",
+					"%w: process %s is not an unexecuted preparation",
+					statedb.ErrStateConflict,
 					processID,
-					err,
 				),
 			)
 		}
 	}
-	stateStore, err := c.stateStore(cleanupCtx)
-	if err != nil {
-		return errors.Join(closeErr, err)
+	if err := c.removeRejectedProcessArtifacts(
+		processID,
+		supervisorInstanceID,
+	); err != nil {
+		return true, errors.Join(closeErr, err)
 	}
 	if err := stateStore.DeleteRejectedPreparationAfterArtifacts(
 		cleanupCtx,
 		processID,
 		supervisorInstanceID,
 	); err != nil {
-		return errors.Join(closeErr, err)
+		if errors.Is(err, statedb.ErrSupervisorIdentityMismatch) ||
+			errors.Is(err, statedb.ErrStateConflict) {
+			return false, errors.Join(closeErr, err)
+		}
+		return true, errors.Join(closeErr, err)
 	}
-	return nil
+	if err := lock.ReleaseAndRemove(); err != nil {
+		return true, errors.Join(closeErr, err)
+	}
+	return false, nil
 }
 
 func (c *Client) removeRejectedProcessArtifacts(
 	processID, supervisorInstanceID string,
 ) error {
-	return c.removeProcessRuntimeArtifacts(processID, supervisorInstanceID, true)
+	return c.removeProcessArtifacts(processID, supervisorInstanceID, true)
 }
 
 func (c *Client) releaseProcessRuntimeArtifacts(
@@ -930,7 +1001,27 @@ func (c *Client) removeProcessRuntimeArtifacts(
 	default:
 		return err
 	}
+	if err := c.removeProcessArtifacts(
+		processID,
+		supervisorInstanceID,
+		removeOutput,
+	); err != nil {
+		return err
+	}
+	if lock != nil {
+		return lock.ReleaseAndRemove()
+	}
+	return nil
+}
 
+func (c *Client) removeProcessArtifacts(
+	processID, supervisorInstanceID string,
+	removeOutput bool,
+) error {
+	machine, err := c.machineStore()
+	if err != nil {
+		return err
+	}
 	processDir, err := machine.ProcessDir(processID)
 	if err != nil {
 		return err
@@ -956,11 +1047,6 @@ func (c *Client) removeProcessRuntimeArtifacts(
 			return err
 		}
 	}
-	if lock != nil {
-		if err := lock.ReleaseAndRemove(); err != nil {
-			return err
-		}
-	}
 	if removeOutput {
 		return localstore.SyncDir(filepath.Dir(processDir))
 	}
@@ -972,7 +1058,15 @@ func (c *Client) addProcess(runtime *processRuntime) {
 		return
 	}
 	c.processMu.Lock()
-	if runtime.runner == nil || !runtime.runner.IsDone() {
+	current := c.processes[runtime.processID]
+	if runtime.cleanupOnly &&
+		current != nil &&
+		!current.cleanupOnly &&
+		current.supervisorInstanceID != runtime.supervisorInstanceID {
+		c.processMu.Unlock()
+		return
+	}
+	if runtime.cleanupOnly || runtime.runner == nil || !runtime.runner.IsDone() {
 		c.processes[runtime.processID] = runtime
 	}
 	c.processMu.Unlock()
@@ -983,7 +1077,7 @@ func (c *Client) replaceProcesses(processes map[string]*processRuntime) {
 	replacement := make(map[string]*processRuntime, len(processes))
 	for processID, runtime := range processes {
 		if runtime != nil &&
-			(runtime.runner == nil || !runtime.runner.IsDone()) {
+			(runtime.cleanupOnly || runtime.runner == nil || !runtime.runner.IsDone()) {
 			replacement[processID] = runtime
 		}
 	}
@@ -1007,6 +1101,18 @@ func (c *Client) localProcess(
 	defer c.processMu.RUnlock()
 	runtime, ok := c.processes[processID]
 	return runtime, ok
+}
+
+func (c *Client) cleanupProcesses() []*processRuntime {
+	c.processMu.RLock()
+	defer c.processMu.RUnlock()
+	runtimes := make([]*processRuntime, 0)
+	for _, runtime := range c.processes {
+		if runtime != nil && runtime.cleanupOnly {
+			runtimes = append(runtimes, runtime)
+		}
+	}
+	return runtimes
 }
 
 func retryWhileStateDBBusy(

--- a/internal/machinedaemon/reconciliation.go
+++ b/internal/machinedaemon/reconciliation.go
@@ -216,6 +216,9 @@ func (c *Client) scanLocalProcessesForRegistrationOnce(
 		statusCtx, cancel := context.WithTimeout(ctx, time.Second)
 		statusErr := runner.Status(statusCtx)
 		cancel()
+		if errors.Is(statusErr, errStorageExhaustionTerminalReady) {
+			continue
+		}
 		if statusErr != nil {
 			return startup, fmt.Errorf(
 				"%w: supervisor %s ended during registration snapshot: %w",
@@ -453,33 +456,75 @@ func (c *Client) applyProcessDisposition(
 				claim.ProcessID,
 			)
 		}
-		if err := retryWhileStateDBBusy(ctx, func() error {
+		if processRuntimeStorageExhaustionReady(runner) {
+			return nil
+		}
+		storageErr := retryWhileStateDBBusy(ctx, func() error {
 			return stateStore.MarkAccepted(
 				ctx,
 				claim.ProcessID,
 				claim.SupervisorInstanceID,
 			)
-		}); err != nil {
-			return err
+		})
+		if storageErr != nil && !isStorageExhaustion(storageErr) {
+			return storageErr
 		}
-		if err := runner.runner.StartOnce(ctx); err != nil {
-			return fmt.Errorf(
-				"start accepted process %s: %w",
-				claim.ProcessID,
-				err,
+		if storageErr == nil {
+			if err := runner.runner.StartOnce(ctx); err != nil {
+				if errors.Is(err, errStorageExhaustionTerminalReady) {
+					return nil
+				}
+				if !isStorageExhaustion(err) {
+					return fmt.Errorf(
+						"start accepted process %s: %w",
+						claim.ProcessID,
+						err,
+					)
+				}
+				storageErr = err
+			}
+		}
+		if storageErr != nil {
+			terminateErr := runner.runner.Terminate(
+				context.WithoutCancel(ctx),
+				daemonprotocol.ProcessReasonMachineStorageExhausted,
 			)
+			if errors.Is(terminateErr, errStorageExhaustionTerminalReady) {
+				return nil
+			}
+			if terminateErr != nil {
+				return terminateErr
+			}
+			return storageErr
 		}
 	case daemonprotocol.ProcessDispositionRetain:
 
 	case daemonprotocol.ProcessDispositionRelease:
-		if err := retryWhileStateDBBusy(ctx, func() error {
+		storageCleanup := processRuntimeStorageExhaustionReady(runner)
+		markReleasedErr := retryWhileStateDBBusy(ctx, func() error {
 			return stateStore.MarkServerReleased(
 				ctx,
 				claim.ProcessID,
 				claim.SupervisorInstanceID,
 			)
-		}); err != nil {
-			return err
+		})
+		if markReleasedErr != nil &&
+			!(storageCleanup && errors.Is(markReleasedErr, statedb.ErrFull)) {
+			return markReleasedErr
+		}
+		if storageCleanup {
+			terminateCtx, cancel := context.WithTimeout(
+				context.WithoutCancel(ctx),
+				10*time.Second,
+			)
+			terminateErr := runner.runner.Terminate(terminateCtx, "server_resolved")
+			cancel()
+			if terminateErr != nil {
+				return terminateErr
+			}
+			runner.runner = nil
+			runner.cleanupOnly = true
+			return nil
 		}
 		reports, err := stateStore.ReportsForProcess(ctx, claim.ProcessID)
 		if err != nil {
@@ -551,6 +596,14 @@ func (c *Client) applyProcessDisposition(
 		}
 	}
 	return nil
+}
+
+func processRuntimeStorageExhaustionReady(runtime *processRuntime) bool {
+	if runtime == nil {
+		return false
+	}
+	runner, ok := runtime.runner.(*ipcProcessRunner)
+	return ok && runner.storageExhaustionReady()
 }
 
 func (c *Client) applyActionDisposition(
@@ -958,6 +1011,77 @@ func (c *Client) closeRejectedPreparation(
 		return true, errors.Join(closeErr, err)
 	}
 	return false, nil
+}
+
+func (c *Client) closeStorageExhaustedProcess(
+	ctx context.Context,
+	runtime *processRuntime,
+) (bool, error) {
+	if runtime.runner != nil && !runtime.runner.IsDone() {
+		terminateCtx, cancel := context.WithTimeout(
+			context.WithoutCancel(ctx),
+			2*time.Second,
+		)
+		err := runtime.runner.Terminate(terminateCtx, "server_resolved")
+		cancel()
+		if runner, ok := runtime.runner.(*ipcProcessRunner); ok {
+			err = errors.Join(err, runner.EndReconciliation())
+		}
+		if err != nil {
+			return true, err
+		}
+		runtime.runner = nil
+	}
+	stateStore, err := c.stateStore(ctx)
+	if err != nil {
+		return true, err
+	}
+	process, found, err := stateStore.Process(ctx, runtime.processID)
+	if err != nil {
+		return true, err
+	}
+	if found && process.SupervisorInstanceID != runtime.supervisorInstanceID {
+		return false, statedb.ErrSupervisorIdentityMismatch
+	}
+	if found && process.Phase != statedb.ProcessAccepted &&
+		process.Phase != statedb.ProcessTerminal {
+		return false, statedb.ErrStateConflict
+	}
+	machine, err := c.machineStore()
+	if err != nil {
+		return true, err
+	}
+	lockPath, err := machine.LifetimeLockPath(runtime.processID)
+	if err != nil {
+		return true, err
+	}
+	lock, err := localstore.TryAcquireExistingLock(lockPath)
+	if errors.Is(err, os.ErrNotExist) {
+		lock, err = localstore.TryAcquireLock(lockPath)
+	}
+	if err == nil {
+		defer func() { _ = lock.Release() }()
+	}
+	if err == nil {
+		err = c.removeProcessArtifacts(
+			runtime.processID,
+			runtime.supervisorInstanceID,
+			true,
+		)
+	}
+	if err == nil {
+		err = stateStore.DeleteStorageExhaustedAfterArtifacts(
+			ctx,
+			runtime.processID,
+			runtime.supervisorInstanceID,
+		)
+	}
+	if err == nil {
+		err = lock.ReleaseAndRemove()
+	}
+	permanent := errors.Is(err, statedb.ErrSupervisorIdentityMismatch) ||
+		errors.Is(err, statedb.ErrStateConflict)
+	return err != nil && !permanent, err
 }
 
 func (c *Client) removeRejectedProcessArtifacts(

--- a/internal/machinedaemon/reconciliation.go
+++ b/internal/machinedaemon/reconciliation.go
@@ -946,10 +946,10 @@ func (c *Client) closeRejectedPreparation(
 				break
 			}
 			if !errors.Is(err, localstore.ErrLockHeld) {
-				return false, errors.Join(closeErr, err)
+				return closeErr == nil && isStorageExhaustion(err), errors.Join(closeErr, err)
 			}
 			if err := sleepContext(cleanupCtx, 25*time.Millisecond); err != nil {
-				return false, errors.Join(
+				return closeErr == nil, errors.Join(
 					closeErr,
 					fmt.Errorf(
 						"wait for ungranted supervisor %s to stop: %w",

--- a/internal/machinedaemon/report_outbox.go
+++ b/internal/machinedaemon/report_outbox.go
@@ -136,6 +136,13 @@ func (c *Client) outboxReports(
 	blockedProcesses := make(map[string]struct{})
 	blockedActions := make(map[string]struct{})
 	for _, report := range candidates {
+		c.processMu.RLock()
+		runtime := c.processes[report.ProcessID]
+		cleanupOnly := runtime != nil && runtime.cleanupOnly
+		c.processMu.RUnlock()
+		if cleanupOnly {
+			continue
+		}
 		if _, blocked := blockedProcesses[report.ProcessID]; blocked {
 			continue
 		}
@@ -207,20 +214,48 @@ func (c *Client) finalizeReleasedProcessesLoop(ctx context.Context) {
 }
 
 func (c *Client) finalizeReleasedProcesses(ctx context.Context) error {
+	stateStore, err := c.stateStore(ctx)
+	if err != nil {
+		return err
+	}
 	for _, runtime := range c.cleanupProcesses() {
-		cleanupPending, err := c.closeRejectedPreparation(
-			ctx,
-			runtime.processID,
-			runtime.supervisorInstanceID,
-			nil,
-			nil,
-		)
+		process, found, err := stateStore.Process(ctx, runtime.processID)
+		if err != nil {
+			continue
+		}
+		if !found {
+			if err := c.removeProcessRuntimeArtifacts(
+				runtime.processID,
+				runtime.supervisorInstanceID,
+				true,
+			); err != nil {
+				continue
+			}
+			c.removeProcessInstance(
+				runtime.processID,
+				runtime.supervisorInstanceID,
+			)
+			continue
+		}
+		var cleanupPending bool
+		if process.Phase == statedb.ProcessPreparing ||
+			process.Phase == statedb.ProcessPrepared {
+			cleanupPending, err = c.closeRejectedPreparation(
+				ctx,
+				runtime.processID,
+				runtime.supervisorInstanceID,
+				nil,
+				nil,
+			)
+		} else {
+			cleanupPending, err = c.closeStorageExhaustedProcess(ctx, runtime)
+		}
 		if cleanupPending {
 			continue
 		}
 		if err != nil {
 			c.log.Debug(
-				"rejected process preparation cleanup failed",
+				"process cleanup failed",
 				"process_id",
 				runtime.processID,
 				"supervisor_instance_id",
@@ -236,10 +271,6 @@ func (c *Client) finalizeReleasedProcesses(ctx context.Context) error {
 		)
 	}
 
-	stateStore, err := c.stateStore(ctx)
-	if err != nil {
-		return err
-	}
 	processes, err := stateStore.Processes(ctx)
 	if err != nil {
 		return err

--- a/internal/machinedaemon/report_outbox.go
+++ b/internal/machinedaemon/report_outbox.go
@@ -219,7 +219,7 @@ func (c *Client) finalizeReleasedProcesses(ctx context.Context) error {
 			continue
 		}
 		if err != nil {
-			c.log.Warn(
+			c.log.Debug(
 				"rejected process preparation cleanup failed",
 				"process_id",
 				runtime.processID,

--- a/internal/machinedaemon/report_outbox.go
+++ b/internal/machinedaemon/report_outbox.go
@@ -207,6 +207,35 @@ func (c *Client) finalizeReleasedProcessesLoop(ctx context.Context) {
 }
 
 func (c *Client) finalizeReleasedProcesses(ctx context.Context) error {
+	for _, runtime := range c.cleanupProcesses() {
+		cleanupPending, err := c.closeRejectedPreparation(
+			ctx,
+			runtime.processID,
+			runtime.supervisorInstanceID,
+			nil,
+			nil,
+		)
+		if cleanupPending {
+			continue
+		}
+		if err != nil {
+			c.log.Warn(
+				"rejected process preparation cleanup failed",
+				"process_id",
+				runtime.processID,
+				"supervisor_instance_id",
+				runtime.supervisorInstanceID,
+				"error",
+				err,
+			)
+			continue
+		}
+		c.removeProcessInstance(
+			runtime.processID,
+			runtime.supervisorInstanceID,
+		)
+	}
+
 	stateStore, err := c.stateStore(ctx)
 	if err != nil {
 		return err
@@ -221,6 +250,9 @@ func (c *Client) finalizeReleasedProcesses(ctx context.Context) error {
 		}
 		if !process.LocalClosed {
 			if runtime, ok := c.localProcess(process.ProcessID); ok {
+				if runtime.cleanupOnly || runtime.runner == nil {
+					continue
+				}
 				probeCtx, cancel := context.WithTimeout(
 					ctx,
 					250*time.Millisecond,
@@ -252,6 +284,7 @@ func (c *Client) finalizeReleasedProcesses(ctx context.Context) error {
 					ctx,
 					process.ProcessID,
 					process.SupervisorInstanceID,
+					lock,
 				)
 				releaseErr := lock.Release()
 				if recoverErr != nil {

--- a/internal/machinedaemon/report_outbox_test.go
+++ b/internal/machinedaemon/report_outbox_test.go
@@ -190,6 +190,15 @@ func TestOutboxForcedReportKeepsLifecycleOrder(t *testing.T) {
 	sent := make(chan statedb.Report, 2)
 	client := New(Config{}, nil, nil)
 	client.state = store
+	client.addProcess(&processRuntime{
+		processID:            processID,
+		supervisorInstanceID: supervisorInstanceID,
+		cleanupOnly:          true,
+	})
+	if !client.daemonIdle(ctx) {
+		t.Fatal("server-resolved storage cleanup prevented idleness")
+	}
+	client.removeProcessInstance(processID, supervisorInstanceID)
 	client.transport = rejectingReportTransport{sent: sent}
 	replayCtx, cancelReplay := context.WithCancel(ctx)
 	replayDone := make(chan struct{})

--- a/internal/machinedaemon/runner_ipc_client.go
+++ b/internal/machinedaemon/runner_ipc_client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/omnara-ai/omnara/internal/machinedaemon/localipc"
@@ -17,6 +18,7 @@ type ipcProcessRunner struct {
 	supervisorInstanceID string
 	done                 chan struct{}
 	doneOnce             sync.Once
+	storageFailureReady  atomic.Bool
 
 	reconciliationMu sync.RWMutex
 	reconciliation   *runnerReconciliationSession
@@ -51,8 +53,12 @@ func (r *ipcProcessRunner) BeginReconciliation(
 		return err
 	}
 	if _, err := readRunnerResponse(ctx, conn); err != nil {
-		_ = conn.Close()
-		return err
+		if errors.Is(err, errStorageExhaustionTerminalReady) {
+			r.storageFailureReady.Store(true)
+		} else {
+			_ = conn.Close()
+			return err
+		}
 	}
 	r.reconciliation = &runnerReconciliationSession{conn: conn}
 	return nil
@@ -188,6 +194,11 @@ func (r *ipcProcessRunner) call(
 	ctx context.Context,
 	request runnerRequest,
 ) (response runnerResponse, err error) {
+	defer func() {
+		if errors.Is(err, errStorageExhaustionTerminalReady) {
+			r.storageFailureReady.Store(true)
+		}
+	}()
 	if _, ok := ctx.Deadline(); !ok {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, 15*time.Second)
@@ -218,6 +229,10 @@ func (r *ipcProcessRunner) call(
 		return runnerResponse{}, err
 	}
 	return readRunnerResponse(ctx, conn)
+}
+
+func (r *ipcProcessRunner) storageExhaustionReady() bool {
+	return r.storageFailureReady.Load()
 }
 
 func (s *runnerReconciliationSession) call(

--- a/internal/machinedaemon/runner_protocol.go
+++ b/internal/machinedaemon/runner_protocol.go
@@ -35,9 +35,15 @@ type runnerErrorCode string
 const (
 	runnerErrorActionBlocked              runnerErrorCode = "action_blocked"
 	runnerErrorSupervisorIdentityMismatch runnerErrorCode = "supervisor_identity_mismatch"
+	runnerErrorStorageExhaustion          runnerErrorCode = "storage_exhaustion"
+	runnerErrorStorageExhaustionReady     runnerErrorCode = "storage_exhaustion_terminal_ready"
 )
 
-var errRunnerIdentityMismatch = errors.New("supervisor identity mismatch")
+var (
+	errRunnerIdentityMismatch         = errors.New("supervisor identity mismatch")
+	errRunnerStorageExhaustion        = errors.New("runner storage exhausted")
+	errStorageExhaustionTerminalReady = errors.New("storage exhaustion terminal ready")
+)
 
 type runnerRequest struct {
 	SupervisorToken      string          `json:"supervisor_token,omitempty"`
@@ -115,19 +121,23 @@ func runnerResponseError(response runnerResponse) error {
 		if response.Error == "" {
 			return errors.New("supervisor request failed")
 		}
-		if response.ErrorCode == runnerErrorActionBlocked {
+		switch response.ErrorCode {
+		case runnerErrorActionBlocked:
 			return fmt.Errorf(
 				"%w: %s",
 				statedb.ErrActionBlocked,
 				response.Error,
 			)
-		}
-		if response.ErrorCode == runnerErrorSupervisorIdentityMismatch {
+		case runnerErrorSupervisorIdentityMismatch:
 			return fmt.Errorf(
 				"%w: %s",
 				errRunnerIdentityMismatch,
 				response.Error,
 			)
+		case runnerErrorStorageExhaustion:
+			return fmt.Errorf("%w: %s", errRunnerStorageExhaustion, response.Error)
+		case runnerErrorStorageExhaustionReady:
+			return fmt.Errorf("%w: %s", errStorageExhaustionTerminalReady, response.Error)
 		}
 		return errors.New(response.Error)
 	}

--- a/internal/machinedaemon/runner_protocol_test.go
+++ b/internal/machinedaemon/runner_protocol_test.go
@@ -90,6 +90,26 @@ func TestRunnerProtocolPreservesActionBlockedError(t *testing.T) {
 	}
 }
 
+func TestRunnerProtocolPreservesStorageErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		code runnerErrorCode
+		want error
+	}{
+		{runnerErrorStorageExhaustion, errRunnerStorageExhaustion},
+		{runnerErrorStorageExhaustionReady, errStorageExhaustionTerminalReady},
+	} {
+		err := runnerResponseError(runnerResponse{
+			Error:     "storage failure",
+			ErrorCode: test.code,
+		})
+		if !errors.Is(err, test.want) {
+			t.Fatalf("runner error = %v, want %v", err, test.want)
+		}
+	}
+}
+
 type unexpectedRunnerRequestError string
 
 func (e unexpectedRunnerRequestError) Error() string {

--- a/internal/machinedaemon/runner_reconciliation_test.go
+++ b/internal/machinedaemon/runner_reconciliation_test.go
@@ -192,6 +192,13 @@ func TestRegistrationReclaimsMissingPreparedLifetimeLock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	machine, err := client.machineStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := localstore.EnsurePrivateDir(machine.RunDir()); err != nil {
+		t.Fatal(err)
+	}
 	const (
 		processID            = "prc_missing_prepared_lock"
 		supervisorInstanceID = "supervisor-instance-missing-prepared-lock"
@@ -222,6 +229,17 @@ func TestRegistrationReclaimsMissingPreparedLifetimeLock(t *testing.T) {
 	}
 	if startup.stoppedLocks[processID] == nil {
 		t.Fatal("missing prepared lifetime lock was not safely reacquired")
+	}
+	if err := client.recoverStoppedReleasedProcess(
+		ctx,
+		processID,
+		supervisorInstanceID,
+		startup.stoppedLocks[processID],
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, found, err := store.Process(ctx, processID); err != nil || found {
+		t.Fatalf("recovered prepared process: found=%t err=%v", found, err)
 	}
 }
 

--- a/internal/machinedaemon/runner_server.go
+++ b/internal/machinedaemon/runner_server.go
@@ -206,13 +206,14 @@ type runnerServerState struct {
 
 	reconciliationMu sync.RWMutex
 
-	mu              sync.RWMutex
-	prepared        *localProcessRunner
-	assignment      ProcessAssignment
-	packageBody     []byte
-	startOutcome    processStartOutcome
-	localClosed     bool
-	ungrantedClosed bool
+	mu                     sync.RWMutex
+	prepared               *localProcessRunner
+	assignment             ProcessAssignment
+	packageBody            []byte
+	startOutcome           processStartOutcome
+	localClosed            bool
+	ungrantedClosed        bool
+	storageExhaustionReady bool
 
 	startMu          sync.Mutex
 	effectBoundaryMu sync.Mutex
@@ -337,27 +338,41 @@ func (s *runnerServerState) handle(
 	ctx context.Context,
 	request runnerRequest,
 ) runnerResponse {
+	var response runnerResponse
 	switch request.Method {
 	case runnerMethodStatus:
-		return s.status(ctx)
+		response = s.status(ctx)
 	case runnerMethodPrepare:
-		return s.prepare(ctx, request.Payload)
+		response = s.prepare(ctx, request.Payload)
 	case runnerMethodStartOnce:
-		return s.startOnce(ctx)
+		response = s.startOnce(ctx)
 	case runnerMethodApplyOnce:
-		return s.applyOnce(ctx, request.Payload)
+		response = s.applyOnce(ctx, request.Payload)
 	case runnerMethodCloseUngranted:
-		return s.closeUngranted(ctx)
+		response = s.closeUngranted(ctx)
 	case runnerMethodTerminate:
-		return s.terminate(ctx, request.Payload)
+		response = s.terminate(ctx, request.Payload)
 	default:
 		return runnerResponse{OK: false, Error: "unsupported supervisor method"}
 	}
+	if response.ErrorCode == runnerErrorStorageExhaustion &&
+		request.Method != runnerMethodStatus &&
+		request.Method != runnerMethodPrepare &&
+		request.Method != runnerMethodCloseUngranted {
+		return runnerErrorResponse(s.closeForStorageExhaustion(ctx))
+	}
+	return response
 }
 
 func (s *runnerServerState) status(ctx context.Context) runnerResponse {
+	s.mu.RLock()
+	ready := s.storageExhaustionReady
+	s.mu.RUnlock()
+	if ready {
+		return runnerErrorResponse(errStorageExhaustionTerminalReady)
+	}
 	if _, err := s.processState.Process(ctx); err != nil {
-		return runnerResponse{OK: false, Error: err.Error()}
+		return runnerErrorResponse(err)
 	}
 	return runnerResponse{OK: true}
 }
@@ -400,7 +415,7 @@ func (s *runnerServerState) prepare(
 	}
 	runner, err := prepareLocalRunner(ctx, s.bootstrap, assignment)
 	if err != nil {
-		return runnerResponse{OK: false, Error: err.Error()}
+		return runnerErrorResponse(err)
 	}
 	s.prepared = runner
 	s.assignment = assignment
@@ -413,6 +428,10 @@ func (s *runnerServerState) startOnce(ctx context.Context) runnerResponse {
 	defer s.startMu.Unlock()
 
 	s.mu.RLock()
+	if s.storageExhaustionReady {
+		s.mu.RUnlock()
+		return runnerErrorResponse(errStorageExhaustionTerminalReady)
+	}
 	if s.startOutcome != "" {
 		outcome := s.startOutcome
 		s.mu.RUnlock()
@@ -432,6 +451,9 @@ func (s *runnerServerState) startOnce(ctx context.Context) runnerResponse {
 	}
 	if prepared == nil {
 		return runnerResponse{OK: false, Error: "supervisor is not prepared"}
+	}
+	if isStorageExhaustion(prepared.startErr) {
+		return runnerErrorResponse(prepared.startErr)
 	}
 
 	startError := s.assignment.PreparationError
@@ -458,7 +480,7 @@ func (s *runnerServerState) startOnce(ctx context.Context) runnerResponse {
 
 	authorized, err := s.processState.AuthorizeSpawnOnce(ctx)
 	if err != nil {
-		return runnerResponse{OK: false, Error: err.Error()}
+		return runnerErrorResponse(err)
 	}
 	if !authorized {
 		response, exit := terminalStartResult(
@@ -478,6 +500,12 @@ func (s *runnerServerState) startOnce(ctx context.Context) runnerResponse {
 	}
 	runner, outcome, startErr := startPreparedLocalRunner(prepared)
 	if startErr != nil {
+		if isStorageExhaustion(startErr) {
+			s.mu.Lock()
+			s.prepared = runner
+			s.mu.Unlock()
+			return runnerErrorResponse(startErr)
+		}
 		state := daemonprotocol.ProcessStateFailed
 		reason := "start_failed"
 		if outcome == processAmbiguous {
@@ -509,6 +537,12 @@ func (s *runnerServerState) startOnce(ctx context.Context) runnerResponse {
 		processContainmentKind,
 		strconv.Itoa(containmentID),
 	); err != nil {
+		if isStorageExhaustion(err) {
+			s.mu.Lock()
+			s.prepared = runner
+			s.mu.Unlock()
+			return runnerErrorResponse(err)
+		}
 		response, exit := terminalStartResult(
 			processAmbiguous,
 			daemonprotocol.ProcessStateUnknown,
@@ -768,6 +802,10 @@ func (s *runnerServerState) finishTerminalRunner(
 	if containmentClosed {
 		outputErr = runner.waitOutputDrain()
 	}
+	if containmentClosed && isStorageExhaustion(outputErr) {
+		s.markStorageExhaustionReady()
+		return
+	}
 	if containmentErr != nil {
 		exit.State = daemonprotocol.ProcessStateUnknown
 		exit.ExitCode = nil
@@ -1001,8 +1039,13 @@ func (s *runnerServerState) applyOnce(
 
 func runnerErrorResponse(err error) runnerResponse {
 	response := runnerResponse{OK: false, Error: err.Error()}
-	if errors.Is(err, statedb.ErrActionBlocked) {
+	switch {
+	case errors.Is(err, statedb.ErrActionBlocked):
 		response.ErrorCode = runnerErrorActionBlocked
+	case errors.Is(err, errStorageExhaustionTerminalReady):
+		response.ErrorCode = runnerErrorStorageExhaustionReady
+	case isStorageExhaustion(err):
+		response.ErrorCode = runnerErrorStorageExhaustion
 	}
 	return response
 }
@@ -1052,6 +1095,13 @@ func (s *runnerServerState) runApplyOnce(
 	localAction := s.localAction(action)
 
 	s.effectBoundaryMu.Lock()
+	s.mu.RLock()
+	storageReady := s.storageExhaustionReady
+	s.mu.RUnlock()
+	if storageReady {
+		s.effectBoundaryMu.Unlock()
+		return errRunnerStorageExhaustion
+	}
 	decision, _, err := s.processState.ApplyOnce(ctx, localAction)
 	if err != nil {
 		s.effectBoundaryMu.Unlock()
@@ -1340,7 +1390,7 @@ func (s *runnerServerState) closeUngranted(
 	defer s.startMu.Unlock()
 	process, err := s.processState.Process(ctx)
 	if err != nil {
-		return runnerResponse{OK: false, Error: err.Error()}
+		return runnerErrorResponse(err)
 	}
 	if process.ExecCommitted ||
 		process.Phase == statedb.ProcessAccepted ||
@@ -1379,14 +1429,22 @@ func (s *runnerServerState) terminate(
 	if payload.Reason == "" {
 		payload.Reason = "machine_deleted"
 	}
+	if payload.Reason == daemonprotocol.ProcessReasonMachineStorageExhausted {
+		return runnerErrorResponse(s.closeForStorageExhaustion(ctx))
+	}
 	s.mu.RLock()
 	runner := s.prepared
 	startOutcome := s.startOutcome
+	storageReady := s.storageExhaustionReady
 	s.mu.RUnlock()
+	if storageReady {
+		s.shutdown()
+		return runnerResponse{OK: true}
+	}
 	if runner == nil || runner.cmd == nil || runner.cmd.Process == nil {
 		process, err := s.processState.Process(ctx)
 		if err != nil {
-			return runnerResponse{OK: false, Error: err.Error()}
+			return runnerErrorResponse(err)
 		}
 		if process.Phase == statedb.ProcessTerminal ||
 			(startOutcome != "" && startOutcome != processStarted) {
@@ -1426,7 +1484,7 @@ func (s *runnerServerState) terminate(
 	err := runner.terminate(terminateCtx)
 	cancel()
 	if err != nil {
-		return runnerResponse{OK: false, Error: err.Error()}
+		return runnerErrorResponse(err)
 	}
 	return runnerResponse{OK: true}
 }
@@ -1438,19 +1496,68 @@ func (s *runnerServerState) markLocallyClosed() {
 	s.shutdown()
 }
 
+func (s *runnerServerState) closeForStorageExhaustion(ctx context.Context) error {
+	s.effectBoundaryMu.Lock()
+	defer s.effectBoundaryMu.Unlock()
+
+	s.mu.RLock()
+	ready := s.storageExhaustionReady
+	runner := s.prepared
+	s.mu.RUnlock()
+	if ready {
+		return errStorageExhaustionTerminalReady
+	}
+	if runner != nil {
+		_ = runner.CloseInput()
+		if runner.cmd == nil || runner.cmd.Process == nil {
+			_ = runner.output.Close()
+		} else {
+			closeCtx, cancel := context.WithTimeout(
+				context.WithoutCancel(ctx),
+				15*time.Second,
+			)
+			closure := terminateAndReapProcessCommand(closeCtx, runner)
+			if closure.ContainmentErr == nil {
+				closure.ContainmentErr = releaseProcessCommand(closeCtx, runner)
+			}
+			cancel()
+			if closure.ContainmentErr != nil {
+				return closure.ContainmentErr
+			}
+			_ = runner.waitOutputDrain()
+		}
+	}
+	s.markStorageExhaustionReady()
+	return errStorageExhaustionTerminalReady
+}
+
+func (s *runnerServerState) markStorageExhaustionReady() {
+	s.mu.Lock()
+	s.storageExhaustionReady = true
+	s.mu.Unlock()
+}
+
 func (s *runnerServerState) autonomousStateWrite(
 	ctx context.Context,
 	write func() error,
 ) error {
 	s.reconciliationMu.RLock()
 	defer s.reconciliationMu.RUnlock()
-	return retrySupervisorStateWrite(ctx, write)
+	s.mu.RLock()
+	ready := s.storageExhaustionReady
+	s.mu.RUnlock()
+	if ready {
+		return errStorageExhaustionTerminalReady
+	}
+	err := retrySupervisorStateWrite(ctx, write)
+	if isStorageExhaustion(err) {
+		return s.closeForStorageExhaustion(ctx)
+	}
+	return err
 }
 
 func (s *runnerServerState) autonomousLocalClosure(ctx context.Context) {
-	s.reconciliationMu.RLock()
-	defer s.reconciliationMu.RUnlock()
-	if err := retrySupervisorStateWrite(ctx, func() error {
+	if err := s.autonomousStateWrite(ctx, func() error {
 		return s.processState.MarkLocalClosed(ctx)
 	}); err == nil {
 		s.markLocallyClosed()
@@ -1470,8 +1577,9 @@ func (s *runnerServerState) stopForSupervisorExit(
 	runner := s.prepared
 	locallyClosed := s.localClosed
 	ungrantedClosed := s.ungrantedClosed
+	storageReady := s.storageExhaustionReady
 	s.mu.RUnlock()
-	if locallyClosed || ungrantedClosed ||
+	if locallyClosed || ungrantedClosed || storageReady ||
 		runner == nil ||
 		runner.cmd == nil ||
 		runner.cmd.Process == nil {
@@ -1500,7 +1608,8 @@ func retrySupervisorStateWrite(
 			return nil
 		}
 		if errors.Is(err, statedb.ErrStateConflict) ||
-			errors.Is(err, statedb.ErrSupervisorIdentityMismatch) {
+			errors.Is(err, statedb.ErrSupervisorIdentityMismatch) ||
+			errors.Is(err, statedb.ErrFull) {
 			return err
 		}
 		if sleepErr := sleepContext(ctx, time.Second); sleepErr != nil {

--- a/internal/machinedaemon/runner_server.go
+++ b/internal/machinedaemon/runner_server.go
@@ -138,7 +138,7 @@ func runCommandSupervisor(
 	defer func() {
 		_ = listener.Close()
 		resultErr = errors.Join(resultErr, localipc.Cleanup(endpoint))
-		if state.safeToReleaseLock() {
+		if state.safeToRemoveLock() {
 			resultErr = errors.Join(
 				resultErr,
 				lifetimeLock.ReleaseAndRemove(),
@@ -1457,10 +1457,10 @@ func (s *runnerServerState) autonomousLocalClosure(ctx context.Context) {
 	}
 }
 
-func (s *runnerServerState) safeToReleaseLock() bool {
+func (s *runnerServerState) safeToRemoveLock() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.localClosed || s.ungrantedClosed
+	return s.localClosed
 }
 
 func (s *runnerServerState) stopForSupervisorExit(

--- a/internal/machinedaemon/runner_server_exit_unix_test.go
+++ b/internal/machinedaemon/runner_server_exit_unix_test.go
@@ -120,3 +120,48 @@ func TestUnexpectedSupervisorListenerFailureClosesProcessContainment(
 		t.Fatal("unexpected listener failure left the child unreaped")
 	}
 }
+
+func TestStorageExhaustionClosesProcessBeforeTerminalReadiness(t *testing.T) {
+	t.Parallel()
+
+	command := exec.Command("/bin/sh", "-c", "sleep 30")
+	if err := setupProcessCommand(command); err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	runner := &localProcessRunner{
+		cmd:                 command,
+		terminalResultReady: make(chan struct{}),
+	}
+	released := false
+	t.Cleanup(func() {
+		if !released {
+			_ = command.Process.Kill()
+			_ = command.Wait()
+		}
+	})
+	if err := afterStartProcessCommand(runner); err != nil {
+		t.Fatal(err)
+	}
+	state := &runnerServerState{prepared: runner}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := state.closeForStorageExhaustion(ctx); !errors.Is(
+		err,
+		errStorageExhaustionTerminalReady,
+	) {
+		t.Fatalf("storage closure error = %v", err)
+	}
+	if command.ProcessState == nil {
+		t.Fatal("storage terminal readiness preceded process reaping")
+	}
+	if response := state.status(ctx); response.ErrorCode != runnerErrorStorageExhaustionReady {
+		t.Fatalf("storage-ready status = %+v", response)
+	}
+	if err := releaseProcessCommand(ctx, runner); err != nil {
+		t.Fatal(err)
+	}
+	released = true
+}

--- a/internal/machinedaemon/runner_subprocess.go
+++ b/internal/machinedaemon/runner_subprocess.go
@@ -169,8 +169,9 @@ func (subprocessRunnerLauncher) Prepare(
 			heldLock,
 		)
 		if cleanupErr != nil {
-			runtime.cleanupOnly = cleanupPending
-			if cleanupPending {
+			runtime.cleanupOnly = cleanupPending ||
+				(!supervisorStarted && lifetimeLock == nil && isStorageExhaustion(cause))
+			if runtime.cleanupOnly {
 				return errors.Join(
 					cause,
 					fmt.Errorf(
@@ -284,7 +285,7 @@ func (subprocessRunnerLauncher) Prepare(
 		wasCurrent := false
 		if current := c.processes[assignment.ID]; current != nil &&
 			current.supervisorInstanceID == supervisorInstanceID &&
-			!current.cleanupOnly {
+			!current.cleanupOnly && !current.storageFailureReporting {
 			delete(c.processes, assignment.ID)
 			wasCurrent = true
 		}

--- a/internal/machinedaemon/runner_subprocess.go
+++ b/internal/machinedaemon/runner_subprocess.go
@@ -93,7 +93,7 @@ func (subprocessRunnerLauncher) Prepare(
 		supervisorInstanceID: supervisorInstanceID,
 		done:                 make(chan struct{}),
 	}
-	rt := &processRuntime{
+	runtime := &processRuntime{
 		processID:            assignment.ID,
 		supervisorInstanceID: supervisorInstanceID,
 		runner:               runner,
@@ -157,20 +157,29 @@ func (subprocessRunnerLauncher) Prepare(
 			)
 		}
 
-		var cleanupErr error
-		if lifetimeLock != nil {
-			cleanupErr = lifetimeLock.Release()
+		heldLock := lifetimeLock
+		if supervisorStarted {
+			heldLock = nil
 		}
-		cleanupErr = errors.Join(
-			cleanupErr,
-			c.closeRejectedPreparation(
-				cleanupCtx,
-				assignment.ID,
-				supervisorInstanceID,
-				nil,
-			),
+		cleanupPending, cleanupErr := c.closeRejectedPreparation(
+			cleanupCtx,
+			assignment.ID,
+			supervisorInstanceID,
+			nil,
+			heldLock,
 		)
 		if cleanupErr != nil {
+			runtime.cleanupOnly = cleanupPending
+			if cleanupPending {
+				return errors.Join(
+					cause,
+					fmt.Errorf(
+						"rollback ungranted process %s cleanup remains pending: %w",
+						assignment.ID,
+						cleanupErr,
+					),
+				)
+			}
 			return errors.Join(
 				errUnresolvedProcessPreparation,
 				cause,
@@ -186,11 +195,11 @@ func (subprocessRunnerLauncher) Prepare(
 
 	lockPath, err := machine.LifetimeLockPath(assignment.ID)
 	if err != nil {
-		return nil, fail(err)
+		return runtime, fail(err)
 	}
 	lifetimeLock, err = localstore.TryAcquireLock(lockPath)
 	if err != nil {
-		return nil, fail(
+		return runtime, fail(
 			fmt.Errorf("acquire supervisor lifetime lock: %w", err),
 		)
 	}
@@ -209,7 +218,7 @@ func (subprocessRunnerLauncher) Prepare(
 		machine.RunDir(),
 	)
 	if err != nil {
-		return nil, fail(err)
+		return runtime, fail(err)
 	}
 	defer func() {
 		if err := removeSupervisorIdentityBootstrap(
@@ -229,7 +238,7 @@ func (subprocessRunnerLauncher) Prepare(
 
 	executable, err := os.Executable()
 	if err != nil {
-		return nil, fail(err)
+		return runtime, fail(err)
 	}
 	command = exec.Command( //nolint:noctx // The supervisor intentionally survives daemon cancellation.
 		executable,
@@ -243,19 +252,19 @@ func (subprocessRunnerLauncher) Prepare(
 	)
 	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
 	if err != nil {
-		return nil, fail(err)
+		return runtime, fail(err)
 	}
 	defer func() { _ = devNull.Close() }()
 	command.Stdin = devNull
 	command.Stdout = devNull
 	command.Stderr = devNull
 	if err := detachRunnerCommand(command); err != nil {
-		return nil, fail(err)
+		return runtime, fail(err)
 	}
 	inheritedLockFD, restoreInheritance, err :=
 		lifetimeLock.PrepareChildInheritance(command)
 	if err != nil {
-		return nil, fail(err)
+		return runtime, fail(err)
 	}
 	command.Args = append(command.Args, strconv.Itoa(inheritedLockFD))
 	startErr := func() error {
@@ -263,10 +272,10 @@ func (subprocessRunnerLauncher) Prepare(
 		return command.Start()
 	}()
 	if startErr != nil {
-		return nil, fail(startErr)
+		return runtime, fail(startErr)
 	}
 	supervisorStarted = true
-	rt.supervisorPID = command.Process.Pid
+	runtime.supervisorPID = command.Process.Pid
 	supervisorDone = make(chan struct{})
 	go func() {
 		waitErr := command.Wait()
@@ -274,7 +283,8 @@ func (subprocessRunnerLauncher) Prepare(
 		runner.markDone()
 		wasCurrent := false
 		if current := c.processes[assignment.ID]; current != nil &&
-			current.supervisorInstanceID == supervisorInstanceID {
+			current.supervisorInstanceID == supervisorInstanceID &&
+			!current.cleanupOnly {
 			delete(c.processes, assignment.ID)
 			wasCurrent = true
 		}
@@ -292,22 +302,22 @@ func (subprocessRunnerLauncher) Prepare(
 	}()
 	if err := lifetimeLock.RelinquishInherited(); err != nil {
 		_ = command.Process.Kill()
-		return nil, fail(err)
+		return runtime, fail(err)
 	}
 	if err := runner.waitReady(ctx); err != nil {
-		return nil, fail(err)
+		return runtime, fail(err)
 	}
 	if err := runner.prepare(ctx, assignment); err != nil {
-		return nil, fail(err)
+		return runtime, fail(err)
 	}
 	if err := stateStore.MarkPrepared(
 		ctx,
 		assignment.ID,
 		supervisorInstanceID,
 	); err != nil {
-		return nil, fail(err)
+		return runtime, fail(err)
 	}
-	return rt, nil
+	return runtime, nil
 }
 
 func (r *ipcProcessRunner) prepare(

--- a/internal/machinedaemon/runtime_types.go
+++ b/internal/machinedaemon/runtime_types.go
@@ -193,11 +193,12 @@ type processClosureResult struct {
 }
 
 type processRuntime struct {
-	processID            string
-	supervisorInstanceID string
-	supervisorPID        int
-	runner               processRunner
-	cleanupOnly          bool
+	processID               string
+	supervisorInstanceID    string
+	supervisorPID           int
+	runner                  processRunner
+	cleanupOnly             bool
+	storageFailureReporting bool
 }
 
 type localProcessRunner struct {

--- a/internal/machinedaemon/runtime_types.go
+++ b/internal/machinedaemon/runtime_types.go
@@ -197,6 +197,7 @@ type processRuntime struct {
 	supervisorInstanceID string
 	supervisorPID        int
 	runner               processRunner
+	cleanupOnly          bool
 }
 
 type localProcessRunner struct {

--- a/internal/machinedaemon/statedb/internal/dbsqlc/process.sql.go
+++ b/internal/machinedaemon/statedb/internal/dbsqlc/process.sql.go
@@ -267,30 +267,6 @@ func (q *Queries) GetProcessSupervisorIdentity(ctx context.Context, arg GetProce
 	return i, err
 }
 
-const getUngrantedProcessStatus = `-- name: GetUngrantedProcessStatus :one
-SELECT phase, exec_committed
-FROM processes
-WHERE process_id = ?1
-  AND supervisor_instance_id = ?2
-`
-
-type GetUngrantedProcessStatusParams struct {
-	ProcessID            string
-	SupervisorInstanceID string
-}
-
-type GetUngrantedProcessStatusRow struct {
-	Phase         string
-	ExecCommitted int64
-}
-
-func (q *Queries) GetUngrantedProcessStatus(ctx context.Context, arg GetUngrantedProcessStatusParams) (GetUngrantedProcessStatusRow, error) {
-	row := q.db.QueryRowContext(ctx, getUngrantedProcessStatus, arg.ProcessID, arg.SupervisorInstanceID)
-	var i GetUngrantedProcessStatusRow
-	err := row.Scan(&i.Phase, &i.ExecCommitted)
-	return i, err
-}
-
 const insertProcess = `-- name: InsertProcess :exec
 INSERT INTO processes(
     process_id,

--- a/internal/machinedaemon/statedb/process.go
+++ b/internal/machinedaemon/statedb/process.go
@@ -106,29 +106,29 @@ func (s *Store) DeleteRejectedPreparationAfterArtifacts(
 	defer func() { _ = tx.Rollback() }()
 	qtx := s.q.WithTx(tx)
 
-	status, err := qtx.GetUngrantedProcessStatus(
-		ctx,
-		dbsqlc.GetUngrantedProcessStatusParams{
-			ProcessID:            processID,
-			SupervisorInstanceID: supervisorInstanceID,
-		},
-	)
-	if errors.Is(err, sql.ErrNoRows) {
+	process, found, err := processTx(ctx, qtx, processID)
+	if err != nil {
+		return err
+	}
+	if !found {
 		return commitWrite(tx)
 	}
-	if err != nil {
-		return dbError("read ungranted process state", err)
+	if process.SupervisorInstanceID != supervisorInstanceID {
+		return fmt.Errorf(
+			"%w: %s",
+			ErrSupervisorIdentityMismatch,
+			processID,
+		)
 	}
-	phase := ProcessPhase(status.Phase)
-	if phase != ProcessPreparing && phase != ProcessPrepared {
+	if process.Phase != ProcessPreparing && process.Phase != ProcessPrepared {
 		return fmt.Errorf(
 			"%w: process %s is %s, not an ungranted preparation",
 			ErrStateConflict,
 			processID,
-			phase,
+			process.Phase,
 		)
 	}
-	if status.ExecCommitted != 0 {
+	if process.ExecCommitted {
 		return fmt.Errorf(
 			"%w: ungranted process %s crossed the execution boundary",
 			ErrStateConflict,

--- a/internal/machinedaemon/statedb/process.go
+++ b/internal/machinedaemon/statedb/process.go
@@ -99,6 +99,21 @@ func (s *Store) DeleteRejectedPreparationAfterArtifacts(
 	ctx context.Context,
 	processID, supervisorInstanceID string,
 ) error {
+	return s.deleteProcessAfterArtifacts(ctx, processID, supervisorInstanceID, false)
+}
+
+func (s *Store) DeleteStorageExhaustedAfterArtifacts(
+	ctx context.Context,
+	processID, supervisorInstanceID string,
+) error {
+	return s.deleteProcessAfterArtifacts(ctx, processID, supervisorInstanceID, true)
+}
+
+func (s *Store) deleteProcessAfterArtifacts(
+	ctx context.Context,
+	processID, supervisorInstanceID string,
+	accepted bool,
+) error {
 	tx, err := beginWrite(ctx, s.db)
 	if err != nil {
 		return err
@@ -120,15 +135,19 @@ func (s *Store) DeleteRejectedPreparationAfterArtifacts(
 			processID,
 		)
 	}
-	if process.Phase != ProcessPreparing && process.Phase != ProcessPrepared {
+	validPhase := process.Phase == ProcessPreparing || process.Phase == ProcessPrepared
+	if accepted {
+		validPhase = process.Phase == ProcessAccepted || process.Phase == ProcessTerminal
+	}
+	if !validPhase {
 		return fmt.Errorf(
-			"%w: process %s is %s, not an ungranted preparation",
+			"%w: process %s cannot be deleted in %s",
 			ErrStateConflict,
 			processID,
 			process.Phase,
 		)
 	}
-	if process.ExecCommitted {
+	if !accepted && process.ExecCommitted {
 		return fmt.Errorf(
 			"%w: ungranted process %s crossed the execution boundary",
 			ErrStateConflict,
@@ -142,7 +161,7 @@ func (s *Store) DeleteRejectedPreparationAfterArtifacts(
 			SupervisorInstanceID: supervisorInstanceID,
 		},
 	); err != nil {
-		return dbError("delete ungranted process state", err)
+		return dbError("delete process state", err)
 	}
 	return commitWrite(tx)
 }

--- a/internal/machinedaemon/statedb/queries/process.sql
+++ b/internal/machinedaemon/statedb/queries/process.sql
@@ -34,12 +34,6 @@ WHERE process_id = sqlc.arg(process_id)
   AND local_closed = 0
   AND server_released = 0;
 
--- name: GetUngrantedProcessStatus :one
-SELECT phase, exec_committed
-FROM processes
-WHERE process_id = sqlc.arg(process_id)
-  AND supervisor_instance_id = sqlc.arg(supervisor_instance_id);
-
 -- name: DeleteProcess :exec
 DELETE FROM processes
 WHERE process_id = sqlc.arg(process_id)

--- a/internal/machinedaemon/statedb/statedbtest/faults.go
+++ b/internal/machinedaemon/statedb/statedbtest/faults.go
@@ -1,0 +1,32 @@
+package statedbtest
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	_ "modernc.org/sqlite"
+)
+
+func SetProcessDeleteFailure(
+	ctx context.Context,
+	path string,
+	enabled bool,
+) error {
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return err
+	}
+	statement := `DROP TRIGGER IF EXISTS fail_rejected_preparation_delete`
+	if enabled {
+		statement = `
+CREATE TRIGGER fail_rejected_preparation_delete
+BEFORE DELETE ON processes
+BEGIN
+    SELECT RAISE(ABORT, 'injected rejected preparation delete failure');
+END;
+`
+	}
+	_, execErr := db.ExecContext(ctx, statement)
+	return errors.Join(execErr, db.Close())
+}

--- a/internal/machinedaemon/statedb/store.go
+++ b/internal/machinedaemon/statedb/store.go
@@ -49,6 +49,7 @@ const (
 
 var (
 	ErrBusy                       = errors.New("state database is busy")
+	ErrFull                       = errors.New("state database is full")
 	ErrProcessExists              = errors.New("local state already exists for process")
 	ErrSupervisorIdentityMismatch = errors.New("supervisor identity mismatch")
 	ErrStateConflict              = errors.New("local state conflict")
@@ -487,6 +488,9 @@ func dbError(operation string, err error) error {
 	var sqliteErr *sqlite3.Error
 	if errors.As(err, &sqliteErr) {
 		code := sqliteErr.Code() & 0xff
+		if code == sqlite3lib.SQLITE_FULL {
+			return fmt.Errorf("%s: %w: %w", operation, ErrFull, err)
+		}
 		if code == sqlite3lib.SQLITE_BUSY || code == sqlite3lib.SQLITE_LOCKED {
 			return fmt.Errorf("%s: %w: %w", operation, ErrBusy, err)
 		}

--- a/internal/machinedaemon/statedb/store_test.go
+++ b/internal/machinedaemon/statedb/store_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/omnara-ai/omnara/internal/daemonprotocol"
 	"github.com/omnara-ai/omnara/internal/processaction"
+	sqlite3 "modernc.org/sqlite"
 )
 
 const (
@@ -63,6 +64,32 @@ func TestEmptyCollectionsAreNil(t *testing.T) {
 	}
 	if reports != nil {
 		t.Fatalf("process reports = %#v, want nil", reports)
+	}
+}
+
+func TestDatabaseFullHasTypedCause(t *testing.T) {
+	t.Parallel()
+
+	store, _ := openTestStore(t)
+	ctx := context.Background()
+	if _, err := store.db.ExecContext(ctx, "CREATE TABLE storage_fill (body BLOB NOT NULL)"); err != nil {
+		t.Fatal(err)
+	}
+	var pages int
+	if err := store.db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pages); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, "PRAGMA max_page_count = "+strconv.Itoa(pages)); err != nil {
+		t.Fatal(err)
+	}
+	_, err := store.db.ExecContext(ctx, "INSERT INTO storage_fill(body) VALUES (zeroblob(10485760))")
+	classified := dbError("fill state database", err)
+	if err == nil || !errors.Is(classified, ErrFull) {
+		t.Fatalf("database full error = %v", classified)
+	}
+	var sqliteErr *sqlite3.Error
+	if !errors.As(classified, &sqliteErr) {
+		t.Fatalf("database full error lost SQLite cause: %v", classified)
 	}
 }
 
@@ -113,6 +140,16 @@ func TestDeleteRejectedPreparationRequiresExactUngrantedIdentity(t *testing.T) {
 		process.SupervisorInstanceID,
 	); !errors.Is(err, ErrStateConflict) {
 		t.Fatalf("accepted cleanup error = %v, want state conflict", err)
+	}
+	if err := store.DeleteStorageExhaustedAfterArtifacts(
+		ctx,
+		process.ProcessID,
+		process.SupervisorInstanceID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, found, err := store.Process(ctx, process.ProcessID); err != nil || found {
+		t.Fatalf("process after accepted cleanup: found=%t err=%v", found, err)
 	}
 }
 

--- a/internal/machinedaemon/statedb/store_test.go
+++ b/internal/machinedaemon/statedb/store_test.go
@@ -66,6 +66,56 @@ func TestEmptyCollectionsAreNil(t *testing.T) {
 	}
 }
 
+func TestDeleteRejectedPreparationRequiresExactUngrantedIdentity(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store, _ := openTestStore(t)
+	if err := store.DeleteRejectedPreparationAfterArtifacts(
+		ctx,
+		"prc_missing_rejected_cleanup",
+		"supervisor-instance-missing-rejected-cleanup",
+	); err != nil {
+		t.Fatalf("idempotent missing cleanup: %v", err)
+	}
+	process := Process{
+		ProcessID:            "prc_rejected_cleanup_identity",
+		SupervisorInstanceID: "supervisor-instance-rejected-cleanup",
+		SupervisorToken:      "supervisor-token-rejected-cleanup",
+	}
+	if err := store.ReserveProcess(ctx, process); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkPrepared(
+		ctx,
+		process.ProcessID,
+		process.SupervisorInstanceID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DeleteRejectedPreparationAfterArtifacts(
+		ctx,
+		process.ProcessID,
+		"supervisor-instance-replacement",
+	); !errors.Is(err, ErrSupervisorIdentityMismatch) {
+		t.Fatalf("replacement cleanup error = %v, want identity mismatch", err)
+	}
+	if err := store.MarkAccepted(
+		ctx,
+		process.ProcessID,
+		process.SupervisorInstanceID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DeleteRejectedPreparationAfterArtifacts(
+		ctx,
+		process.ProcessID,
+		process.SupervisorInstanceID,
+	); !errors.Is(err, ErrStateConflict) {
+		t.Fatalf("accepted cleanup error = %v, want state conflict", err)
+	}
+}
+
 func TestProcessCrossesExecutionBoundaryOnce(t *testing.T) {
 	ctx := context.Background()
 	store, path := openTestStore(t)

--- a/internal/machinedaemon/stopped_process_recovery_test.go
+++ b/internal/machinedaemon/stopped_process_recovery_test.go
@@ -32,6 +32,7 @@ func TestStoppedSupervisorRecoveryPreservesDurableOutput(
 		context.Background(),
 		process.ProcessID,
 		process.SupervisorInstanceID,
+		nil,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -64,6 +65,7 @@ func TestStoppedSupervisorRecoveryMakesCorruptOutputExplicit(
 		context.Background(),
 		process.ProcessID,
 		process.SupervisorInstanceID,
+		nil,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -91,6 +93,7 @@ func TestStoppedSupervisorRecoveryMakesMissingOutputExplicit(
 		context.Background(),
 		process.ProcessID,
 		process.SupervisorInstanceID,
+		nil,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/machinedaemon/storage_exhaustion.go
+++ b/internal/machinedaemon/storage_exhaustion.go
@@ -114,6 +114,11 @@ func (c *Client) handleAcceptedStorageFailure(
 		err = runner.Terminate(terminateCtx, "server_resolved")
 		cancel()
 	}
+	if err == nil {
+		if socket, ok := transport.(*daemonSocketTransport); ok {
+			socket.forgetResolvedProcessActions(runtime.processID)
+		}
+	}
 	c.processMu.Lock()
 	if err != nil {
 		runtime.storageFailureReporting = false
@@ -125,11 +130,6 @@ func (c *Client) handleAcceptedStorageFailure(
 		}
 	}
 	c.processMu.Unlock()
-	if err == nil {
-		if socket, ok := transport.(*daemonSocketTransport); ok {
-			socket.forgetResolvedProcessActions(runtime.processID)
-		}
-	}
 	return true, err
 }
 

--- a/internal/machinedaemon/storage_exhaustion.go
+++ b/internal/machinedaemon/storage_exhaustion.go
@@ -1,0 +1,150 @@
+package machinedaemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"syscall"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/omnara-ai/omnara/internal/daemonprotocol"
+	"github.com/omnara-ai/omnara/internal/machinedaemon/statedb"
+)
+
+func isStorageExhaustion(err error) bool {
+	return errors.Is(err, syscall.ENOSPC) ||
+		errors.Is(err, syscall.EDQUOT) ||
+		errors.Is(err, statedb.ErrFull) ||
+		errors.Is(err, errRunnerStorageExhaustion)
+}
+
+func sendStorageExhaustionReport(
+	ctx context.Context,
+	transport daemonReportTransport,
+	processID string,
+) error {
+	body, err := json.Marshal(daemonReportedEvent{
+		Type:               daemonprotocol.EventProcessFinished,
+		ProcessID:          processID,
+		State:              daemonprotocol.ProcessStateFailed,
+		StateReasonCode:    daemonprotocol.ProcessReasonMachineStorageExhausted,
+		StateReasonMessage: daemonprotocol.ProcessMessageMachineStorageExhausted,
+	})
+	if err != nil {
+		return err
+	}
+	ack, err := transport.SendReport(ctx, statedb.Report{
+		ID:        uuid.NewString(),
+		ProcessID: processID,
+		Kind:      statedb.ReportProcessTerminal,
+		Body:      body,
+	})
+	if err != nil {
+		return err
+	}
+	if ack.status == daemonprotocol.AckStatusCommitted ||
+		ack.status == daemonprotocol.AckStatusCleanupOnly {
+		return nil
+	}
+	return fmt.Errorf(
+		"storage exhaustion report rejected (%s, %s): %s",
+		ack.status,
+		ack.code,
+		ack.err,
+	)
+}
+
+func (c *Client) handleAcceptedStorageFailure(
+	ctx context.Context,
+	transport daemonReportTransport,
+	runtime *processRuntime,
+	cause error,
+) (bool, error) {
+	ready := errors.Is(cause, errStorageExhaustionTerminalReady)
+	if !ready && !isStorageExhaustion(cause) {
+		return false, cause
+	}
+	if runtime == nil || runtime.runner == nil {
+		return false, errors.New("storage-exhausted process has no supervisor")
+	}
+	runner := runtime.runner
+	c.processMu.Lock()
+	current := c.processes[runtime.processID]
+	if runtime.storageFailureReporting || (current != nil && current != runtime) {
+		c.processMu.Unlock()
+		return true, nil
+	}
+	runtime.storageFailureReporting = true
+	if current == nil {
+		c.processes[runtime.processID] = runtime
+	}
+	c.processMu.Unlock()
+	if !ready {
+		terminateCtx, cancel := context.WithTimeout(
+			context.WithoutCancel(ctx),
+			15*time.Second,
+		)
+		err := runner.Terminate(
+			terminateCtx,
+			daemonprotocol.ProcessReasonMachineStorageExhausted,
+		)
+		cancel()
+		if err != nil && !errors.Is(err, errStorageExhaustionTerminalReady) {
+			c.processMu.Lock()
+			runtime.storageFailureReporting = false
+			c.processMu.Unlock()
+			return false, err
+		}
+	}
+
+	err := sendStorageExhaustionReport(ctx, transport, runtime.processID)
+	if err != nil {
+		c.processMu.Lock()
+		runtime.storageFailureReporting = false
+		c.processMu.Unlock()
+		return true, err
+	}
+	if !runner.IsDone() {
+		terminateCtx, cancel := context.WithTimeout(
+			context.WithoutCancel(ctx),
+			10*time.Second,
+		)
+		err = runner.Terminate(terminateCtx, "server_resolved")
+		cancel()
+	}
+	c.processMu.Lock()
+	if err != nil {
+		runtime.storageFailureReporting = false
+	} else if c.processes[runtime.processID] == runtime {
+		c.processes[runtime.processID] = &processRuntime{
+			processID:            runtime.processID,
+			supervisorInstanceID: runtime.supervisorInstanceID,
+			cleanupOnly:          true,
+		}
+	}
+	c.processMu.Unlock()
+	if err == nil {
+		if socket, ok := transport.(*daemonSocketTransport); ok {
+			socket.forgetResolvedProcessActions(runtime.processID)
+		}
+	}
+	return true, err
+}
+
+func (c *Client) storageFailureRuntimes() []*processRuntime {
+	c.processMu.RLock()
+	defer c.processMu.RUnlock()
+	var runtimes []*processRuntime
+	for _, runtime := range c.processes {
+		if runtime == nil || runtime.cleanupOnly || runtime.storageFailureReporting {
+			continue
+		}
+		runner, ok := runtime.runner.(*ipcProcessRunner)
+		if ok && runner.storageExhaustionReady() {
+			runtimes = append(runtimes, runtime)
+		}
+	}
+	return runtimes
+}

--- a/internal/machinedaemon/storage_exhaustion_test.go
+++ b/internal/machinedaemon/storage_exhaustion_test.go
@@ -1,0 +1,404 @@
+package machinedaemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"syscall"
+	"testing"
+
+	"github.com/omnara-ai/omnara/internal/daemonprotocol"
+	"github.com/omnara-ai/omnara/internal/machinedaemon/localstore"
+	"github.com/omnara-ai/omnara/internal/machinedaemon/statedb"
+	"github.com/omnara-ai/omnara/internal/machinedaemon/statedb/statedbtest"
+)
+
+type storageExhaustionRunner struct {
+	done      chan struct{}
+	startErr  error
+	terminate []string
+}
+
+func (r *storageExhaustionRunner) Status(context.Context) error                   { return nil }
+func (r *storageExhaustionRunner) StartOnce(context.Context) error                { return r.startErr }
+func (r *storageExhaustionRunner) ApplyOnce(context.Context, ProcessAction) error { return nil }
+func (r *storageExhaustionRunner) CloseUngranted(context.Context) error           { return nil }
+func (r *storageExhaustionRunner) Terminate(_ context.Context, reason string) error {
+	r.terminate = append(r.terminate, reason)
+	if reason == daemonprotocol.ProcessReasonMachineStorageExhausted {
+		return errStorageExhaustionTerminalReady
+	}
+	return nil
+}
+func (r *storageExhaustionRunner) Done() <-chan struct{} { return r.done }
+func (r *storageExhaustionRunner) IsDone() bool {
+	select {
+	case <-r.done:
+		return true
+	default:
+		return false
+	}
+}
+
+type storageExhaustionTransport struct {
+	report  statedb.Report
+	reports int
+}
+
+func (t *storageExhaustionTransport) SendReport(
+	_ context.Context,
+	report statedb.Report,
+) (daemonReportAck, error) {
+	t.report = report
+	t.reports++
+	return daemonReportAck{status: daemonprotocol.AckStatusCommitted}, nil
+}
+
+func TestStorageExhaustionClassifierIsNarrow(t *testing.T) {
+	t.Parallel()
+
+	for _, err := range []error{
+		syscall.ENOSPC,
+		syscall.EDQUOT,
+		fmt.Errorf("wrapped: %w", statedb.ErrFull),
+		fmt.Errorf("wrapped: %w", errRunnerStorageExhaustion),
+	} {
+		if !isStorageExhaustion(err) {
+			t.Fatalf("error %v was not classified as storage exhaustion", err)
+		}
+	}
+	for _, err := range []error{
+		errors.New("database or disk is full"),
+		errors.New("input/output error"),
+		context.DeadlineExceeded,
+	} {
+		if isStorageExhaustion(err) {
+			t.Fatalf("error %v was classified as storage exhaustion", err)
+		}
+	}
+}
+
+func TestSupervisorStateWriteDoesNotRetryFull(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	err := retrySupervisorStateWrite(context.Background(), func() error {
+		calls++
+		return statedb.ErrFull
+	})
+	if !errors.Is(err, statedb.ErrFull) || calls != 1 {
+		t.Fatalf("retry result: calls=%d err=%v", calls, err)
+	}
+}
+
+func TestAutonomousStateWriteStopsAfterStorageExhaustion(t *testing.T) {
+	t.Parallel()
+
+	state := &runnerServerState{storageExhaustionReady: true}
+	called := false
+	err := state.autonomousStateWrite(context.Background(), func() error {
+		called = true
+		return nil
+	})
+	if !errors.Is(err, errStorageExhaustionTerminalReady) || called {
+		t.Fatalf("autonomous write after storage exhaustion: called=%t err=%v", called, err)
+	}
+}
+
+func TestStorageExhaustionBeforeSpawnBecomesTerminalReady(t *testing.T) {
+	t.Parallel()
+
+	state := &runnerServerState{
+		prepared: &localProcessRunner{startErr: syscall.ENOSPC},
+	}
+	response := state.handle(
+		context.Background(),
+		runnerRequest{Method: runnerMethodStartOnce},
+	)
+	if response.ErrorCode != runnerErrorStorageExhaustionReady ||
+		state.prepared.cmd != nil {
+		t.Fatalf("storage start response = %+v", response)
+	}
+}
+
+func TestAcceptedStorageFailureReportsAfterContainment(t *testing.T) {
+	t.Parallel()
+
+	client := New(Config{}, nil, nil)
+	runner := &storageExhaustionRunner{done: make(chan struct{})}
+	runtime := &processRuntime{
+		processID:            "prc_storage_report",
+		supervisorInstanceID: "supervisor-storage-report",
+		runner:               runner,
+	}
+	transport := &storageExhaustionTransport{}
+	handled, err := client.handleAcceptedStorageFailure(
+		context.Background(),
+		transport,
+		runtime,
+		statedb.ErrFull,
+	)
+	resolved, found := client.localProcess(runtime.processID)
+	if err != nil || !handled || !found || resolved == runtime ||
+		!resolved.cleanupOnly || resolved.runner != nil ||
+		runtime.cleanupOnly || runtime.runner != runner {
+		t.Fatalf(
+			"storage failure: handled=%t runtime=%+v resolved=%+v err=%v",
+			handled,
+			runtime,
+			resolved,
+			err,
+		)
+	}
+	var event daemonReportedEvent
+	if err := json.Unmarshal(transport.report.Body, &event); err != nil {
+		t.Fatal(err)
+	}
+	if event.State != daemonprotocol.ProcessStateFailed ||
+		event.StateReasonCode != daemonprotocol.ProcessReasonMachineStorageExhausted ||
+		event.StateReasonMessage != daemonprotocol.ProcessMessageMachineStorageExhausted {
+		t.Fatalf("storage report = %+v", event)
+	}
+	want := []string{daemonprotocol.ProcessReasonMachineStorageExhausted, "server_resolved"}
+	if !slices.Equal(runner.terminate, want) {
+		t.Fatalf("termination calls = %v, want %v", runner.terminate, want)
+	}
+	handled, err = client.handleAcceptedStorageFailure(
+		context.Background(),
+		transport,
+		runtime,
+		errStorageExhaustionTerminalReady,
+	)
+	if err != nil || !handled || transport.reports != 1 {
+		t.Fatalf(
+			"repeated storage failure: handled=%t reports=%d err=%v",
+			handled,
+			transport.reports,
+			err,
+		)
+	}
+}
+
+func TestStartupSkipsActionsForStorageExhaustedProcess(t *testing.T) {
+	t.Parallel()
+
+	runner := &ipcProcessRunner{}
+	runner.storageFailureReady.Store(true)
+	startup := localStartupState{
+		Runners: map[string]*processRuntime{
+			"prc_storage_startup": {runner: runner},
+		},
+		Actions: []reconciledAction{{
+			processID: "prc_storage_startup",
+			action:    ProcessAction{ID: "act_storage_startup"},
+		}},
+	}
+	client := New(Config{}, nil, nil)
+	transport := newDaemonSocketTransport(&client, DaemonRuntime{}, startup)
+	transport.resumeStartupActions(context.Background())
+	if len(transport.pendingActions) != 0 || len(transport.actionQueues) != 0 {
+		t.Fatal("storage-exhausted process resumed stale actions")
+	}
+}
+
+func TestRegistrationStartRetainsStorageExhaustedSupervisor(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	const (
+		processID            = "prc_storage_registration"
+		supervisorInstanceID = "supervisor-storage-registration"
+	)
+	client := New(Config{OmnaraHome: t.TempDir()}, nil, nil)
+	client.bootstrap = daemonBootstrap{
+		InstallationID: "ins_storage_registration",
+		MachineID:      "mch_storage_registration",
+	}
+	t.Cleanup(func() { _ = client.closeState() })
+	store, err := client.stateStore(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ReserveProcess(ctx, statedb.Process{
+		ProcessID:            processID,
+		SupervisorInstanceID: supervisorInstanceID,
+		SupervisorToken:      "supervisor-token-storage-registration",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkPrepared(ctx, processID, supervisorInstanceID); err != nil {
+		t.Fatal(err)
+	}
+	runner := &storageExhaustionRunner{
+		done:     make(chan struct{}),
+		startErr: syscall.ENOSPC,
+	}
+	runtime := &processRuntime{
+		processID:            processID,
+		supervisorInstanceID: supervisorInstanceID,
+		runner:               runner,
+	}
+	startup := localStartupState{
+		Runners:       map[string]*processRuntime{processID: runtime},
+		ForcedReports: make(map[string]struct{}),
+	}
+	if err := client.applyProcessDisposition(
+		ctx,
+		&startup,
+		ProcessReconciliationClaim{
+			ProcessID:            processID,
+			SupervisorInstanceID: supervisorInstanceID,
+		},
+		ProcessReconciliationDirective{
+			ProcessID:            processID,
+			SupervisorInstanceID: supervisorInstanceID,
+			Disposition:          daemonprotocol.ProcessDispositionStart,
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if startup.Runners[processID] != runtime {
+		t.Fatal("storage-exhausted supervisor was not retained")
+	}
+	if !slices.Equal(
+		runner.terminate,
+		[]string{daemonprotocol.ProcessReasonMachineStorageExhausted},
+	) {
+		t.Fatalf("termination calls = %v", runner.terminate)
+	}
+}
+
+func TestRegistrationStartRetainsTerminalReadySupervisor(t *testing.T) {
+	t.Parallel()
+
+	client := New(Config{OmnaraHome: t.TempDir()}, nil, nil)
+	client.bootstrap = daemonBootstrap{
+		InstallationID: "ins_storage_registration_ready",
+		MachineID:      "mch_storage_registration_ready",
+	}
+	t.Cleanup(func() { _ = client.closeState() })
+	runner := &ipcProcessRunner{}
+	runner.storageFailureReady.Store(true)
+	const processID = "prc_storage_registration_ready"
+	runtime := &processRuntime{processID: processID, runner: runner}
+	startup := localStartupState{
+		Runners:       map[string]*processRuntime{processID: runtime},
+		ForcedReports: make(map[string]struct{}),
+	}
+	if err := client.applyProcessDisposition(
+		context.Background(),
+		&startup,
+		ProcessReconciliationClaim{ProcessID: processID},
+		ProcessReconciliationDirective{
+			ProcessID:   processID,
+			Disposition: daemonprotocol.ProcessDispositionStart,
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if startup.Runners[processID] != runtime {
+		t.Fatal("terminal-ready supervisor was not retained")
+	}
+}
+
+func TestAcceptedCleanupHandlesLifetimeLock(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	const (
+		processID            = "prc_storage_lock"
+		supervisorInstanceID = "supervisor-storage-lock"
+	)
+	client := New(Config{OmnaraHome: t.TempDir()}, nil, nil)
+	client.bootstrap = daemonBootstrap{InstallationID: "ins_storage_lock", MachineID: "mch_storage_lock"}
+	t.Cleanup(func() { _ = client.closeState() })
+	store, err := client.stateStore(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ReserveProcess(ctx, statedb.Process{
+		ProcessID:            processID,
+		SupervisorInstanceID: supervisorInstanceID,
+		SupervisorToken:      "supervisor-token-storage-lock",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkPrepared(ctx, processID, supervisorInstanceID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkAccepted(ctx, processID, supervisorInstanceID); err != nil {
+		t.Fatal(err)
+	}
+	machine, err := client.machineStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := localstore.EnsurePrivateDir(machine.RunDir()); err != nil {
+		t.Fatal(err)
+	}
+	lockPath, err := machine.LifetimeLockPath(processID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock, err := localstore.TryAcquireLock(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lock.Release(); err != nil {
+		t.Fatal(err)
+	}
+	if err := statedbtest.SetProcessDeleteFailure(ctx, machine.StateDBPath(), true); err != nil {
+		t.Fatal(err)
+	}
+	runtime := &processRuntime{
+		processID:            processID,
+		supervisorInstanceID: supervisorInstanceID,
+	}
+	pending, err := client.closeStorageExhaustedProcess(ctx, runtime)
+	if err == nil || !pending {
+		t.Fatalf("cleanup with state deletion failure: pending=%t err=%v", pending, err)
+	}
+	retained, err := localstore.TryAcquireExistingLock(lockPath)
+	if err != nil {
+		t.Fatalf("retained lifetime lock = %v", err)
+	}
+	if err := retained.Release(); err != nil {
+		t.Fatal(err)
+	}
+	if err := statedbtest.SetProcessDeleteFailure(ctx, machine.StateDBPath(), false); err != nil {
+		t.Fatal(err)
+	}
+	pending, err = client.closeStorageExhaustedProcess(ctx, runtime)
+	if err != nil || pending {
+		t.Fatalf("cleanup retry: pending=%t err=%v", pending, err)
+	}
+	if _, err := os.Stat(lockPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("lifetime lock after cleanup = %v", err)
+	}
+	if _, found, err := store.Process(ctx, processID); err != nil || found {
+		t.Fatalf("process after cleanup: found=%t err=%v", found, err)
+	}
+	if err := store.ReserveProcess(ctx, statedb.Process{
+		ProcessID:            processID,
+		SupervisorInstanceID: supervisorInstanceID,
+		SupervisorToken:      "supervisor-token-storage-lock",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkPrepared(ctx, processID, supervisorInstanceID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkAccepted(ctx, processID, supervisorInstanceID); err != nil {
+		t.Fatal(err)
+	}
+	pending, err = client.closeStorageExhaustedProcess(ctx, runtime)
+	if err != nil || pending {
+		t.Fatalf("cleanup with missing lifetime lock: pending=%t err=%v", pending, err)
+	}
+	if _, found, err := store.Process(ctx, processID); err != nil || found {
+		t.Fatalf("process after missing-lock cleanup: found=%t err=%v", found, err)
+	}
+}

--- a/internal/machinedaemon/supervisor_crash_unix_test.go
+++ b/internal/machinedaemon/supervisor_crash_unix_test.go
@@ -196,6 +196,7 @@ func TestAbruptSupervisorDeathNeverRepeatsCommittedEffects(t *testing.T) {
 		ctx,
 		process.ProcessID,
 		process.SupervisorInstanceID,
+		nil,
 	); err != nil {
 		t.Fatalf("finish recovered process closure: %v", err)
 	}

--- a/internal/machinedaemon/supervisor_recovery_test.go
+++ b/internal/machinedaemon/supervisor_recovery_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/omnara-ai/omnara/internal/daemonprotocol"
 	"github.com/omnara-ai/omnara/internal/machinedaemon/localstore"
 	"github.com/omnara-ai/omnara/internal/machinedaemon/statedb"
+	"github.com/omnara-ai/omnara/internal/machinedaemon/statedb/statedbtest"
 )
 
 func TestAuthorityLossDeletesStateAndReportsUnresolvedContainment(
@@ -342,6 +343,304 @@ func TestVerifyProcessSupervisorsUsesLifetimeLock(t *testing.T) {
 	}
 	if _, found := client.localProcess(runtime.processID); found {
 		t.Fatal("released process state retained stale action routing")
+	}
+}
+
+func TestRejectedPreparationCleanupRetriesWithoutBlockingSleep(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	const (
+		processID            = "prc_rejected_cleanup_retry"
+		supervisorInstanceID = "supervisor-instance-rejected-cleanup-retry"
+	)
+	home := t.TempDir()
+	client := New(Config{OmnaraHome: home}, nil, nil)
+	client.bootstrap = daemonBootstrap{
+		InstallationID: "ins_rejected_cleanup_retry",
+		MachineID:      "mch_rejected_cleanup_retry",
+	}
+	defer client.closeState()
+	store, err := client.stateStore(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ReserveProcess(ctx, statedb.Process{
+		ProcessID:            processID,
+		SupervisorInstanceID: supervisorInstanceID,
+		SupervisorToken:      "supervisor-token-rejected-cleanup-retry",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkPrepared(ctx, processID, supervisorInstanceID); err != nil {
+		t.Fatal(err)
+	}
+	machine, err := client.machineStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := localstore.EnsurePrivateDir(machine.RunDir()); err != nil {
+		t.Fatal(err)
+	}
+	if err := localstore.EnsurePrivateDir(machine.ProcessesDir()); err != nil {
+		t.Fatal(err)
+	}
+	processDir, err := machine.ProcessDir(processID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(processDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(processDir, "partial"), []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lockPath, err := machine.LifetimeLockPath(processID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock, err := localstore.TryAcquireLock(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	startup := localStartupState{
+		Claims: []ProcessReconciliationClaim{{
+			ProcessID:            processID,
+			SupervisorInstanceID: supervisorInstanceID,
+		}},
+		Runners:       make(map[string]*processRuntime),
+		ForcedReports: make(map[string]struct{}),
+		stoppedLocks: map[string]*localstore.Lock{
+			processID: lock,
+		},
+		fencedRunners: make(map[string]*ipcProcessRunner),
+	}
+	if err := statedbtest.SetProcessDeleteFailure(
+		ctx,
+		machine.StateDBPath(),
+		true,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.applyRegistrationReconciliation(
+		ctx,
+		&startup,
+		DaemonRuntimeReconciliation{
+			Processes: []ProcessReconciliationDirective{{
+				ProcessID:            processID,
+				SupervisorInstanceID: supervisorInstanceID,
+				Disposition:          daemonprotocol.ProcessDispositionClosePreparation,
+			}},
+		},
+	); err != nil {
+		t.Fatalf("registration cleanup failure = %v", err)
+	}
+	runtime, found := client.localProcess(processID)
+	if !found || !runtime.cleanupOnly {
+		t.Fatalf("pending cleanup runtime = %+v, found=%t", runtime, found)
+	}
+	if _, err := os.Stat(processDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("process artifacts remained before database deletion: %v", err)
+	}
+	if _, found, err := store.Process(ctx, processID); err != nil || !found {
+		t.Fatalf("retained process row: found=%t err=%v", found, err)
+	}
+	retainedLock, err := localstore.TryAcquireExistingLock(lockPath)
+	if err != nil {
+		t.Fatalf("retained cleanup lock = %v", err)
+	}
+	if err := retainedLock.Release(); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.verifyProcessSupervisors(ctx); err != nil {
+		t.Fatalf("pending cleanup poisoned heartbeat: %v", err)
+	}
+	if !client.daemonIdle(ctx) {
+		t.Fatal("pending cleanup prevented daemon idleness")
+	}
+	if err := statedbtest.SetProcessDeleteFailure(
+		ctx,
+		machine.StateDBPath(),
+		false,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.closeState(); err != nil {
+		t.Fatal(err)
+	}
+
+	restarted := New(Config{OmnaraHome: home}, nil, nil)
+	restarted.bootstrap = client.bootstrap
+	defer restarted.closeState()
+	restartedStartup, err := restarted.scanLocalProcessesForRegistrationOnce(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(restartedStartup.Claims) != 1 ||
+		restartedStartup.Claims[0].ProcessID != processID ||
+		restartedStartup.stoppedLocks[processID] == nil {
+		t.Fatalf("restarted cleanup claim = %+v", restartedStartup.Claims)
+	}
+	if err := restarted.applyRegistrationReconciliation(
+		ctx,
+		&restartedStartup,
+		DaemonRuntimeReconciliation{
+			Processes: []ProcessReconciliationDirective{{
+				ProcessID:            processID,
+				SupervisorInstanceID: supervisorInstanceID,
+				Disposition:          daemonprotocol.ProcessDispositionClosePreparation,
+			}},
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := restarted.stateStore(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, found, err := reopened.Process(ctx, processID); err != nil || found {
+		t.Fatalf("finalized process row: found=%t err=%v", found, err)
+	}
+	if _, err := os.Stat(processDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("finalized process artifacts: %v", err)
+	}
+	if _, err := os.Stat(lockPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("finalized lifetime lock: %v", err)
+	}
+	if _, found := restarted.localProcess(processID); found {
+		t.Fatal("finalized cleanup remained in memory")
+	}
+}
+
+func TestRejectedPreparationCleanupFailureDoesNotBlockFinalization(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	const (
+		rejectedProcessID             = "prc_rejected_cleanup_failure"
+		rejectedSupervisorInstanceID  = "supervisor-instance-rejected-cleanup"
+		cleanupSupervisorInstanceID   = "supervisor-instance-stale-cleanup"
+		finalizedProcessID            = "prc_unrelated_finalization"
+		finalizedSupervisorInstanceID = "supervisor-instance-unrelated-finalization"
+	)
+	var logs bytes.Buffer
+	client := New(
+		Config{OmnaraHome: t.TempDir()},
+		nil,
+		slog.New(slog.NewTextHandler(&logs, nil)),
+	)
+	client.bootstrap = daemonBootstrap{
+		InstallationID: "ins_cleanup_failure_isolation",
+		MachineID:      "mch_cleanup_failure_isolation",
+	}
+	defer client.closeState()
+	store, err := client.stateStore(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	machine, err := client.machineStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := localstore.EnsurePrivateDir(machine.RunDir()); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ReserveProcess(ctx, statedb.Process{
+		ProcessID:            rejectedProcessID,
+		SupervisorInstanceID: rejectedSupervisorInstanceID,
+		SupervisorToken:      "supervisor-token-rejected-cleanup",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	client.addProcess(&processRuntime{
+		processID:            rejectedProcessID,
+		supervisorInstanceID: cleanupSupervisorInstanceID,
+		cleanupOnly:          true,
+	})
+
+	if err := store.ReserveProcess(ctx, statedb.Process{
+		ProcessID:            finalizedProcessID,
+		SupervisorInstanceID: finalizedSupervisorInstanceID,
+		SupervisorToken:      "supervisor-token-unrelated-finalization",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkPrepared(
+		ctx,
+		finalizedProcessID,
+		finalizedSupervisorInstanceID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkAccepted(
+		ctx,
+		finalizedProcessID,
+		finalizedSupervisorInstanceID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	supervisor, err := statedb.OpenSupervisor(
+		ctx,
+		machine.StateDBPath(),
+		client.bootstrap.InstallationID,
+		client.bootstrap.MachineID,
+		finalizedProcessID,
+		finalizedSupervisorInstanceID,
+		"supervisor-token-unrelated-finalization",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	terminalBody, err := json.Marshal(daemonReportedEvent{
+		Type:      daemonprotocol.EventProcessFinished,
+		ProcessID: finalizedProcessID,
+		State:     "exited",
+		EndedAt:   time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	terminal, err := supervisor.FreezeTerminalReport(ctx, statedb.Report{
+		ProcessID: finalizedProcessID,
+		Kind:      statedb.ReportProcessTerminal,
+		Body:      terminalBody,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := supervisor.MarkContainmentEmpty(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := supervisor.MarkLocalClosed(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := supervisor.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AcknowledgeReport(ctx, terminal.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.finalizeReleasedProcesses(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, found, err := store.Process(ctx, finalizedProcessID); err != nil || found {
+		t.Fatalf("unrelated process finalization: found=%t err=%v", found, err)
+	}
+	if _, found, err := store.Process(ctx, rejectedProcessID); err != nil || !found {
+		t.Fatalf("failed cleanup process state: found=%t err=%v", found, err)
+	}
+	runtime, found := client.localProcess(rejectedProcessID)
+	if !found || !runtime.cleanupOnly ||
+		runtime.supervisorInstanceID != cleanupSupervisorInstanceID {
+		t.Fatalf("retained cleanup runtime = %+v, found=%t", runtime, found)
+	}
+	if !client.daemonIdle(ctx) {
+		t.Fatal("failed cleanup prevented daemon idleness")
+	}
+	if got := logs.String(); !strings.Contains(got, "rejected process preparation cleanup failed") ||
+		!strings.Contains(got, rejectedProcessID) {
+		t.Fatalf("cleanup failure log = %q", got)
 	}
 }
 
@@ -691,6 +990,29 @@ func TestProcessCacheRemovalCannotDeleteReplacementSupervisorInstanceID(t *testi
 	current, found := client.localProcess(replacement.processID)
 	if !found || current != replacement {
 		t.Fatal("old supervisor instance cleanup removed the replacement runtime")
+	}
+}
+
+func TestCleanupOnlyCannotReplaceLiveSupervisorInstance(t *testing.T) {
+	t.Parallel()
+
+	client := New(Config{}, nil, nil)
+	cleanup := &processRuntime{
+		processID:            "prc_cleanup_before_replacement",
+		supervisorInstanceID: "supervisor-instance-old",
+		cleanupOnly:          true,
+	}
+	replacement := &processRuntime{
+		processID:            cleanup.processID,
+		supervisorInstanceID: "supervisor-instance-new",
+	}
+	client.addProcess(cleanup)
+	client.addProcess(replacement)
+	client.addProcess(cleanup)
+
+	current, found := client.localProcess(cleanup.processID)
+	if !found || current != replacement {
+		t.Fatal("stale cleanup replaced the live supervisor runtime")
 	}
 }
 

--- a/internal/machinedaemon/supervisor_recovery_test.go
+++ b/internal/machinedaemon/supervisor_recovery_test.go
@@ -230,6 +230,9 @@ func TestVerifyProcessSupervisorsUsesLifetimeLock(t *testing.T) {
 	runtime := &processRuntime{
 		processID:            "prc_supervisor_recovery",
 		supervisorInstanceID: "supervisor-instance-supervisor-recovery",
+		runner: &recordingProcessRunner{
+			statusErr: errors.New("injected transient supervisor status failure"),
+		},
 	}
 	store, err := client.stateStore(ctx)
 	if err != nil {
@@ -640,7 +643,7 @@ func TestRejectedPreparationCleanupFailureDoesNotBlockFinalization(t *testing.T)
 	if !client.daemonIdle(ctx) {
 		t.Fatal("failed cleanup prevented daemon idleness")
 	}
-	if got := logs.String(); !strings.Contains(got, "rejected process preparation cleanup failed") ||
+	if got := logs.String(); !strings.Contains(got, "process cleanup failed") ||
 		!strings.Contains(got, rejectedProcessID) {
 		t.Fatalf("cleanup failure log = %q", got)
 	}

--- a/internal/machinedaemon/supervisor_recovery_test.go
+++ b/internal/machinedaemon/supervisor_recovery_test.go
@@ -527,7 +527,9 @@ func TestRejectedPreparationCleanupFailureDoesNotBlockFinalization(t *testing.T)
 	client := New(
 		Config{OmnaraHome: t.TempDir()},
 		nil,
-		slog.New(slog.NewTextHandler(&logs, nil)),
+		slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
 	)
 	client.bootstrap = daemonBootstrap{
 		InstallationID: "ins_cleanup_failure_isolation",

--- a/internal/machinedaemon/supervisor_subprocess_test.go
+++ b/internal/machinedaemon/supervisor_subprocess_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/omnara-ai/omnara/internal/daemonprotocol"
+	"github.com/omnara-ai/omnara/internal/machinedaemon/localstore"
 	"github.com/omnara-ai/omnara/internal/machinedaemon/statedb"
 	"github.com/omnara-ai/omnara/internal/processaction"
 )
@@ -1160,6 +1161,44 @@ func TestDetachedSupervisorRejectsWrongIPCIdentityBeforeStart(t *testing.T) {
 		t.Fatal(err)
 	}
 	fixture.waitDone(t, 5*time.Second)
+}
+
+func TestDetachedSupervisorCloseUngrantedRetainsLifetimeLock(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	fixture := newDetachedSupervisorTestFixture(
+		t,
+		ctx,
+		ProcessAssignment{
+			ID: "prc_close_ungranted_lock",
+			Process: Process{
+				Command:       "echo should-not-run",
+				ShellSelector: "default",
+				Cwd:           t.TempDir(),
+				IOMode:        "pipe",
+			},
+		},
+	)
+	machine, err := fixture.client.machineStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lockPath, err := machine.LifetimeLockPath(fixture.runtime.processID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.runtime.runner.CloseUngranted(ctx); err != nil {
+		t.Fatal(err)
+	}
+	fixture.waitDone(t, 5*time.Second)
+	lock, err := localstore.TryAcquireExistingLock(lockPath)
+	if err != nil {
+		t.Fatalf("acquire retained lifetime lock: %v", err)
+	}
+	if err := lock.Release(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestDetachedSupervisorTimeoutClosesWholeProcessTree(t *testing.T) {

--- a/internal/storage/executionstore/process_daemon_completion_store.go
+++ b/internal/storage/executionstore/process_daemon_completion_store.go
@@ -68,6 +68,7 @@ func (s *Store) MarkProcessStarted(
 			input.AgentID,
 			input.Authority,
 			input.ID,
+			false,
 		)
 		if err != nil {
 			return DaemonProcessReportApplication{}, err
@@ -260,6 +261,7 @@ func (s *Store) CompleteDaemonProcess(
 			ExitSignal:         input.ExitSignal,
 			StateReasonCode:    sqlcTextFromEmpty(input.StateReasonCode),
 			StateReasonMessage: input.StateReasonMessage,
+			StorageExhausted:   input.StorageExhausted,
 		},
 	)
 	processUpdated := err == nil
@@ -272,6 +274,7 @@ func (s *Store) CompleteDaemonProcess(
 			input.AgentID,
 			input.Authority,
 			input.ID,
+			input.StorageExhausted,
 		)
 		if err != nil {
 			return DaemonProcessReportApplication{}, err
@@ -399,7 +402,19 @@ func (s *Store) CompleteDaemonProcess(
 			)
 		}
 	}
-	if processUpdated {
+	if input.StorageExhausted {
+		if err := completeUnresolvedProcessActionsForClosedProcessTx(
+			ctx,
+			txNotifications,
+			tx,
+			qtx,
+			record.OrgID,
+			record.ID,
+			daemonprotocol.ProcessReasonMachineStorageExhausted,
+		); err != nil {
+			return DaemonProcessReportApplication{}, err
+		}
+	} else if processUpdated {
 		if err := completeQueuedProcessActionsForTerminalProcessTx(
 			ctx,
 			txNotifications,
@@ -425,6 +440,7 @@ func daemonProcessForReportTx(
 	projectID, agentID ID,
 	authority DaemonRuntimeAuthority,
 	processID ID,
+	allowUngranted bool,
 ) (ProcessRecord, error) {
 	row, err := qtx.GetDaemonProcessForProjectReport(
 		ctx,
@@ -444,7 +460,7 @@ func daemonProcessForReportTx(
 	if record.AgentID != agentID {
 		return ProcessRecord{}, storeerr.ErrDaemonRuntimeUnregistered
 	}
-	if record.ExecutionGrantedAt == nil {
+	if record.ExecutionGrantedAt == nil && !allowUngranted {
 		return ProcessRecord{}, storeerr.ErrProcessExecutionNotGranted
 	}
 	return record, nil
@@ -460,7 +476,8 @@ func daemonTerminalReportMatchesRecord(
 		record.StateReasonCode == input.StateReasonCode &&
 		record.StateReasonMessage == input.StateReasonMessage &&
 		matchesProvidedSourceTime(record.SourceStartedAt, input.SourceStartedAt) &&
-		matchesTerminalSourceTime(record.SourceEndedAt, input.SourceEndedAt)
+		(input.StorageExhausted ||
+			matchesTerminalSourceTime(record.SourceEndedAt, input.SourceEndedAt))
 }
 
 func matchesProvidedSourceTime(stored *time.Time, provided time.Time) bool {

--- a/internal/storage/executionstore/process_records.go
+++ b/internal/storage/executionstore/process_records.go
@@ -139,6 +139,7 @@ type CompleteDaemonProcessInput struct {
 	Result             json.RawMessage
 	SourceStartedAt    time.Time
 	SourceEndedAt      time.Time
+	StorageExhausted   bool
 }
 
 type ProcessRecord struct {

--- a/internal/storage/internal/dbsqlc/process_actions.sql.go
+++ b/internal/storage/internal/dbsqlc/process_actions.sql.go
@@ -498,6 +498,7 @@ target AS MATERIALIZED (
         connection.connection_state IN ('online', 'asleep')
         AND $3::text = 'read'
         AND process.state IN ('exited', 'failed', 'killed', 'unknown')
+        AND process.state_reason_code IS DISTINCT FROM 'machine_storage_exhausted'
       )
     )
     AND (

--- a/internal/storage/internal/dbsqlc/processes.sql.go
+++ b/internal/storage/internal/dbsqlc/processes.sql.go
@@ -224,41 +224,57 @@ const completeDaemonObservedProcess = `-- name: CompleteDaemonObservedProcess :o
 UPDATE processes process
 SET state = $1,
     source_started_at = coalesce(source_started_at, $2::timestamptz),
-    source_ended_at = $3::timestamptz,
-    exit_code = $4,
-    exit_signal = $5,
-    state_reason_code = $6,
-    state_reason_message = $7,
+    source_ended_at = CASE
+      WHEN $3::boolean
+        AND process.source_started_at IS NOT NULL
+        AND $4::timestamptz IS NULL
+      THEN greatest(process.source_started_at, statement_timestamp())
+      WHEN $4::timestamptz IS NULL THEN NULL
+      ELSE greatest(process.source_started_at, $4::timestamptz)
+    END,
+    exit_code = $5,
+    exit_signal = $6,
+    state_reason_code = $7,
+    state_reason_message = $8,
     state_changed_at = statement_timestamp(),
     updated_at = statement_timestamp()
-WHERE process.project_id = $8
-  AND process.agent_id = $9
-  AND process.id = $10
-  AND process.machine_id = $11
-  AND process.state IN ('starting', 'running')
+WHERE process.project_id = $9
+  AND process.agent_id = $10
+  AND process.id = $11
+  AND process.machine_id = $12
+  AND (
+    process.state IN ('starting', 'running')
+    OR (
+      $3::boolean
+      AND process.state = 'queued'
+      AND process.execution_granted_at IS NULL
+    )
+  )
   AND $1::text IN ('exited', 'failed', 'killed', 'unknown')
-  AND ($1::text <> 'exited' OR $4::integer IS NOT NULL)
-  AND ($1::text IN ('exited', 'failed') OR $4::integer IS NULL)
-  AND ($1::text <> 'failed' OR $6::text IS NOT NULL)
-  AND ($1::text <> 'unknown' OR $6::text IS NOT NULL)
+  AND ($1::text <> 'exited' OR $5::integer IS NOT NULL)
+  AND ($1::text IN ('exited', 'failed') OR $5::integer IS NULL)
+  AND ($1::text <> 'failed' OR $7::text IS NOT NULL)
+  AND ($1::text <> 'unknown' OR $7::text IS NOT NULL)
   AND (
     $2::timestamptz IS NULL
     OR process.source_started_at IS NULL
     OR process.source_started_at = $2::timestamptz
   )
   AND (
-    $3::timestamptz IS NULL
+    $4::timestamptz IS NULL
     OR coalesce(process.source_started_at, $2::timestamptz) IS NULL
-    OR $3::timestamptz >= coalesce(process.source_started_at, $2::timestamptz)
+    OR $3::boolean
+    OR $4::timestamptz >= coalesce(process.source_started_at, $2::timestamptz)
   )
   AND (
     $1::text NOT IN ('exited', 'killed')
-    OR $3::timestamptz IS NOT NULL
+    OR $4::timestamptz IS NOT NULL
   )
   AND (
     $1::text <> 'failed'
+    OR $3::boolean
     OR coalesce(process.source_started_at, $2::timestamptz) IS NULL
-    OR $3::timestamptz IS NOT NULL
+    OR $4::timestamptz IS NOT NULL
   )
 RETURNING process.id, process.org_id, process.project_id, process.agent_id, process.tool_call_id, process.runtime_lock_id, process.agent_machine_binding_id, process.machine_id, process.execution_granted_at, process.io_mode, process.command, process.shell_selector, process.cwd, process.env, process.secret_env, process.timeout_seconds, process.initial_wait_ms, process.default_output_cursor, process.state, process.state_reason_code, process.state_reason_message, process.source_started_at, process.source_ended_at, process.state_changed_at, process.exit_code, process.exit_signal, process.created_at, process.updated_at
 `
@@ -266,6 +282,7 @@ RETURNING process.id, process.org_id, process.project_id, process.agent_id, proc
 type CompleteDaemonObservedProcessParams struct {
 	State              string
 	SourceStartedAt    *time.Time
+	StorageExhausted   bool
 	SourceEndedAt      *time.Time
 	ExitCode           *int32
 	ExitSignal         string
@@ -281,6 +298,7 @@ func (q *Queries) CompleteDaemonObservedProcess(ctx context.Context, arg Complet
 	row := q.db.QueryRow(ctx, completeDaemonObservedProcess,
 		arg.State,
 		arg.SourceStartedAt,
+		arg.StorageExhausted,
 		arg.SourceEndedAt,
 		arg.ExitCode,
 		arg.ExitSignal,

--- a/internal/storage/queries/process_actions.sql
+++ b/internal/storage/queries/process_actions.sql
@@ -35,6 +35,7 @@ target AS MATERIALIZED (
         connection.connection_state IN ('online', 'asleep')
         AND sqlc.arg(action_kind)::text = 'read'
         AND process.state IN ('exited', 'failed', 'killed', 'unknown')
+        AND process.state_reason_code IS DISTINCT FROM 'machine_storage_exhausted'
       )
     )
     AND (

--- a/internal/storage/queries/processes.sql
+++ b/internal/storage/queries/processes.sql
@@ -227,7 +227,14 @@ RETURNING id, org_id, project_id, agent_id, tool_call_id, runtime_lock_id, agent
 UPDATE processes process
 SET state = sqlc.arg(state),
     source_started_at = coalesce(source_started_at, sqlc.narg(source_started_at)::timestamptz),
-    source_ended_at = sqlc.narg(source_ended_at)::timestamptz,
+    source_ended_at = CASE
+      WHEN sqlc.arg(storage_exhausted)::boolean
+        AND process.source_started_at IS NOT NULL
+        AND sqlc.narg(source_ended_at)::timestamptz IS NULL
+      THEN greatest(process.source_started_at, statement_timestamp())
+      WHEN sqlc.narg(source_ended_at)::timestamptz IS NULL THEN NULL
+      ELSE greatest(process.source_started_at, sqlc.narg(source_ended_at)::timestamptz)
+    END,
     exit_code = sqlc.narg(exit_code),
     exit_signal = sqlc.arg(exit_signal),
     state_reason_code = sqlc.narg(state_reason_code),
@@ -238,7 +245,14 @@ WHERE process.project_id = sqlc.arg(project_id)
   AND process.agent_id = sqlc.arg(agent_id)
   AND process.id = sqlc.arg(id)
   AND process.machine_id = sqlc.arg(machine_id)
-  AND process.state IN ('starting', 'running')
+  AND (
+    process.state IN ('starting', 'running')
+    OR (
+      sqlc.arg(storage_exhausted)::boolean
+      AND process.state = 'queued'
+      AND process.execution_granted_at IS NULL
+    )
+  )
   AND sqlc.arg(state)::text IN ('exited', 'failed', 'killed', 'unknown')
   AND (sqlc.arg(state)::text <> 'exited' OR sqlc.narg(exit_code)::integer IS NOT NULL)
   AND (sqlc.arg(state)::text IN ('exited', 'failed') OR sqlc.narg(exit_code)::integer IS NULL)
@@ -252,6 +266,7 @@ WHERE process.project_id = sqlc.arg(project_id)
   AND (
     sqlc.narg(source_ended_at)::timestamptz IS NULL
     OR coalesce(process.source_started_at, sqlc.narg(source_started_at)::timestamptz) IS NULL
+    OR sqlc.arg(storage_exhausted)::boolean
     OR sqlc.narg(source_ended_at)::timestamptz >= coalesce(process.source_started_at, sqlc.narg(source_started_at)::timestamptz)
   )
   AND (
@@ -260,6 +275,7 @@ WHERE process.project_id = sqlc.arg(project_id)
   )
   AND (
     sqlc.arg(state)::text <> 'failed'
+    OR sqlc.arg(storage_exhausted)::boolean
     OR coalesce(process.source_started_at, sqlc.narg(source_started_at)::timestamptz) IS NULL
     OR sqlc.narg(source_ended_at)::timestamptz IS NOT NULL
   )


### PR DESCRIPTION
There are two main parts to this PR.

Part one:
- makes rejected-preparation cleanup crash-safe by retaining cleanup-only process state until local artifacts and SQLite rows are removed, without blocking idle sleep

Part two:
- detects filesystem, quota, and SQLite exhaustion before or after process acceptance, stops the affected supervisor, and reports machine_storage_exhausted
- carries storage failures through server completion and daemon reconciliation so agents receive durable failure results, unresolved actions settle, and machines recover when space is freed

This PR requires deploying the server before publishing the new daemon version.