### PR TITLE
chore: remove active process and machine state from model context

### DIFF
--- a/internal/harness/tools/executor.go
+++ b/internal/harness/tools/executor.go
@@ -217,9 +217,15 @@ func machineUnavailableToolResult(cause error) (machineUnavailableResult, error)
 	}
 	message := errorCode
 	body := map[string]any{"error": message, "error_code": errorCode}
+	if errors.Is(cause, ErrNoActiveAgentMachineBinding) {
+		body["error"] = "no executable machine is available"
+		body["error_code"] = ErrNoActiveAgentMachineBinding.Error()
+		body["next_action"] = toolcatalog.ToolNameListMachines
+	}
 	if errors.Is(cause, ErrMachineSelectionRequired) {
 		body["error"] = "machine_ref is required when multiple machines are available"
 		body["error_code"] = ErrMachineSelectionRequired.Error()
+		body["next_action"] = toolcatalog.ToolNameListMachines
 		content, marshalErr := structuredToolResultContent(body)
 		if marshalErr != nil {
 			return machineUnavailableResult{}, marshalErr
@@ -229,6 +235,7 @@ func machineUnavailableToolResult(cause error) (machineUnavailableResult, error)
 	if errors.Is(cause, ErrMachineRefUnavailable) {
 		body["error"] = "machine_ref is unavailable"
 		body["error_code"] = ErrMachineRefUnavailable.Error()
+		body["next_action"] = toolcatalog.ToolNameListMachines
 		content, marshalErr := structuredToolResultContent(body)
 		if marshalErr != nil {
 			return machineUnavailableResult{}, marshalErr

--- a/internal/harness/tools/executor_test.go
+++ b/internal/harness/tools/executor_test.go
@@ -2,10 +2,12 @@ package tools
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/omnara-ai/omnara/internal/model"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
+	"github.com/omnara-ai/omnara/internal/toolcatalog"
 )
 
 func TestToolCallMatchesPreservesJSONNumberIdentity(t *testing.T) {
@@ -28,4 +30,79 @@ func TestToolCallMatchesPreservesJSONNumberIdentity(t *testing.T) {
 	) {
 		t.Fatal("distinct large integers matched")
 	}
+}
+
+func TestMachineUnavailableToolResultGuidesKnownResolutionFailures(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		cause     error
+		errorCode string
+		message   string
+	}{
+		{
+			name:      "no executable machine",
+			cause:     ErrNoActiveAgentMachineBinding,
+			errorCode: ErrNoActiveAgentMachineBinding.Error(),
+			message:   "no executable machine is available",
+		},
+		{
+			name:      "selection required",
+			cause:     ErrMachineSelectionRequired,
+			errorCode: ErrMachineSelectionRequired.Error(),
+			message:   "machine_ref is required when multiple machines are available",
+		},
+		{
+			name:      "ref unavailable",
+			cause:     ErrMachineRefUnavailable,
+			errorCode: ErrMachineRefUnavailable.Error(),
+			message:   "machine_ref is unavailable",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := machineUnavailableToolResult(test.cause)
+			if err != nil {
+				t.Fatalf("machine unavailable result: %v", err)
+			}
+			body := unitStructuredResultBody(t, result.Content)
+			if body["error_code"] != test.errorCode || body["error"] != test.message ||
+				body["next_action"] != toolcatalog.ToolNameListMachines {
+				t.Fatalf("machine unavailable result = %+v", body)
+			}
+		})
+	}
+}
+
+func TestMachineUnavailableToolResultDoesNotGuideUnexpectedFailures(t *testing.T) {
+	t.Parallel()
+	cause := errors.New("database unavailable")
+	result, err := machineUnavailableToolResult(cause)
+	if err != nil {
+		t.Fatalf("machine unavailable result: %v", err)
+	}
+	body := unitStructuredResultBody(t, result.Content)
+	if body["error_code"] != cause.Error() || body["error"] != cause.Error() {
+		t.Fatalf("unexpected machine failure result = %+v", body)
+	}
+	if _, ok := body["next_action"]; ok {
+		t.Fatalf("unexpected machine failure includes next_action: %+v", body)
+	}
+}
+
+func unitStructuredResultBody(t *testing.T, content toolResultContent) map[string]any {
+	t.Helper()
+	if len(content.parts) != 1 {
+		t.Fatalf("unexpected result parts: %+v", content.parts)
+	}
+	part, ok := content.parts[0].(toolResultStructuredPart)
+	if !ok {
+		t.Fatalf("unexpected result part: %T", content.parts[0])
+	}
+	var body map[string]any
+	if err := json.Unmarshal(part.value, &body); err != nil {
+		t.Fatalf("decode structured result: %v", err)
+	}
+	return body
 }

--- a/internal/harness/tools/machine_execution_target_integration_test.go
+++ b/internal/harness/tools/machine_execution_target_integration_test.go
@@ -269,6 +269,11 @@ tools:
 		Name:  "inspect_machine",
 		Input: json.RawMessage(`{}`),
 	}
+	staleInspectCall := model.ToolCall{
+		ID:    "call_observe-byo-stale-inspect",
+		Name:  "inspect_machine",
+		Input: json.RawMessage(`{"machine_ref":"mchr-missing"}`),
+	}
 	toolCalls, lock, admitted, contextRecord := recordMachineToolCallsForDirectStoreTest(
 		t,
 		ctx,
@@ -277,10 +282,17 @@ tools:
 		fixture.UserID,
 		config.ID,
 		"observe-byo",
-		[]model.ToolCall{listCall, inspectCall, mixedInspectCall, createPoolCall, alwaysAllowMixedInspectCall},
+		[]model.ToolCall{
+			listCall,
+			inspectCall,
+			mixedInspectCall,
+			createPoolCall,
+			alwaysAllowMixedInspectCall,
+			staleInspectCall,
+		},
 		fixture.Now.Add(7*time.Second),
 	)
-	for _, index := range []int{0, 3, 4} {
+	for _, index := range []int{0, 3, 4, 5} {
 		if _, err := fixture.Store.Execution().MarkToolCallReady(
 			ctx,
 			executionstore.MarkToolCallReadyInput{
@@ -405,7 +417,8 @@ tools:
 	}
 	mixedBody := toolResultMapFromTestParts(t, mixedResult.ContentParts)
 	if mixedBody["error_code"] != ErrMachineSelectionRequired.Error() ||
-		mixedBody["error"] != "machine_ref is required when multiple machines are available" {
+		mixedBody["error"] != "machine_ref is required when multiple machines are available" ||
+		mixedBody["next_action"] != toolcatalog.ToolNameListMachines {
 		t.Fatalf("mixed-source inspect_machine result = %+v", mixedBody)
 	}
 	alwaysAllowTurn := turn
@@ -426,6 +439,16 @@ tools:
 			alwaysAllowMixedBody,
 			mixedBody,
 		)
+	}
+	staleResult, err := executor.Dispatch(ctx, alwaysAllowTurn, staleInspectCall)
+	if err != nil {
+		t.Fatalf("dispatch stale inspect_machine: %v", err)
+	}
+	staleBody := toolResultMapFromTestParts(t, staleResult.ContentParts)
+	if staleBody["error_code"] != ErrMachineRefUnavailable.Error() ||
+		staleBody["error"] != "machine_ref is unavailable" ||
+		staleBody["next_action"] != toolcatalog.ToolNameListMachines {
+		t.Fatalf("stale inspect_machine result = %+v", staleBody)
 	}
 }
 
@@ -821,7 +844,8 @@ func TestProcessToolMachineSelectionFailureKeepsStructuredPayload(t *testing.T) 
 		t.Fatalf("decode result content: %v; raw=%s", unmarshalErr, parts[0].Value)
 	}
 	if body["error_code"] != ErrMachineSelectionRequired.Error() ||
-		body["error"] != "machine_ref is required when multiple machines are available" {
+		body["error"] != "machine_ref is required when multiple machines are available" ||
+		body["next_action"] != toolcatalog.ToolNameListMachines {
 		t.Fatalf("unexpected structured machine selection result: %+v", body)
 	}
 }

--- a/internal/harness/tools/machine_tools.go
+++ b/internal/harness/tools/machine_tools.go
@@ -221,15 +221,26 @@ func inspectMachine(
 		}
 	}
 	if err != nil {
-		if errors.Is(err, ErrMachineSelectionRequired) {
+		if input.MachineRef != "" && errors.Is(err, storeerr.ErrNotFound) {
+			err = ErrMachineRefUnavailable
+		}
+		if errors.Is(err, ErrMachineSelectionRequired) ||
+			errors.Is(err, ErrMachineRefUnavailable) {
 			unavailable, resultErr := machineUnavailableToolResult(err)
 			if resultErr != nil {
 				return nil, resultErr
 			}
 			return failInTransaction(unavailable.Content, unavailable.Cause), nil
 		}
-		if !errors.Is(err, storeerr.ErrNotFound) &&
-			!errors.Is(err, ErrNoMachine) {
+		if errors.Is(err, ErrNoMachine) {
+			return failMachineTransactionWithMessage(
+				"inspect_machine_failed",
+				"no machines are associated with this agent",
+				err,
+				false,
+			)
+		}
+		if !errors.Is(err, storeerr.ErrNotFound) {
 			return nil, err
 		}
 		return failMachineTransaction("inspect_machine_failed", err, false)

--- a/internal/harness/tools/process_tools.go
+++ b/internal/harness/tools/process_tools.go
@@ -361,7 +361,7 @@ func observeProcess(
 		); err != nil {
 			return nil, err
 		}
-		records, err := call.Reader.ListActiveProcessesForContext(ctx)
+		records, err := call.Reader.ListActiveProcesses(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -442,7 +442,7 @@ func createProcessAction(
 			false,
 			processID,
 			"",
-			"",
+			processToolNextActionList,
 		)
 	}
 	input := executionstore.CreateProcessActionInput{
@@ -505,7 +505,7 @@ func createProcessAction(
 					false,
 					processID,
 					"",
-					"",
+					processToolNextActionList,
 				)
 			}
 			return nil, fmt.Errorf(

--- a/internal/model/anthropicmessages/request.go
+++ b/internal/model/anthropicmessages/request.go
@@ -236,16 +236,6 @@ func buildMessages(
 	if historyAdded {
 		messages = markLastMessageCacheBreakpoint(messages, cacheControl(policy.CacheRetention))
 	}
-	if modelcontext.HasExecutionContext(bundle) {
-		messages = appendMessageBlocks(messages, anthropicRoleUser, []any{textBlock{
-			Type: "text",
-			Text: "<active_runtime_context>\n" + modelcontext.ExecutionContextContent(
-				bundle.ActiveProcesses,
-				bundle.AttachedMachines,
-			) +
-				"\n</active_runtime_context>",
-		}})
-	}
 	if len(messages) > 0 && messages[0].Role == anthropicRoleAssistant {
 		messages = append(
 			[]message{{Role: anthropicRoleUser, Content: []any{textBlock{Type: "text", Text: "Continue."}}}},

--- a/internal/model/anthropicmessages/request_test.go
+++ b/internal/model/anthropicmessages/request_test.go
@@ -580,9 +580,6 @@ func TestPrepareCacheBreakpointsStayOnStablePrefix(t *testing.T) {
 		Context: modelcontext.Bundle{
 			SystemPrompt:      "sys",
 			ContextCheckpoint: &modelcontext.CheckpointRef{ID: "ccp_1", Summary: "stable summary"},
-			ActiveProcesses: []modelcontext.ActiveProcessRef{
-				{ProcessID: "prc_1", State: "running", CommandLabel: "changing suffix"},
-			},
 			IntegrationTargets: []modelcontext.IntegrationTargetRef{
 				{
 					TargetRef:       "slack-abcd",
@@ -629,8 +626,7 @@ func TestPrepareCacheBreakpointsStayOnStablePrefix(t *testing.T) {
 	}
 	system := string(payload.System)
 	if strings.Contains(system, "stable summary") ||
-		!strings.Contains(system, "context_checkpoint") ||
-		strings.Contains(system, "Active execution observations") {
+		!strings.Contains(system, "context_checkpoint") {
 		t.Fatalf("expected only fixed checkpoint guidance in the cached system prefix: %s", system)
 	}
 	if len(systemBlocks) != 2 || systemBlocks[0].CacheControl != nil ||
@@ -640,13 +636,12 @@ func TestPrepareCacheBreakpointsStayOnStablePrefix(t *testing.T) {
 		strings.Contains(systemBlocks[1].Text, "internal-target-id") {
 		t.Fatalf("expected integration target refs without durable ids: %s", system)
 	}
-	if len(payload.Messages) != 1 || len(payload.Messages[0].Content) != 3 {
-		t.Fatalf("messages = %+v, want checkpoint/history/active-work blocks", payload.Messages)
+	if len(payload.Messages) != 1 || len(payload.Messages[0].Content) != 2 {
+		t.Fatalf("messages = %+v, want checkpoint/history blocks", payload.Messages)
 	}
 	blocks := payload.Messages[0].Content
 	if !strings.Contains(blocks[0].Text, "stable summary") || blocks[0].CacheControl == nil ||
-		!strings.Contains(blocks[1].Text, "changing user suffix") || blocks[1].CacheControl == nil ||
-		!strings.Contains(blocks[2].Text, "active_runtime_context") || blocks[2].CacheControl != nil {
+		!strings.Contains(blocks[1].Text, "changing user suffix") || blocks[1].CacheControl == nil {
 		t.Fatalf("cache boundaries are not on the stable system, checkpoint, and history tail: %s", prepared.Body)
 	}
 }

--- a/internal/model/openaichatcompletions/request.go
+++ b/internal/model/openaichatcompletions/request.go
@@ -199,9 +199,6 @@ func buildMessages(
 	if modelcontext.MachinePoolContextEnabled(bundle.ToolSpecs) {
 		capacity++
 	}
-	if modelcontext.HasExecutionContext(bundle) {
-		capacity++
-	}
 	if modelcontext.IntegrationTargetContextEnabled(bundle.ToolSpecs) {
 		capacity++
 	}
@@ -239,15 +236,6 @@ func buildMessages(
 		messages = append(messages, chatMessage{
 			Role:    chatRoleSystem,
 			Content: modelcontext.AvailableMachinePoolsContent(bundle.AvailableMachinePools),
-		})
-	}
-	if modelcontext.HasExecutionContext(bundle) {
-		messages = append(messages, chatMessage{
-			Role: chatRoleSystem,
-			Content: modelcontext.ExecutionContextContent(
-				bundle.ActiveProcesses,
-				bundle.AttachedMachines,
-			),
 		})
 	}
 	if modelcontext.IntegrationTargetContextEnabled(bundle.ToolSpecs) {

--- a/internal/model/openairesponses/input.go
+++ b/internal/model/openairesponses/input.go
@@ -37,9 +37,6 @@ func buildInput(
 	if modelcontext.MachinePoolContextEnabled(bundle.ToolSpecs) {
 		capacity++
 	}
-	if modelcontext.HasExecutionContext(bundle) {
-		capacity++
-	}
 	if modelcontext.IntegrationTargetContextEnabled(bundle.ToolSpecs) {
 		capacity++
 	}
@@ -91,18 +88,6 @@ func buildInput(
 			map[string]any{
 				"role":    responsesRoleSystem,
 				"content": modelcontext.AvailableMachinePoolsContent(bundle.AvailableMachinePools),
-			},
-		)
-	}
-	if modelcontext.HasExecutionContext(bundle) {
-		items = append(
-			items,
-			map[string]any{
-				"role": responsesRoleSystem,
-				"content": modelcontext.ExecutionContextContent(
-					bundle.ActiveProcesses,
-					bundle.AttachedMachines,
-				),
 			},
 		)
 	}

--- a/internal/model/openairesponses/input_test.go
+++ b/internal/model/openairesponses/input_test.go
@@ -127,52 +127,6 @@ func TestPreparePreservesCanonicalToolResultContent(t *testing.T) {
 	t.Fatalf("function_call_output not found in payload: %s", prepared.Body)
 }
 
-func TestPrepareIncludesExecutionContextInProviderInput(t *testing.T) {
-	client := Client{EndpointPath: testEndpointPath, ProviderModelSlug: "gpt-test"}
-	prepared, err := client.Prepare(
-		context.Background(),
-		model.PrepareInput{
-			Context: modelcontext.Bundle{
-				SystemPrompt: "sys",
-				ActiveProcesses: []modelcontext.ActiveProcessRef{
-					{ProcessID: "prc_1", State: "running", CommandLabel: "go test ./..."},
-				},
-			},
-		},
-	)
-	if err != nil {
-		t.Fatalf("prepare: %v", err)
-	}
-	var payload struct {
-		Input []struct {
-			Role    string `json:"role"`
-			Content string `json:"content"`
-		} `json:"input"`
-	}
-	if err := json.Unmarshal(prepared.Body, &payload); err != nil {
-		t.Fatalf("decode prepared payload: %v", err)
-	}
-	if len(payload.Input) != 1 || payload.Input[0].Role != string(responsesRoleSystem) {
-		t.Fatalf("expected one system active-work input, got %+v", payload.Input)
-	}
-	for _, want := range []string{
-		"Active execution observations",
-		"active_processes",
-		"process_id",
-		"prc_1",
-		"go test ./...",
-	} {
-		if !strings.Contains(payload.Input[0].Content, want) {
-			t.Fatalf("active-work content missing %q: %s", want, payload.Input[0].Content)
-		}
-	}
-	for _, forbidden := range []string{"typed runtime authority", "mach_1", "runtime_lock_id", "machine_id", "argv"} {
-		if strings.Contains(payload.Input[0].Content, forbidden) {
-			t.Fatalf("active-work content leaked %q: %s", forbidden, payload.Input[0].Content)
-		}
-	}
-}
-
 func TestPrepareIncludesAvailableMachinePoolsInProviderInput(t *testing.T) {
 	client := Client{EndpointPath: testEndpointPath, ProviderModelSlug: "gpt-test"}
 	prepared, err := client.Prepare(
@@ -218,60 +172,6 @@ func TestPrepareExplainsWhenCreateMachineHasNoAvailablePools(t *testing.T) {
 	}
 	if !strings.Contains(string(prepared.Body), "no machine pools are currently available") {
 		t.Fatalf("missing empty machine-pool context: %s", prepared.Body)
-	}
-}
-
-func TestPreparePlacesExecutionContextAtEndOfProviderInput(t *testing.T) {
-	client := Client{EndpointPath: testEndpointPath, ProviderModelSlug: "gpt-test"}
-	prepared, err := client.Prepare(context.Background(), model.PrepareInput{Context: modelcontext.Bundle{
-		SystemPrompt:      "sys",
-		ContextCheckpoint: &modelcontext.CheckpointRef{ID: "ccp_1", Summary: "stable summary"},
-		Messages: []modelcontext.Message{
-			openAITextMessage(modelprotocol.RoleUser, "latest user message"),
-			messageAtSequence(assistantToolCallMessage("mcc_1", "tcl_1"), 2),
-		},
-		ToolResults: []modelcontext.ToolResultRef{{SourceEventSequence: 1, ToolCallID: "tcl_1",
-			ModelCallContextID: "mcc_1",
-			ProviderCallID:     "call_1",
-			Name:               "run_command",
-			Input:              json.RawMessage(`{"command":"true"}`),
-			ContentParts:       json.RawMessage(`[{"type":"structured_data","value":{"ok":true}}]`),
-		}},
-		AttachedMachines: []modelcontext.AttachedMachineRef{{
-			MachineRef:  "mchr-abc234",
-			Description: "Build machine",
-			Cwd:         "/workspace",
-		}},
-	}})
-	if err != nil {
-		t.Fatalf("prepare: %v", err)
-	}
-	var payload struct {
-		Input []struct {
-			Type    string          `json:"type"`
-			Role    string          `json:"role"`
-			Content json.RawMessage `json:"content"`
-		} `json:"input"`
-	}
-	if err := json.Unmarshal(prepared.Body, &payload); err != nil {
-		t.Fatalf("decode prepared payload: %v", err)
-	}
-	if len(payload.Input) != 5 {
-		t.Fatalf(
-			"expected checkpoint, message, rebuilt call, call output, and active work, got %d: %s",
-			len(payload.Input),
-			prepared.Body,
-		)
-	}
-	last := payload.Input[len(payload.Input)-1]
-	if last.Role != string(responsesRoleSystem) ||
-		!strings.Contains(string(last.Content), "Active execution observations") ||
-		!strings.Contains(string(last.Content), "mchr-abc234") {
-		t.Fatalf("expected active work as final provider input item, got %+v in %s", last, prepared.Body)
-	}
-	if strings.Contains(string(payload.Input[0].Content), "mchr-abc234") ||
-		strings.Contains(string(payload.Input[1].Content), "mchr-abc234") {
-		t.Fatalf("active work leaked into stable prefix: %s", prepared.Body)
 	}
 }
 

--- a/internal/model/openairesponses/test_helpers_test.go
+++ b/internal/model/openairesponses/test_helpers_test.go
@@ -112,8 +112,3 @@ func assistantToolCallMessage(
 		Content:            json.RawMessage(`[]`),
 	}, toolCallIDs...)
 }
-
-func messageAtSequence(message modelcontext.Message, sequence int64) modelcontext.Message {
-	message.Sequence = sequence
-	return message
-}

--- a/internal/modelcontext/context.go
+++ b/internal/modelcontext/context.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 
 	"github.com/omnara-ai/omnara/internal/agentconfig"
-	"github.com/omnara-ai/omnara/internal/processcmd"
-	"github.com/omnara-ai/omnara/internal/publicid"
 	"github.com/omnara-ai/omnara/internal/storage"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 	"github.com/omnara-ai/omnara/internal/storage/integrationstore"
@@ -160,57 +158,6 @@ func (b Builder) Build(ctx context.Context, input BuildInput) (Bundle, error) {
 	)
 	if err != nil {
 		return Bundle{}, err
-	}
-	var activeProcesses []executionstore.ActiveProcessRecord
-	if ProcessContextEnabled(toolSpecs) {
-		activeProcesses, err = b.Store.ListActiveProcessesForContext(
-			ctx,
-			input.ProjectID,
-			input.AgentID,
-		)
-		if err != nil {
-			return Bundle{}, err
-		}
-	}
-	var executableMachineBindings []executionstore.AgentMachineBindingRecord
-	if MachineContextEnabled(toolSpecs) {
-		executableMachineBindings, err = b.Store.ListExecutableAgentMachineBindings(
-			ctx,
-			input.ProjectID,
-			input.AgentID,
-		)
-		if err != nil {
-			return Bundle{}, err
-		}
-	}
-	bundle.ActiveProcesses = make([]ActiveProcessRef, 0, len(activeProcesses))
-	for _, work := range activeProcesses {
-		processID, err := publicid.Encode(publicid.KindProcess, work.ID)
-		if err != nil {
-			return Bundle{}, err
-		}
-		bundle.ActiveProcesses = append(
-			bundle.ActiveProcesses,
-			ActiveProcessRef{
-				ProcessID:     processID,
-				State:         string(work.State),
-				CommandLabel:  processcmd.CommandLabel(work.Command),
-				Command:       work.Command,
-				ShellSelector: string(work.ShellSelector),
-				Cwd:           work.Cwd,
-			},
-		)
-	}
-	bundle.AttachedMachines = make([]AttachedMachineRef, 0, len(executableMachineBindings))
-	for _, binding := range executableMachineBindings {
-		bundle.AttachedMachines = append(
-			bundle.AttachedMachines,
-			AttachedMachineRef{
-				MachineRef:  binding.MachineRef,
-				Description: binding.Description,
-				Cwd:         binding.Cwd,
-			},
-		)
 	}
 	if IntegrationTargetContextEnabled(toolSpecs) {
 		bundle.IntegrationTargets = make([]IntegrationTargetRef, 0, len(integrationTargets))

--- a/internal/modelcontext/context_test.go
+++ b/internal/modelcontext/context_test.go
@@ -370,147 +370,6 @@ func TestBuildPreservesStructuredProcessResultValues(t *testing.T) {
 	}
 }
 
-func TestBuildProjectsActiveProcessWorkAsObservationRefs(t *testing.T) {
-	processID := testIDN(910)
-	store := &fakeContextStore{
-		watermark: 12,
-		hasConfig: true,
-		config:    testAgentConfigRecordWithTools(t, toolcatalog.ToolNameReadProcess),
-		activeWork: []executionstore.ActiveProcessRecord{
-			{
-				ID:            processID,
-				State:         executionstore.ProcessStateRunning,
-				MachineID:     testIDN(911),
-				Command:       "go test ./...",
-				ShellSelector: "default",
-				ToolCallID:    testIDN(912),
-			},
-		},
-	}
-	bundle, err := (Builder{Store: store}).Build(
-		context.Background(),
-		BuildInput{
-			ProjectID:       testProjectID,
-			AgentID:         testAgentID,
-			TurnID:          testTurnID,
-			OpeningInputIDs: []storage.ID{testInputID},
-			Now:             time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC),
-		},
-	)
-	if err != nil {
-		t.Fatalf("build context: %v", err)
-	}
-	processHandle, err := publicid.Encode(publicid.KindProcess, processID)
-	if err != nil {
-		t.Fatalf("encode process id: %v", err)
-	}
-	if len(bundle.ActiveProcesses) != 1 || bundle.ActiveProcesses[0].ProcessID != processHandle {
-		t.Fatalf("expected active process context, got %+v", bundle.ActiveProcesses)
-	}
-	serialized := string(contextFixtureJSON(t, bundle))
-	for _, internal := range []string{"provider_allocation", "env_1", testIDN(911).String(), "argv"} {
-		if strings.Contains(serialized, internal) {
-			t.Fatalf("active work projection must not expose %s internals: %s", internal, serialized)
-		}
-	}
-}
-
-func TestBuildProjectsExecutableMachinesAsSelectorRefs(t *testing.T) {
-	machineID := testIDN(920)
-	bindingID := testIDN(1920)
-	store := &fakeContextStore{
-		watermark: 13,
-		hasConfig: true,
-		config:    testAgentConfigRecordWithTools(t, toolcatalog.ToolNameInspectMachine),
-		executableMachineBindings: []executionstore.AgentMachineBindingRecord{
-			{
-				ID:          bindingID,
-				MachineID:   machineID,
-				MachineRef:  "mchr-abc234",
-				Description: "Primary machine",
-				Cwd:         "/workspace",
-			},
-		},
-	}
-	bundle, err := (Builder{Store: store}).Build(
-		context.Background(),
-		BuildInput{
-			ProjectID:       testProjectID,
-			AgentID:         testAgentID,
-			TurnID:          testTurnID,
-			OpeningInputIDs: []storage.ID{testInputID},
-			Now:             time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC),
-		},
-	)
-	if err != nil {
-		t.Fatalf("build context: %v", err)
-	}
-	if len(bundle.AttachedMachines) != 1 ||
-		bundle.AttachedMachines[0].MachineRef != "mchr-abc234" ||
-		bundle.AttachedMachines[0].Description != "Primary machine" ||
-		bundle.AttachedMachines[0].Cwd != "/workspace" {
-		t.Fatalf("expected attached machine context, got %+v", bundle.AttachedMachines)
-	}
-	if serialized := string(contextFixtureJSON(t, bundle)); strings.Contains(serialized, machineID.String()) {
-		t.Fatalf("active machine projection must not expose raw machine id: %s", serialized)
-	}
-	if serialized := string(contextFixtureJSON(t, bundle)); strings.Contains(serialized, bindingID.String()) {
-		t.Fatalf("attached machine context must not expose durable binding id: %s", serialized)
-	}
-}
-
-func TestBuildOmitsMachineSelectorRefsWhenNoExecutableBindingsExist(t *testing.T) {
-	store := &fakeContextStore{
-		watermark: 14,
-		hasConfig: true,
-		config:    testAgentConfigRecordWithTools(t, toolcatalog.ToolNameInspectMachine),
-	}
-	bundle, err := (Builder{Store: store}).Build(
-		context.Background(),
-		BuildInput{
-			ProjectID:       testProjectID,
-			AgentID:         testAgentID,
-			TurnID:          testTurnID,
-			OpeningInputIDs: []storage.ID{testInputID},
-			Now:             time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC),
-		},
-	)
-	if err != nil {
-		t.Fatalf("build context: %v", err)
-	}
-	if len(bundle.AttachedMachines) != 0 {
-		t.Fatalf("expected no machine selector refs, got %+v", bundle.AttachedMachines)
-	}
-}
-
-func TestBuildOmitsExecutionContextWithoutRelevantTools(t *testing.T) {
-	store := &fakeContextStore{
-		watermark: 15,
-		activeWork: []executionstore.ActiveProcessRecord{{
-			ID:    testIDN(930),
-			State: executionstore.ProcessStateRunning,
-		}},
-		executableMachineBindings: []executionstore.AgentMachineBindingRecord{{
-			ID:         testIDN(931),
-			MachineID:  testIDN(932),
-			MachineRef: "mchr-abc234",
-		}},
-	}
-	bundle, err := (Builder{Store: store}).Build(context.Background(), BuildInput{
-		ProjectID:       testProjectID,
-		AgentID:         testAgentID,
-		TurnID:          testTurnID,
-		OpeningInputIDs: []storage.ID{testInputID},
-		Now:             time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC),
-	})
-	if err != nil {
-		t.Fatalf("build context: %v", err)
-	}
-	if len(bundle.ActiveProcesses) != 0 || len(bundle.AttachedMachines) != 0 {
-		t.Fatalf("execution context must follow the tool contract: %+v", bundle)
-	}
-}
-
 func TestBuildProjectsIntegrationTargets(t *testing.T) {
 	targetID := testIDN(940)
 	store := &fakeContextStore{
@@ -680,8 +539,6 @@ type fakeContextStore struct {
 	messages                   []executionstore.ContextEventRecord
 	toolCalls                  []executionstore.ToolCallRecord
 	completedToolCallWatermark int64
-	activeWork                 []executionstore.ActiveProcessRecord
-	executableMachineBindings  []executionstore.AgentMachineBindingRecord
 	integrationTargets         []integrationstore.IntegrationTargetSummary
 	machinePools               []executionstore.MachinePoolSourceRecord
 	watermark                  int64
@@ -795,26 +652,6 @@ func (s *fakeContextStore) ListCompletedToolCallsAtWatermark(
 		out = append(out, toolCall)
 	}
 	return out, nil
-}
-
-func (s *fakeContextStore) ListActiveProcessesForContext(
-	ctx context.Context,
-	projectID, agentID storage.ID,
-) ([]executionstore.ActiveProcessRecord, error) {
-	_ = ctx
-	_ = projectID
-	_ = agentID
-	return s.activeWork, nil
-}
-
-func (s *fakeContextStore) ListExecutableAgentMachineBindings(
-	ctx context.Context,
-	projectID, agentID storage.ID,
-) ([]executionstore.AgentMachineBindingRecord, error) {
-	_ = ctx
-	_ = projectID
-	_ = agentID
-	return s.executableMachineBindings, nil
 }
 
 func (s *fakeContextStore) ListIntegrationTargets(

--- a/internal/modelcontext/normalize.go
+++ b/internal/modelcontext/normalize.go
@@ -70,26 +70,6 @@ func (ProjectionNormalizer) Normalize(bundle Bundle) error {
 	if len(bundle.Messages) > 0 && lastCheckpointEnd > 0 && bundle.Messages[0].Sequence <= lastCheckpointEnd {
 		return fmt.Errorf("transcript tail overlaps checkpoint range")
 	}
-	seenProcesses := map[string]bool{}
-	for _, process := range bundle.ActiveProcesses {
-		if process.ProcessID == "" || process.State == "" {
-			return fmt.Errorf("active process id and state are required")
-		}
-		if seenProcesses[process.ProcessID] {
-			return fmt.Errorf("duplicate active process in context: %s", process.ProcessID)
-		}
-		seenProcesses[process.ProcessID] = true
-	}
-	seenMachines := map[string]bool{}
-	for _, machine := range bundle.AttachedMachines {
-		if machine.MachineRef == "" {
-			return fmt.Errorf("attached machine ref is required")
-		}
-		if seenMachines[machine.MachineRef] {
-			return fmt.Errorf("duplicate attached machine in context: %s", machine.MachineRef)
-		}
-		seenMachines[machine.MachineRef] = true
-	}
 	seenIntegrationTargets := map[string]bool{}
 	currentIntegrationTargets := 0
 	for _, target := range bundle.IntegrationTargets {

--- a/internal/modelcontext/normalize_test.go
+++ b/internal/modelcontext/normalize_test.go
@@ -9,67 +9,6 @@ import (
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 )
 
-func TestProjectionNormalizerRejectsInvalidExecutionContext(t *testing.T) {
-	base := Bundle{
-		ProjectID:          testProjectID,
-		AgentID:            testAgentID,
-		TurnID:             testTurnID,
-		OpeningInputIDs:    []storage.ID{testInputID},
-		InputEventSequence: 1,
-	}
-	tests := []struct {
-		name      string
-		processes []ActiveProcessRef
-		machines  []AttachedMachineRef
-	}{
-		{name: "process missing state", processes: []ActiveProcessRef{{ProcessID: "prc_1"}}},
-		{name: "machine missing ref", machines: []AttachedMachineRef{{Description: "Build machine"}}},
-		{
-			name: "duplicate process",
-			processes: []ActiveProcessRef{
-				{ProcessID: "prc_1", State: "running"},
-				{ProcessID: "prc_1", State: "exited"},
-			},
-		},
-		{
-			name: "duplicate machine",
-			machines: []AttachedMachineRef{
-				{MachineRef: "mchr-abc234"},
-				{MachineRef: "mchr-abc234"},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			bundle := base
-			bundle.ActiveProcesses = tt.processes
-			bundle.AttachedMachines = tt.machines
-			if err := (ProjectionNormalizer{}).Normalize(bundle); err == nil {
-				t.Fatalf("expected invalid execution context to fail")
-			}
-		})
-	}
-}
-
-func TestProjectionNormalizerAcceptsExecutionContext(t *testing.T) {
-	bundle := Bundle{
-		ProjectID:          testProjectID,
-		AgentID:            testAgentID,
-		TurnID:             testTurnID,
-		OpeningInputIDs:    []storage.ID{testInputID},
-		InputEventSequence: 1,
-		ActiveProcesses:    []ActiveProcessRef{{ProcessID: "prc_1", State: "running"}},
-		AttachedMachines: []AttachedMachineRef{{
-			MachineRef:  "mchr-abc234",
-			Description: "Build machine",
-			Cwd:         "/workspace",
-		}},
-	}
-	if err := (ProjectionNormalizer{}).Normalize(bundle); err != nil {
-		t.Fatalf("normalize execution context: %v", err)
-	}
-}
-
 func TestProjectionNormalizerRejectsInvalidIntegrationTargets(t *testing.T) {
 	base := Bundle{
 		ProjectID:          testProjectID,

--- a/internal/modelcontext/runtime_context.go
+++ b/internal/modelcontext/runtime_context.go
@@ -18,44 +18,6 @@ func IntegrationTargetContextEnabled(specs []ToolSpec) bool {
 	)
 }
 
-func ProcessContextEnabled(specs []ToolSpec) bool {
-	return HasAnyTool(
-		specs,
-		toolcatalog.ToolNameRunCommand,
-		toolcatalog.ToolNameWriteProcess,
-		toolcatalog.ToolNameReadProcess,
-		toolcatalog.ToolNameStopProcess,
-		toolcatalog.ToolNameListProcesses,
-	)
-}
-
-func MachineContextEnabled(specs []ToolSpec) bool {
-	return HasAnyTool(
-		specs,
-		toolcatalog.ToolNameRunCommand,
-		toolcatalog.ToolNameCreateMachine,
-		toolcatalog.ToolNameDeleteMachine,
-		toolcatalog.ToolNameListMachines,
-		toolcatalog.ToolNameInspectMachine,
-	)
-}
-
-func HasExecutionContext(bundle Bundle) bool {
-	return len(bundle.ActiveProcesses) > 0 || len(bundle.AttachedMachines) > 0
-}
-
-func ExecutionContextContent(processes []ActiveProcessRef, machines []AttachedMachineRef) string {
-	body, err := json.Marshal(struct {
-		ActiveProcesses  []ActiveProcessRef   `json:"active_processes,omitempty"`
-		AttachedMachines []AttachedMachineRef `json:"attached_machines,omitempty"`
-	}{ActiveProcesses: processes, AttachedMachines: machines})
-	if err != nil {
-		return "Active execution context is present but could not be serialized."
-	}
-	return "Active execution observations. These are not transcript messages; use the latest tool results " +
-		"and visible process state together when reasoning about active work: " + string(body)
-}
-
 func IntegrationTargetsContent(targets []IntegrationTargetRef) string {
 	if len(targets) == 0 {
 		return "No external integration targets are currently available for this agent."

--- a/internal/modelcontext/sources.go
+++ b/internal/modelcontext/sources.go
@@ -31,14 +31,6 @@ type ExecutionStore interface {
 		afterSequence int64,
 		watermark int64,
 	) ([]executionstore.ToolCallRecord, error)
-	ListActiveProcessesForContext(
-		ctx context.Context,
-		projectID, agentID storage.ID,
-	) ([]executionstore.ActiveProcessRecord, error)
-	ListExecutableAgentMachineBindings(
-		ctx context.Context,
-		projectID, agentID storage.ID,
-	) ([]executionstore.AgentMachineBindingRecord, error)
 	ListMachinePoolSources(
 		ctx context.Context,
 		projectID, agentID, agentConfigID storage.ID,

--- a/internal/modelcontext/types.go
+++ b/internal/modelcontext/types.go
@@ -33,8 +33,6 @@ type Bundle struct {
 	ToolSpecs             []ToolSpec               `json:"tool_specs"`
 	ToolResults           []ToolResultRef          `json:"tool_results"`
 	AvailableMachinePools []MachinePoolRef         `json:"machine_pools,omitempty"`
-	ActiveProcesses       []ActiveProcessRef       `json:"active_processes,omitempty"`
-	AttachedMachines      []AttachedMachineRef     `json:"attached_machines,omitempty"`
 	IntegrationTargets    []IntegrationTargetRef   `json:"integration_targets,omitempty"`
 	ContextCheckpoint     *CheckpointRef           `json:"context_checkpoint,omitempty"`
 	ResolvedMedia         map[string]ResolvedMedia `json:"resolved_media,omitempty"`
@@ -113,21 +111,6 @@ type ToolResultRef struct {
 	Input               json.RawMessage                  `json:"input"`
 	Outcome             executionstore.ToolResultOutcome `json:"-"`
 	ContentParts        json.RawMessage                  `json:"content_parts"`
-}
-
-type ActiveProcessRef struct {
-	ProcessID     string `json:"process_id"`
-	State         string `json:"state"`
-	CommandLabel  string `json:"command_label,omitempty"`
-	Command       string `json:"command,omitempty"`
-	ShellSelector string `json:"shell_selector,omitempty"`
-	Cwd           string `json:"cwd,omitempty"`
-}
-
-type AttachedMachineRef struct {
-	MachineRef  string `json:"machine_ref"`
-	Description string `json:"description,omitempty"`
-	Cwd         string `json:"cwd,omitempty"`
 }
 
 type IntegrationTargetRef struct {

--- a/internal/storage/executionstore/process_daemon_completion_store.go
+++ b/internal/storage/executionstore/process_daemon_completion_store.go
@@ -502,21 +502,21 @@ func (s *Store) GetProcessByToolCall(
 	return getProcessByToolCallTx(ctx, s.pool, projectID, agentID, toolCallID)
 }
 
-func (r *ToolCallReader) ListActiveProcessesForContext(
+func (r *ToolCallReader) ListActiveProcesses(
 	ctx context.Context,
 ) ([]ActiveProcessRecord, error) {
 	t := r.transaction
-	return listActiveProcessesForContext(ctx, t.q, t.input.ProjectID, t.input.AgentID)
+	return listActiveProcesses(ctx, t.q, t.input.ProjectID, t.input.AgentID)
 }
 
-func listActiveProcessesForContext(
+func listActiveProcesses(
 	ctx context.Context,
 	q *dbsqlc.Queries,
 	projectID, agentID ID,
 ) ([]ActiveProcessRecord, error) {
-	rows, err := q.ListActiveProcessesForContext(
+	rows, err := q.ListActiveProcesses(
 		ctx,
-		dbsqlc.ListActiveProcessesForContextParams{ProjectID: projectID, AgentID: agentID},
+		dbsqlc.ListActiveProcessesParams{ProjectID: projectID, AgentID: agentID},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list active processes: %w", err)

--- a/internal/storage/executionstore/process_daemon_completion_store.go
+++ b/internal/storage/executionstore/process_daemon_completion_store.go
@@ -502,16 +502,6 @@ func (s *Store) GetProcessByToolCall(
 	return getProcessByToolCallTx(ctx, s.pool, projectID, agentID, toolCallID)
 }
 
-func (s *Store) ListActiveProcessesForContext(
-	ctx context.Context,
-	projectID, agentID ID,
-) ([]ActiveProcessRecord, error) {
-	if isNilID(projectID) || isNilID(agentID) {
-		return nil, errors.New("project and agent are required")
-	}
-	return listActiveProcessesForContext(ctx, s.q, projectID, agentID)
-}
-
 func (r *ToolCallReader) ListActiveProcessesForContext(
 	ctx context.Context,
 ) ([]ActiveProcessRecord, error) {

--- a/internal/storage/executionstore/process_rows.go
+++ b/internal/storage/executionstore/process_rows.go
@@ -79,7 +79,7 @@ func processRecordFromAcceptSQLC(row dbsqlc.AcceptDaemonProcessRow) ProcessRecor
 	}
 }
 
-func activeProcessRecordFromSQLC(row dbsqlc.ListActiveProcessesForContextRow) ActiveProcessRecord {
+func activeProcessRecordFromSQLC(row dbsqlc.ListActiveProcessesRow) ActiveProcessRecord {
 	return ActiveProcessRecord{
 		ID:              row.ID,
 		State:           ProcessState(row.State),

--- a/internal/storage/internal/dbsqlc/processes.sql.go
+++ b/internal/storage/internal/dbsqlc/processes.sql.go
@@ -1022,7 +1022,7 @@ func (q *Queries) InsertProcess(ctx context.Context, arg InsertProcessParams) (P
 	return i, err
 }
 
-const listActiveProcessesForContext = `-- name: ListActiveProcessesForContext :many
+const listActiveProcesses = `-- name: ListActiveProcesses :many
 SELECT id, state, machine_id, io_mode, command, shell_selector, cwd, source_started_at, created_at, updated_at, tool_call_id
 FROM processes
 WHERE project_id = $1
@@ -1032,12 +1032,12 @@ ORDER BY updated_at DESC, id
 LIMIT 20
 `
 
-type ListActiveProcessesForContextParams struct {
+type ListActiveProcessesParams struct {
 	ProjectID uuid.UUID
 	AgentID   uuid.UUID
 }
 
-type ListActiveProcessesForContextRow struct {
+type ListActiveProcessesRow struct {
 	ID              uuid.UUID
 	State           string
 	MachineID       uuid.UUID
@@ -1051,15 +1051,15 @@ type ListActiveProcessesForContextRow struct {
 	ToolCallID      uuid.UUID
 }
 
-func (q *Queries) ListActiveProcessesForContext(ctx context.Context, arg ListActiveProcessesForContextParams) ([]ListActiveProcessesForContextRow, error) {
-	rows, err := q.db.Query(ctx, listActiveProcessesForContext, arg.ProjectID, arg.AgentID)
+func (q *Queries) ListActiveProcesses(ctx context.Context, arg ListActiveProcessesParams) ([]ListActiveProcessesRow, error) {
+	rows, err := q.db.Query(ctx, listActiveProcesses, arg.ProjectID, arg.AgentID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ListActiveProcessesForContextRow{}
+	items := []ListActiveProcessesRow{}
 	for rows.Next() {
-		var i ListActiveProcessesForContextRow
+		var i ListActiveProcessesRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.State,

--- a/internal/storage/queries/processes.sql
+++ b/internal/storage/queries/processes.sql
@@ -505,7 +505,7 @@ WHERE process.org_id = sqlc.arg(org_id)
   )
 ORDER BY project_id, agent_id, created_at, id;
 
--- name: ListActiveProcessesForContext :many
+-- name: ListActiveProcesses :many
 SELECT id, state, machine_id, io_mode, command, shell_selector, cwd, source_started_at, created_at, updated_at, tool_call_id
 FROM processes
 WHERE project_id = sqlc.arg(project_id)

--- a/internal/toolcatalog/catalog.go
+++ b/internal/toolcatalog/catalog.go
@@ -31,10 +31,10 @@ const (
 	writeProcessToolDescription   = "Write exact stdin/PTY bytes to a running process, close pipe stdin, or do both."
 	stopProcessToolDescription    = "Interrupt or terminate a running process."
 	readProcessToolDescription    = "Read retained process output, optionally waiting briefly for output or completion."
-	listProcessesToolDescription  = "List active processes in the current agent."
+	listProcessesToolDescription  = "List active processes in the current agent, including process_id values."
 	createMachineToolDescription  = "Request another pool-backed machine for this agent. machine_pool_name is only needed when multiple machine pools are available."
 	deleteMachineToolDescription  = "Request deletion of a pool-backed machine."
-	listMachinesToolDescription   = "List BYO and pool-backed machines currently associated with this agent."
+	listMachinesToolDescription   = "List BYO and pool-backed machines currently associated with this agent, including machine_ref values and current availability."
 	inspectMachineToolDescription = "Inspect a BYO or pool-backed machine. machine_ref is only needed when multiple machines are available."
 	askQuestionToolDescription    = "Ask the human user one or more multiple-choice questions. " +
 		"Omnara appends a text-capable Other choice to every question for free-form user responses."
@@ -79,7 +79,7 @@ func buildDefaultCatalog() (Catalog, error) {
 	}
 	machineRef := map[string]any{
 		"type":        "string",
-		"description": "Pass machine_ref only when multiple machines are available; otherwise omit it.",
+		"description": "Exact machine_ref returned by list_machines. Omit it when the target is unambiguous.",
 	}
 	deleteMachineRef := map[string]any{
 		"type":        "string",
@@ -91,7 +91,7 @@ func buildDefaultCatalog() (Catalog, error) {
 	}
 	processID := map[string]any{
 		"type":        "string",
-		"description": "Opaque process_id returned by run_command after execution is granted. Copy it exactly.",
+		"description": "Opaque process_id returned by run_command or list_processes. Copy it exactly.",
 	}
 	entries := map[string]Entry{}
 	var err error

--- a/internal/toolcatalog/catalog_test.go
+++ b/internal/toolcatalog/catalog_test.go
@@ -31,3 +31,40 @@ func TestEntryRejectsReservedMCPNamespace(t *testing.T) {
 		t.Fatalf("validation error = %v, want reserved MCP tool namespace rejection", err)
 	}
 }
+
+func TestDefaultCatalogIncludesRuntimeDiscoveryGuidance(t *testing.T) {
+	catalog, err := Default()
+	if err != nil {
+		t.Fatalf("default catalog: %v", err)
+	}
+	checks := []struct {
+		name        string
+		description []string
+		schema      []string
+	}{
+		{
+			name:        ToolNameListMachines,
+			description: []string{"machine_ref", "availability"},
+		},
+		{name: ToolNameRunCommand, schema: []string{ToolNameListMachines}},
+		{name: ToolNameInspectMachine, schema: []string{ToolNameListMachines}},
+		{name: ToolNameListProcesses, description: []string{"process_id"}},
+		{name: ToolNameReadProcess, schema: []string{ToolNameListProcesses}},
+	}
+	for _, check := range checks {
+		entry, ok := catalog.Lookup(check.name)
+		if !ok {
+			t.Fatalf("%s missing from default catalog", check.name)
+		}
+		for _, needle := range check.description {
+			if !strings.Contains(entry.Description, needle) {
+				t.Fatalf("%s description does not contain %q: %s", check.name, needle, entry.Description)
+			}
+		}
+		for _, needle := range check.schema {
+			if !strings.Contains(string(entry.InputSchema), needle) {
+				t.Fatalf("%s schema does not contain %q: %s", check.name, needle, entry.InputSchema)
+			}
+		}
+	}
+}


### PR DESCRIPTION
- removes automatic active-process and attached-machine inventories from model prompts so rapidly changing runtime state no longer disrupts prompt-cache reuse
- deletes the now-unused model-context construction, normalization, provider serialization, and direct storage paths for that execution-state bundle
- preserves on-demand process and machine discovery through the existing list tools
- leaves machine-pool and integration-target prompt context unchanged
