### PR TITLE
feat: streamline agent creation and configuration

### DIFF
--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -25,7 +25,7 @@ Create an agent from a [config](/agents/configuration), or from a [profile](/age
 
   Users with launch-only access can select **From profile** but cannot create a config with the Builder or YAML editor.
 
-  Add an **Agent name (optional)** — launches from a profile default to the profile's name — and a **First message (optional)** to kick the agent off, then click **Create agent**. You land in the conversation view.
+  Give the agent a **Name**, then click **Create & launch agent**. In the conversation view, use the composer to send its first task.
 </Tab>
 <Tab title="API">
   ```bash

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -48,9 +48,7 @@ Omnara is model-agnostic: you bring a provider API key, and agents use the model
 
       `model.name` must match a configured model exactly, as shown on the **Models** page — substitute yours if it's named differently.
 
-      In **Agent name (optional)**, enter `Research assistant`.
-
-      In **First message (optional)**, give it the task:
+      In **Name**, enter `Research assistant`, then click **Create & launch agent**. In the conversation composer, send this task:
 
       ```text
       Find the Omnara blog post "The Log Is the Agent." Before summarizing it, use
@@ -59,7 +57,7 @@ Omnara is model-agnostic: you bring a provider API key, and agents use the model
       takeaways, and link to the post.
       ```
 
-      Click **Create agent**. The console validates the config, launches the agent, and drops you into its conversation view.
+      The agent starts working as soon as you send the message.
     </Step>
     <Step title="Answer the scope question">
       The agent pauses and an **Agent question** card appears in the conversation. Choose an option and click **Submit**. The agent resumes immediately.

--- a/frontend/apps/web/e2e/web.spec.ts
+++ b/frontend/apps/web/e2e/web.spec.ts
@@ -73,7 +73,7 @@ async function signIn(page: Page, email: string, returnTo: string) {
 }
 
 async function selectConfiguredModel(page: Page) {
-  const modelPicker = page.getByRole('combobox', { name: 'Search granted models…' })
+  const modelPicker = page.getByRole('combobox', { name: 'Model' })
   await modelPicker.fill(modelName)
   await page
     .getByRole('option')
@@ -84,7 +84,7 @@ async function selectConfiguredModel(page: Page) {
 
 async function createProfile(page: Page, name: string, instruction: string) {
   await signIn(page, adminEmail, createAgentPath)
-  await page.getByLabel('Name', { exact: true }).fill(name)
+  await page.getByRole('textbox', { name: 'Name', exact: true }).fill(name)
   await page.getByLabel('Instruction').fill(instruction)
   await selectConfiguredModel(page)
   await expect(page.getByRole('button', { name: 'Create profile' })).toBeEnabled()
@@ -101,6 +101,14 @@ async function typeInConfigEditor(page: Page, text: string) {
   const editor = page.getByRole('textbox', { name: 'Config (YAML)' })
   await expect(editor).toBeVisible()
   await editor.focus()
+  await page.keyboard.insertText(text)
+}
+
+async function replaceConfigEditor(page: Page, text: string) {
+  const editor = page.getByRole('textbox', { name: 'Config (YAML)' })
+  await expect(editor).toBeVisible()
+  await editor.focus()
+  await page.keyboard.press('Control+A')
   await page.keyboard.insertText(text)
 }
 
@@ -193,14 +201,18 @@ test('creates an agent from YAML', async ({ page }) => {
   await expect(page.getByRole('button', { name: 'YAML' })).toBeVisible()
 
   await page.getByRole('button', { name: 'YAML' }).click()
+  await expect(page.getByRole('textbox', { name: 'Config (YAML)' })).toHaveAttribute(
+    'aria-required',
+    'true',
+  )
 
   const agentName = uniqueName('YAML E2E Agent')
-  await page.getByLabel('Name', { exact: true }).fill(agentName)
+  await page.getByRole('textbox', { name: 'Name', exact: true }).fill(agentName)
   const yamlLines = [
     'instruction: Test agent creation from YAML.',
     `model: { provider_config: "${providerConfig}", name: "${modelName}" }`,
   ]
-  await typeInConfigEditor(page, yamlLines.join('\n'))
+  await replaceConfigEditor(page, yamlLines.join('\n'))
   await expect(page.getByRole('button', { name: 'Create & launch agent' })).toBeEnabled()
   await page.getByRole('button', { name: 'Create & launch agent' }).click()
 
@@ -214,8 +226,34 @@ test('creates an agent with the Builder', async ({ page }) => {
   await signIn(page, adminEmail, createAgentPath)
 
   await expect(page.getByRole('button', { name: 'Builder' })).toBeVisible()
+  await expect(page.getByRole('combobox', { name: 'Model' })).toHaveAttribute(
+    'aria-required',
+    'true',
+  )
+  await expect(page.getByText('web_search', { exact: true })).toBeVisible()
+  await expect(page.getByText('web_fetch', { exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Toolsets' })).toHaveCount(0)
+  await expect(page.getByLabel('First message (optional)')).toHaveCount(0)
+  await expect(page.getByText('No machine sources', { exact: true })).toHaveCount(0)
+  await expect(page.getByText('No skills attached', { exact: true })).toHaveCount(0)
+  await expect(page.getByText('No MCP servers', { exact: true })).toHaveCount(0)
+
+  await page.getByRole('button', { name: 'Add tools' }).click()
+  await expect(page.getByRole('menuitem', { name: 'skill', exact: true })).toHaveCount(0)
+  await expect(
+    page.getByRole('menuitem', { name: 'send_integration_message', exact: true }),
+  ).toHaveCount(0)
+  await expect(
+    page.getByRole('menuitem', { name: 'set_integration_target', exact: true }),
+  ).toHaveCount(0)
+  await page.keyboard.press('Escape')
+
+  await page.getByRole('button', { name: 'About web_search' }).hover()
+  await expect(page.getByRole('tooltip')).toContainText('Search the public web')
+  await expect(page.getByRole('tooltip').getByRole('link', { name: 'Learn more' })).toHaveCount(0)
+
   const agentName = uniqueName('Builder Agent')
-  await page.getByLabel('Name', { exact: true }).fill(agentName)
+  await page.getByRole('textbox', { name: 'Name', exact: true }).fill(agentName)
   await page.getByLabel('Instruction').fill('Use the visual Builder to create this test agent.')
   await selectConfiguredModel(page)
 
@@ -264,7 +302,7 @@ test('granting a model from the Builder does not create a profile or agent', asy
   })
   await signIn(page, adminEmail, createAgentPath)
 
-  await page.getByLabel('Name', { exact: true }).fill('Unintended Agent')
+  await page.getByRole('textbox', { name: 'Name', exact: true }).fill('Unintended Agent')
   await page.getByLabel('Instruction').fill('This form must not submit from a grant dialog.')
   await selectConfiguredModel(page)
   await expect(page.getByRole('button', { name: 'Create & launch agent' })).toBeEnabled()
@@ -282,9 +320,20 @@ test('granting a model from the Builder does not create a profile or agent', asy
     }
   })
 
-  await page.getByRole('button', { name: 'Grant models' }).click()
+  const modelPicker = page.getByRole('combobox', { name: 'Model' })
+  await modelPicker.fill('Grant models')
+  const grantModelsOption = page.getByRole('option', { name: 'Grant models…' })
+  await expect(grantModelsOption).toBeVisible()
+  await modelPicker.press('ArrowDown')
+  await expect(grantModelsOption).toHaveAttribute('data-highlighted', '')
+  const providerListResponse = page.waitForResponse((response) => {
+    const url = new URL(response.url())
+    return response.request().method() === 'GET' && url.pathname.endsWith('/model-provider-configs')
+  })
+  await modelPicker.press('Enter')
   const dialog = page.getByRole('dialog', { name: 'Grant models' })
   const providerPicker = dialog.getByRole('combobox', { name: 'Search model providers…' })
+  expect((await providerListResponse).ok()).toBe(true)
   await providerPicker.fill(providerConfig)
   await page.getByRole('option', { name: providerConfig }).click()
   const configuredModelPicker = dialog.getByRole('combobox', {
@@ -296,6 +345,7 @@ test('granting a model from the Builder does not create a profile or agent', asy
 
   await expect(dialog).toHaveCount(0)
   await expect(page).toHaveURL(createAgentPath)
+  await page.keyboard.press('Escape')
   await expect(page.getByRole('button', { name: 'Create & launch agent' })).toBeEnabled()
   expect(agentSubmissionRequests).toBe(0)
   expect(failures).toEqual([])
@@ -426,6 +476,7 @@ test('edits a profile with the Builder', async ({ page }) => {
   const failures = installFailureTracking(page)
   await createProfile(page, uniqueName('Builder Edit Agent'), 'Original instruction.')
 
+  await expect(page.getByRole('combobox', { name: 'Model' })).toBeVisible()
   const instruction = page.getByLabel('Instruction')
   await expect(instruction).toHaveValue('Original instruction.')
   const save = page.getByRole('button', { name: 'Save revision' })

--- a/frontend/apps/web/src/components/agents/AgentConfigBasicForm.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigBasicForm.tsx
@@ -2,12 +2,11 @@ import { useToolCatalog } from '@omnara/react'
 
 import { AgentConfigMachineSourcesField } from '@/components/agents/AgentConfigMachineSourcesField'
 import { AgentConfigMcpServersField } from '@/components/agents/AgentConfigMcpServersField'
-import { AgentConfigModelField } from '@/components/agents/AgentConfigModelField'
 import { AgentConfigSkillsField } from '@/components/agents/AgentConfigSkillsField'
 import { AgentConfigToolsField } from '@/components/agents/AgentConfigToolsField'
 import { addMissingMachineTools, hasMissingMachineTools } from '@/components/agents/builtInTools'
 import type { AgentBuilderForm } from '@/components/agents/useAgentBuilderForm'
-import { Field, FieldGroup, FieldLabel } from '@/components/ui/field'
+import { Field, FieldGroup, RequiredFieldLabel } from '@/components/ui/field'
 import { Textarea } from '@/components/ui/textarea'
 
 export function AgentConfigBasicForm({
@@ -27,54 +26,63 @@ export function AgentConfigBasicForm({
   return (
     <FieldGroup className="gap-8">
       <Field>
-        <FieldLabel htmlFor="agent-config-basic-instruction">Agent Instructions</FieldLabel>
+        <RequiredFieldLabel htmlFor="agent-config-basic-instruction">
+          Agent Instructions
+        </RequiredFieldLabel>
         <Textarea
           id="agent-config-basic-instruction"
+          required
           value={form.instruction}
           placeholder="You are a research assistant. When given a topic, gather sources and produce a short summary with citations."
-          className="min-h-36 resize-y"
+          className="max-h-96 min-h-20 resize-y"
           onChange={(event) => {
             form.setInstruction(event.target.value)
           }}
         />
       </Field>
-      <AgentConfigModelField
-        orgId={orgId}
-        projectId={projectId}
-        value={form.model}
-        onChange={form.setModel}
-        onUnavailableChange={form.reportModelUnavailable}
-      />
-      <AgentConfigMachineSourcesField
-        orgId={orgId}
-        projectId={projectId}
-        sources={form.machineSources}
-        onSourcesChange={form.setMachineSources}
-        onUnavailableIdsChange={form.reportUnavailableSourceIds}
-        showMissingToolsWarning={showMissingMachineTools}
-        onAddMissingTools={() => {
-          form.setTools(addMissingMachineTools(form.tools))
-        }}
-      />
-      <AgentConfigToolsField
-        catalog={toolCatalog.data}
-        tools={form.tools}
-        onToolsChange={form.setTools}
-      />
-      <AgentConfigSkillsField
-        orgId={orgId}
-        projectId={projectId}
-        selectedIds={form.skillIds}
-        onSelectedIdsChange={form.setSkillIds}
-        onUnavailableIdsChange={form.reportUnavailableSkillIds}
-      />
-      <AgentConfigMcpServersField
-        orgId={orgId}
-        projectId={projectId}
-        permissionProfile={toolCatalog.data?.mcp_tool_permissions}
-        servers={form.mcpServers}
-        onServersChange={form.setMcpServers}
-      />
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-right text-sm">Optional</p>
+        <div className="bg-muted/15 divide-y overflow-hidden rounded-xl">
+          <div className="p-5">
+            <AgentConfigMachineSourcesField
+              orgId={orgId}
+              projectId={projectId}
+              sources={form.machineSources}
+              onSourcesChange={form.setMachineSources}
+              onUnavailableIdsChange={form.reportUnavailableSourceIds}
+              showMissingToolsWarning={showMissingMachineTools}
+              onAddMissingTools={() => {
+                form.setTools(addMissingMachineTools(form.tools))
+              }}
+            />
+          </div>
+          <div className="p-5">
+            <AgentConfigToolsField
+              catalog={toolCatalog.data}
+              tools={form.tools}
+              onToolsChange={form.setTools}
+            />
+          </div>
+          <div className="p-5">
+            <AgentConfigSkillsField
+              orgId={orgId}
+              projectId={projectId}
+              selectedIds={form.skillIds}
+              onSelectedIdsChange={form.setSkillIds}
+              onUnavailableIdsChange={form.reportUnavailableSkillIds}
+            />
+          </div>
+          <div className="p-5">
+            <AgentConfigMcpServersField
+              orgId={orgId}
+              projectId={projectId}
+              permissionProfile={toolCatalog.data?.mcp_tool_permissions}
+              servers={form.mcpServers}
+              onServersChange={form.setMcpServers}
+            />
+          </div>
+        </div>
+      </div>
     </FieldGroup>
   )
 }

--- a/frontend/apps/web/src/components/agents/AgentConfigEditor.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigEditor.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 
 import { AgentConfigBasicForm } from '@/components/agents/AgentConfigBasicForm'
+import { AgentConfigModelField } from '@/components/agents/AgentConfigModelField'
 import { AgentConfigYamlField } from '@/components/agents/AgentConfigYamlField'
 import { ConfirmDiscardYamlDialog } from '@/components/agents/ConfirmDiscardYamlDialog'
 import { PillTabs } from '@/components/agents/PillTabs'
@@ -45,6 +46,13 @@ export function AgentConfigEditorFields({
       )}
       {builderSession != null && (
         <div className={showBuilder ? 'flex flex-col gap-8' : 'hidden'}>
+          <AgentConfigModelField
+            orgId={orgId}
+            projectId={projectId}
+            value={editor.form.model}
+            onChange={editor.form.setModel}
+            onUnavailableChange={editor.form.reportModelUnavailable}
+          />
           <AgentConfigBasicForm orgId={orgId} projectId={projectId} form={editor.form} />
         </div>
       )}

--- a/frontend/apps/web/src/components/agents/AgentConfigMachineSourceComboboxes.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigMachineSourceComboboxes.tsx
@@ -75,6 +75,8 @@ function useStaleName<TItem>(
 }
 
 export function PoolSourceCombobox({
+  id,
+  required,
   orgId,
   projectId,
   value,
@@ -82,6 +84,8 @@ export function PoolSourceCombobox({
   onUnavailableChange,
   onPoolResolved,
 }: {
+  id?: string
+  required?: boolean
   orgId: string
   projectId: string
   value: string
@@ -121,6 +125,8 @@ export function PoolSourceCombobox({
   return (
     <>
       <PoolNameCombobox
+        id={id}
+        required={required}
         items={grants.map((item) => ({
           name: item.machine_pool.name,
           pool: item.machine_pool,
@@ -159,6 +165,8 @@ export function PoolSourceCombobox({
 }
 
 export function MachineSourceCombobox({
+  id,
+  required,
   orgId,
   projectId,
   value,
@@ -166,6 +174,8 @@ export function MachineSourceCombobox({
   onUnavailableChange,
   onMachinesGranted,
 }: {
+  id?: string
+  required?: boolean
   orgId: string
   projectId: string
   value: string
@@ -200,6 +210,8 @@ export function MachineSourceCombobox({
   return (
     <>
       <MachineNameCombobox
+        id={id}
+        required={required}
         items={machines.map((machine) => ({ name: machine.display_name }))}
         value={value === '' ? null : { name: value }}
         onValueChange={(machine) => {

--- a/frontend/apps/web/src/components/agents/AgentConfigMachineSourcesField.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigMachineSourcesField.tsx
@@ -1,4 +1,4 @@
-import { Trash2Icon } from 'lucide-react'
+import { PlusIcon, Trash2Icon } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
 import {
@@ -15,7 +15,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Field, FieldDescription, FieldLabel } from '@/components/ui/field'
+import { Field, FieldLabel, RequiredFieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 
 export function AgentConfigMachineSourcesField({
@@ -59,17 +59,20 @@ export function AgentConfigMachineSourcesField({
   }, [onUnavailableIdsChange, sources, unavailableIds])
 
   return (
-    <Field>
+    <Field className="gap-5">
       <div className="flex items-center justify-between gap-3">
-        <div>
-          <FieldLabel>Machine sources</FieldLabel>
-          <FieldDescription>Machines the agent can run commands on.</FieldDescription>
-        </div>
+        <FieldLabel>Machine sources</FieldLabel>
         <div className="flex items-center gap-2">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button type="button" size="sm" variant="outline">
-                Add source
+              <Button
+                type="button"
+                size="icon"
+                variant="outline"
+                className="bg-muted/40 size-8"
+                aria-label="Add source"
+              >
+                <PlusIcon />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
@@ -85,7 +88,7 @@ export function AgentConfigMachineSourcesField({
                   onSourcesChange([...sources, newMachineSource('machine')])
                 }}
               >
-                Existing machine
+                BYO machine
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -102,22 +105,22 @@ export function AgentConfigMachineSourcesField({
           </Button>
         </div>
       )}
-      <div className="space-y-3">
-        {sources.length === 0 ? (
-          <div className="border-border bg-background/60 text-muted-foreground flex min-h-16 items-center justify-center rounded-md border border-dashed px-4 text-sm">
-            No machine sources
-          </div>
-        ) : (
-          sources.map((source) => (
+      {sources.length > 0 && (
+        <div className="space-y-3">
+          {sources.map((source) => (
             <div
               key={source.id}
-              className="border-border bg-background space-y-4 rounded-lg border p-4"
+              className="border-border bg-muted/40 space-y-4 rounded-lg border p-4"
             >
               <div className="grid gap-4 sm:grid-cols-[1fr_auto]">
                 <Field>
-                  <FieldLabel>{source.kind === 'pool' ? 'Machine pool' : 'Machine'}</FieldLabel>
+                  <RequiredFieldLabel htmlFor={`${source.id}-source`}>
+                    {source.kind === 'pool' ? 'Machine pool' : 'BYO machine'}
+                  </RequiredFieldLabel>
                   {source.kind === 'pool' ? (
                     <PoolSourceCombobox
+                      id={`${source.id}-source`}
+                      required
                       orgId={orgId}
                       projectId={projectId}
                       value={source.name}
@@ -152,6 +155,8 @@ export function AgentConfigMachineSourcesField({
                     />
                   ) : (
                     <MachineSourceCombobox
+                      id={`${source.id}-source`}
+                      required
                       orgId={orgId}
                       projectId={projectId}
                       value={source.name}
@@ -278,9 +283,9 @@ export function AgentConfigMachineSourcesField({
                 Remove source
               </Button>
             </div>
-          ))
-        )}
-      </div>
+          ))}
+        </div>
+      )}
     </Field>
   )
 }

--- a/frontend/apps/web/src/components/agents/AgentConfigMcpSecretCombobox.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigMcpSecretCombobox.tsx
@@ -13,11 +13,15 @@ const SecretCombobox = createResourceCombobox<Secret>({
 })
 
 export function AgentConfigMcpSecretCombobox({
+  id,
+  required,
   orgId,
   projectId,
   server,
   onChange,
 }: {
+  id?: string
+  required?: boolean
   orgId: string
   projectId: string
   server: BasicMcpServer
@@ -52,6 +56,8 @@ export function AgentConfigMcpSecretCombobox({
 
   return (
     <SecretCombobox
+      id={id}
+      required={required}
       items={secrets}
       value={selectedSecret}
       onValueChange={(secret) => {

--- a/frontend/apps/web/src/components/agents/AgentConfigMcpServersField.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigMcpServersField.tsx
@@ -1,10 +1,10 @@
 import type { ToolPermissionProfile } from '@omnara/sdk'
-import { Trash2Icon } from 'lucide-react'
+import { PlusIcon, Trash2Icon } from 'lucide-react'
 
 import { AgentConfigMcpSecretCombobox } from '@/components/agents/AgentConfigMcpSecretCombobox'
 import type { BasicMcpServer, McpAuthType } from '@/components/agents/useAgentBuilderForm'
 import { Button } from '@/components/ui/button'
-import { Field, FieldDescription, FieldLabel } from '@/components/ui/field'
+import { Field, FieldDescription, FieldLabel, RequiredFieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import {
   Select,
@@ -58,43 +58,39 @@ export function AgentConfigMcpServersField({
   }
 
   return (
-    <Field>
+    <Field className="gap-5">
       <div className="flex items-center justify-between gap-3">
-        <div>
-          <FieldLabel>MCP servers</FieldLabel>
-          <FieldDescription>Remote MCP servers the agent can call tools on.</FieldDescription>
-        </div>
+        <FieldLabel>MCP servers</FieldLabel>
         <Button
           type="button"
-          size="sm"
+          size="icon"
           variant="outline"
+          className="bg-muted/40 size-8"
           disabled={permissionProfile == null}
+          aria-label="Add server"
           onClick={() => {
             if (permissionProfile != null) {
               onServersChange([...servers, newMcpServer(permissionProfile)])
             }
           }}
         >
-          Add server
+          <PlusIcon />
         </Button>
       </div>
-      <div className="space-y-3">
-        {servers.length === 0 ? (
-          <div className="border-border bg-background/60 text-muted-foreground flex min-h-16 items-center justify-center rounded-md border border-dashed px-4 text-sm">
-            No MCP servers
-          </div>
-        ) : (
-          servers.map((server) => {
+      {servers.length > 0 && (
+        <div className="space-y-3">
+          {servers.map((server) => {
             return (
               <div
                 key={server.id}
-                className="border-border bg-background space-y-4 rounded-lg border p-4"
+                className="border-border bg-muted/40 space-y-4 rounded-lg border p-4"
               >
                 <div className="grid gap-4 sm:grid-cols-[minmax(8rem,14rem)_1fr_auto]">
                   <Field>
-                    <FieldLabel htmlFor={`${server.id}-name`}>Name</FieldLabel>
+                    <RequiredFieldLabel htmlFor={`${server.id}-name`}>Name</RequiredFieldLabel>
                     <Input
                       id={`${server.id}-name`}
+                      required
                       value={server.name}
                       placeholder="github"
                       onChange={(event) => {
@@ -103,9 +99,10 @@ export function AgentConfigMcpServersField({
                     />
                   </Field>
                   <Field>
-                    <FieldLabel htmlFor={`${server.id}-url`}>URL</FieldLabel>
+                    <RequiredFieldLabel htmlFor={`${server.id}-url`}>URL</RequiredFieldLabel>
                     <Input
                       id={`${server.id}-url`}
+                      required
                       value={server.url}
                       placeholder="https://example.com/mcp"
                       onChange={(event) => {
@@ -207,8 +204,12 @@ export function AgentConfigMcpServersField({
                   </Field>
                   {server.authType !== 'none' && (
                     <Field>
-                      <FieldLabel>Secret</FieldLabel>
+                      <RequiredFieldLabel htmlFor={`${server.id}-secret`}>
+                        Secret
+                      </RequiredFieldLabel>
                       <AgentConfigMcpSecretCombobox
+                        id={`${server.id}-secret`}
+                        required
                         orgId={orgId}
                         projectId={projectId}
                         server={server}
@@ -228,11 +229,12 @@ export function AgentConfigMcpServersField({
                   {server.authType === 'sigv4' &&
                     awsSigningFields.map((field) => (
                       <Field key={field.key}>
-                        <FieldLabel htmlFor={`${server.id}-aws-${field.key}`}>
+                        <RequiredFieldLabel htmlFor={`${server.id}-aws-${field.key}`}>
                           {field.label}
-                        </FieldLabel>
+                        </RequiredFieldLabel>
                         <Input
                           id={`${server.id}-aws-${field.key}`}
+                          required
                           value={server[field.key]}
                           onChange={(event) => {
                             updateServer(server.id, { [field.key]: event.target.value })
@@ -255,9 +257,9 @@ export function AgentConfigMcpServersField({
                 </Button>
               </div>
             )
-          })
-        )}
-      </div>
+          })}
+        </div>
+      )}
     </Field>
   )
 }

--- a/frontend/apps/web/src/components/agents/AgentConfigModelField.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigModelField.tsx
@@ -1,23 +1,40 @@
 import { useProjectModelGrants } from '@omnara/react'
 import type { ConfiguredModelSummary } from '@omnara/sdk'
-import { useEffect } from 'react'
+import { PlusIcon } from 'lucide-react'
+import { useEffect, useState } from 'react'
 
-import { GrantModelButton } from '@/components/projects/GrantModelButton'
-import { Field, FieldLabel } from '@/components/ui/field'
+import { GrantProjectModelDialog } from '@/components/projects/GrantProjectModelDialog'
+import { Field, RequiredFieldLabel } from '@/components/ui/field'
 import { createResourceCombobox } from '@/components/ui/resource-combobox'
 import { useCompleteInfiniteQueryItems } from '@/hooks/use-complete-infinite-query-items'
 import { useInfiniteQueryItems } from '@/hooks/use-infinite-query-items'
 import { exactNameGlob, useTypeaheadSearch } from '@/hooks/use-resource-list'
+import { useProjectPage } from '@/lib/use-project-page'
 
-const ModelCombobox = createResourceCombobox<ConfiguredModelSummary>({
-  itemKey: (model) => model.id,
-  itemLabel: (model) => `${model.name} · ${model.provider_config}`,
-  renderItem: (model) => (
-    <span className="flex min-w-0 items-baseline gap-1.5">
-      <span className="truncate">{model.name}</span>
-      <span className="text-muted-foreground truncate text-xs">{model.provider_config}</span>
-    </span>
-  ),
+type ModelOption = { kind: 'grant' } | { kind: 'model'; model: ConfiguredModelSummary }
+
+const grantModelsOption: ModelOption = { kind: 'grant' }
+
+const ModelCombobox = createResourceCombobox<ModelOption>({
+  itemKey: (option) => (option.kind === 'grant' ? 'grant-models' : option.model.id),
+  itemLabel: (option) =>
+    option.kind === 'grant'
+      ? 'Grant models…'
+      : `${option.model.name} · ${option.model.provider_config}`,
+  renderItem: (option) =>
+    option.kind === 'grant' ? (
+      <>
+        <PlusIcon className="size-4" />
+        <span>Grant models…</span>
+      </>
+    ) : (
+      <span className="flex min-w-0 items-baseline gap-1.5">
+        <span className="truncate">{option.model.name}</span>
+        <span className="text-muted-foreground truncate text-xs">
+          {option.model.provider_config}
+        </span>
+      </span>
+    ),
   placeholder: 'Search granted models…',
   emptyMessage: 'No granted models found.',
 })
@@ -40,6 +57,8 @@ export function AgentConfigModelField({
   onChange: (selection: ModelSelection) => void
   onUnavailableChange?: (unavailable: boolean) => void
 }) {
+  const { project } = useProjectPage()
+  const [grantOpen, setGrantOpen] = useState(false)
   const search = useTypeaheadSearch()
   const grantsQuery = useProjectModelGrants(orgId, projectId, {
     filters: search.filters,
@@ -61,72 +80,88 @@ export function AgentConfigModelField({
     listedSelected ?? completeSelection.items.map((item) => item.model).find(matchesValue) ?? null
   const displayedModels =
     selected && !models.some((model) => model.id === selected.id) ? [selected, ...models] : models
+  const modelOptions: ModelOption[] = displayedModels.map((model) => ({ kind: 'model', model }))
+  const selectedOption: ModelOption | null = selected ? { kind: 'model', model: selected } : null
+  const options = project?.access.can_manage_access
+    ? [grantModelsOption, ...modelOptions]
+    : modelOptions
   const unavailable = lookupEnabled && completeSelection.isComplete && selected === null
   useEffect(() => {
     onUnavailableChange?.(unavailable)
   }, [onUnavailableChange, unavailable])
 
   return (
-    <Field>
-      <div className="flex items-center justify-between gap-3">
-        <FieldLabel>Model</FieldLabel>
-        <GrantModelButton />
-      </div>
-      <p className="text-muted-foreground text-sm">
-        Choose the exact granted model this agent will use.
-      </p>
-      <ModelCombobox
-        items={displayedModels}
-        value={selected}
-        onValueChange={(model) => {
-          if (!model) return
-          onChange({ providerConfig: model.provider_config, modelName: model.name })
-        }}
-        search={search}
-        query={grantsQuery}
-        placeholder={
-          grantsQuery.isPending
-            ? 'Loading models…'
-            : models.length === 0 && search.search === ''
-              ? 'No models granted'
-              : 'Search granted models…'
-        }
-        disabled={grantsQuery.isError || selectedQuery.isError}
+    <>
+      <Field>
+        <RequiredFieldLabel htmlFor="agent-config-model">Model</RequiredFieldLabel>
+        <ModelCombobox
+          id="agent-config-model"
+          required
+          items={options}
+          value={selectedOption}
+          onValueChange={(option) => {
+            if (option?.kind === 'grant') {
+              setGrantOpen(true)
+              return
+            }
+            if (!option) return
+            onChange({
+              providerConfig: option.model.provider_config,
+              modelName: option.model.name,
+            })
+          }}
+          search={search}
+          query={grantsQuery}
+          placeholder={
+            grantsQuery.isPending
+              ? 'Loading models…'
+              : models.length === 0 && search.search === ''
+                ? 'No models granted'
+                : 'Search granted models…'
+          }
+          disabled={grantsQuery.isError || selectedQuery.isError}
+        />
+        {unavailable && (
+          <p className="text-destructive text-sm">
+            The configured model “{value.modelName}” ({value.providerConfig}) is no longer available
+            to the project. Pick another model or grant it again.
+          </p>
+        )}
+        {grantsQuery.isError && (
+          <p className="text-destructive text-sm">
+            Could not load granted models.{' '}
+            <button
+              type="button"
+              className="underline"
+              onClick={() => {
+                void grantsQuery.refetch()
+              }}
+            >
+              Retry
+            </button>
+          </p>
+        )}
+        {selectedQuery.isError && (
+          <p className="text-destructive text-sm">
+            Could not load the selected model.{' '}
+            <button
+              type="button"
+              className="underline"
+              onClick={() => {
+                void selectedQuery.refetch()
+              }}
+            >
+              Retry
+            </button>
+          </p>
+        )}
+      </Field>
+      <GrantProjectModelDialog
+        open={grantOpen}
+        onOpenChange={setGrantOpen}
+        orgId={orgId}
+        projectId={projectId}
       />
-      {unavailable && (
-        <p className="text-destructive text-sm">
-          The configured model “{value.modelName}” ({value.providerConfig}) is no longer available
-          to the project. Pick another model or grant it again.
-        </p>
-      )}
-      {grantsQuery.isError && (
-        <p className="text-destructive text-sm">
-          Could not load granted models.{' '}
-          <button
-            type="button"
-            className="underline"
-            onClick={() => {
-              void grantsQuery.refetch()
-            }}
-          >
-            Retry
-          </button>
-        </p>
-      )}
-      {selectedQuery.isError && (
-        <p className="text-destructive text-sm">
-          Could not load the selected model.{' '}
-          <button
-            type="button"
-            className="underline"
-            onClick={() => {
-              void selectedQuery.refetch()
-            }}
-          >
-            Retry
-          </button>
-        </p>
-      )}
-    </Field>
+    </>
   )
 }

--- a/frontend/apps/web/src/components/agents/AgentConfigPanel.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigPanel.tsx
@@ -144,7 +144,8 @@ function AgentConfigPanelEditor({
 
   return (
     <form
-      className="flex flex-1 flex-col"
+      noValidate
+      className="mx-auto flex w-full max-w-3xl flex-1 flex-col"
       onSubmit={(event) => {
         void submit(event)
       }}

--- a/frontend/apps/web/src/components/agents/AgentConfigSkillsField.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigSkillsField.tsx
@@ -1,10 +1,10 @@
 import { useProjectAvailableSkills } from '@omnara/react'
 import type { Skill } from '@omnara/sdk'
-import { CircleAlert, Sparkles, Trash2Icon } from 'lucide-react'
+import { CircleAlert, PlusIcon, Sparkles, Trash2Icon } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
-import { Field, FieldDescription, FieldLabel } from '@/components/ui/field'
+import { Field, FieldLabel } from '@/components/ui/field'
 import { createResourceCombobox } from '@/components/ui/resource-combobox'
 import { useCompleteInfiniteQueryItems } from '@/hooks/use-complete-infinite-query-items'
 import { useInfiniteQueryItems } from '@/hooks/use-infinite-query-items'
@@ -107,24 +107,21 @@ export function AgentConfigSkillsField({
   }, [onUnavailableIdsChange, unavailableReportKey])
 
   return (
-    <Field>
+    <Field className="gap-5">
       <div className="flex items-center justify-between gap-3">
-        <div>
-          <FieldLabel>Skills</FieldLabel>
-          <FieldDescription>
-            Reusable instructions and files this agent can load on demand.
-          </FieldDescription>
-        </div>
+        <FieldLabel>Skills</FieldLabel>
         <Button
           type="button"
-          size="sm"
+          size="icon"
           variant="outline"
+          className="bg-muted/40 size-8"
+          aria-label="Add skill"
           onClick={() => {
             setPickerOpen((open) => !open)
             search.setSearch('')
           }}
         >
-          Add skill
+          <PlusIcon />
         </Button>
       </div>
       {pickerOpen && (
@@ -143,14 +140,9 @@ export function AgentConfigSkillsField({
           placeholder={skillsQuery.isPending ? 'Loading skills…' : 'Search skills…'}
         />
       )}
-      <div className="space-y-2">
-        {selectedIds.length === 0 ? (
-          <div className="border-border bg-background/60 text-muted-foreground flex min-h-20 items-center justify-center gap-2 rounded-md border border-dashed px-4 text-sm">
-            <Sparkles className="size-4" />
-            No skills attached
-          </div>
-        ) : (
-          selectedIds.map((id) => (
+      {selectedIds.length > 0 && (
+        <div className="space-y-2">
+          {selectedIds.map((id) => (
             <SelectedSkillRow
               key={id}
               orgId={orgId}
@@ -164,9 +156,9 @@ export function AgentConfigSkillsField({
                 onSelectedIdsChange(selectedIds.filter((selectedId) => selectedId !== id))
               }}
             />
-          ))
-        )}
-      </div>
+          ))}
+        </div>
+      )}
     </Field>
   )
 }
@@ -214,7 +206,7 @@ function SelectedSkillRow({
       className={
         unavailable
           ? 'border-destructive/40 bg-destructive/5 flex items-center gap-3 rounded-md border px-3 py-2.5'
-          : 'border-border bg-background flex items-center gap-3 rounded-md border px-3 py-2.5'
+          : 'border-border bg-muted/40 flex items-center gap-3 rounded-md border px-3 py-2.5'
       }
     >
       <div className="bg-muted flex size-8 shrink-0 items-center justify-center rounded-md">

--- a/frontend/apps/web/src/components/agents/AgentConfigToolsField.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigToolsField.tsx
@@ -1,5 +1,5 @@
 import type { ToolCatalog, ToolCatalogEntry, ToolPermissionSelection } from '@omnara/sdk'
-import { ChevronDownIcon, Trash2Icon } from 'lucide-react'
+import { InfoIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -8,7 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Field, FieldDescription, FieldLabel } from '@/components/ui/field'
+import { Field, FieldLabel } from '@/components/ui/field'
 import {
   Select,
   SelectContent,
@@ -16,13 +16,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-
-import { builtInToolsets } from './builtInTools'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
 export interface BasicTool {
   name: string
   permission: ToolPermissionSelection | null
 }
+
+const hiddenToolNames = new Set(['skill', 'send_integration_message', 'set_integration_target'])
 
 export function AgentConfigToolsField({
   catalog,
@@ -33,80 +34,31 @@ export function AgentConfigToolsField({
   tools: BasicTool[]
   onToolsChange: (tools: BasicTool[]) => void
 }) {
-  const catalogTools = (catalog?.built_in_tools ?? []).filter((entry) => entry.name !== 'skill')
+  const catalogTools = (catalog?.built_in_tools ?? []).filter(
+    (entry) => !hiddenToolNames.has(entry.name),
+  )
+  const visibleTools = tools.filter((tool) => !hiddenToolNames.has(tool.name))
   const catalogByName = new Map(catalogTools.map((entry) => [entry.name, entry]))
   const availableTools = catalogTools.filter((entry) =>
     tools.every((tool) => tool.name !== entry.name),
   )
-  const selectedToolNames = new Set(tools.map((tool) => tool.name))
-  const hasAvailableToolsets = builtInToolsets.some(
-    (toolset) =>
-      toolset.tools.every((toolName) => catalogByName.has(toolName)) &&
-      toolset.tools.some((toolName) => !selectedToolNames.has(toolName)),
-  )
-
-  function addToolset(toolNames: readonly string[]) {
-    const additions: BasicTool[] = []
-    for (const name of toolNames) {
-      if (selectedToolNames.has(name)) {
-        continue
-      }
-      const entry = catalogByName.get(name)
-      if (entry == null) {
-        return
-      }
-      additions.push({
-        name,
-        permission: structuredClone(entry.default_permission),
-      })
-    }
-    onToolsChange([...tools, ...additions])
-  }
 
   return (
-    <Field>
+    <Field className="gap-5">
       <div className="flex items-center justify-between gap-3">
-        <div>
-          <FieldLabel>Tools</FieldLabel>
-          <FieldDescription>Built-in tools the agent can call.</FieldDescription>
-        </div>
+        <FieldLabel>Tools</FieldLabel>
         <div className="flex items-center gap-2">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button type="button" size="sm" variant="outline" disabled={!hasAvailableToolsets}>
-                Toolsets
-                <ChevronDownIcon />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {builtInToolsets.map((toolset) => {
-                const isAvailable = toolset.tools.every((toolName) => catalogByName.has(toolName))
-                const isComplete = toolset.tools.every((toolName) =>
-                  selectedToolNames.has(toolName),
-                )
-                return (
-                  <DropdownMenuItem
-                    key={toolset.name}
-                    disabled={!isAvailable || isComplete}
-                    onSelect={() => {
-                      addToolset(toolset.tools)
-                    }}
-                  >
-                    {toolset.name}
-                  </DropdownMenuItem>
-                )
-              })}
-            </DropdownMenuContent>
-          </DropdownMenu>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
                 type="button"
-                size="sm"
+                size="icon"
                 variant="outline"
+                className="bg-muted/40 size-8"
                 disabled={availableTools.length === 0}
+                aria-label="Add tools"
               >
-                Add tools
+                <PlusIcon />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="max-h-72 overflow-y-auto">
@@ -130,20 +82,33 @@ export function AgentConfigToolsField({
           </DropdownMenu>
         </div>
       </div>
-      <div className="space-y-2">
-        {tools.length === 0 ? (
-          <div className="border-border bg-background/60 text-muted-foreground flex min-h-16 items-center justify-center rounded-md border border-dashed px-4 text-sm">
-            No tools
-          </div>
-        ) : (
-          tools.map((tool) => {
+      {visibleTools.length > 0 && (
+        <div className="border-border bg-muted/40 divide-y overflow-hidden rounded-xl border">
+          {visibleTools.map((tool) => {
             const entry = catalogByName.get(tool.name)
             return (
-              <div
-                key={tool.name}
-                className="border-border bg-background flex items-center gap-3 rounded-md border px-3 py-2"
-              >
-                <span className="min-w-0 flex-1 truncate font-mono text-sm">{tool.name}</span>
+              <div key={tool.name} className="flex items-center gap-3 px-3 py-2">
+                <div className="flex min-w-0 flex-1 items-center gap-1">
+                  <span className="truncate font-mono text-sm">{tool.name}</span>
+                  {entry?.description && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          type="button"
+                          size="icon"
+                          variant="ghost"
+                          className="text-muted-foreground size-7 shrink-0"
+                          aria-label={`About ${tool.name}`}
+                        >
+                          <InfoIcon className="size-4" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top" className="max-w-sm">
+                        {entry.description}
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                </div>
                 <PermissionModeSelect
                   entry={entry}
                   value={tool.permission?.mode ?? entry?.default_permission.mode ?? ''}
@@ -170,9 +135,9 @@ export function AgentConfigToolsField({
                 </Button>
               </div>
             )
-          })
-        )}
-      </div>
+          })}
+        </div>
+      )}
     </Field>
   )
 }

--- a/frontend/apps/web/src/components/agents/AgentConfigYamlEditor.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigYamlEditor.tsx
@@ -103,6 +103,7 @@ export function AgentConfigYamlEditor({
     editorRef.current = monaco.editor.create(editorElementRef.current, {
       model,
       ariaLabel: agentConfigYamlAriaLabel(initialReadOnlyRef.current),
+      ariaRequired: !initialReadOnlyRef.current,
       automaticLayout: true,
       fontFamily: 'var(--font-mono)',
       fontSize: 12,
@@ -161,6 +162,7 @@ export function AgentConfigYamlEditor({
   useEffect(() => {
     editorRef.current?.updateOptions({
       ariaLabel: agentConfigYamlAriaLabel(readOnly),
+      ariaRequired: !readOnly,
       readOnly,
     })
   }, [readOnly])

--- a/frontend/apps/web/src/components/agents/AgentConfigYamlField.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigYamlField.tsx
@@ -2,7 +2,7 @@ import { CatchBoundary } from '@tanstack/react-router'
 import { lazy, Suspense } from 'react'
 
 import { Button } from '@/components/ui/button'
-import { Field, FieldLabel } from '@/components/ui/field'
+import { Field, RequiredFieldLabel } from '@/components/ui/field'
 import { Spinner } from '@/components/ui/spinner'
 import { cn } from '@/lib/utils'
 
@@ -77,9 +77,9 @@ export function AgentConfigYamlField({
 
   return (
     <Field>
-      <FieldLabel asChild>
+      <RequiredFieldLabel asChild>
         <span>Config (YAML)</span>
-      </FieldLabel>
+      </RequiredFieldLabel>
       {editor}
     </Field>
   )

--- a/frontend/apps/web/src/components/agents/AgentProfileConfigEditor.tsx
+++ b/frontend/apps/web/src/components/agents/AgentProfileConfigEditor.tsx
@@ -59,6 +59,7 @@ export function AgentProfileConfigEditor({
 
   return (
     <form
+      noValidate
       onSubmit={(event) => {
         void submit(event)
       }}

--- a/frontend/apps/web/src/components/agents/CreateAgentForm.tsx
+++ b/frontend/apps/web/src/components/agents/CreateAgentForm.tsx
@@ -25,10 +25,12 @@ export function CreateAgentForm() {
     poolGrants.find((grant) => grant.machine_pool.management_kind === 'cluster') ?? poolGrants[0]
   )?.machine_pool
   const defaultModel = modelGrantsQuery.data?.pages[0]?.data[0]?.model
-  const templatesReady =
-    !toolCatalog.isPending && !poolGrantsQuery.isPending && !modelGrantsQuery.isPending
+  const templatesReady = !poolGrantsQuery.isPending && !modelGrantsQuery.isPending
   const linkedTemplate = agentTemplates.find((template) => template.id === search.template)
 
+  if (toolCatalog.isPending) return <FullPageSpinner />
+  if (toolCatalog.isError)
+    throw new Error('Failed to load tool catalog', { cause: toolCatalog.error })
   if (linkedTemplate && !templatesReady) return <FullPageSpinner />
 
   return (

--- a/frontend/apps/web/src/components/agents/CreateAgentFormView.tsx
+++ b/frontend/apps/web/src/components/agents/CreateAgentFormView.tsx
@@ -9,6 +9,7 @@ import { useNavigate } from '@tanstack/react-router'
 import { type SyntheticEvent, useReducer, useRef, useState } from 'react'
 
 import { AgentConfigBasicForm } from '@/components/agents/AgentConfigBasicForm'
+import { AgentConfigModelField } from '@/components/agents/AgentConfigModelField'
 import {
   type AgentConfigMode,
   agentConfigModeReducer,
@@ -21,17 +22,19 @@ import {
   type AgentTemplate,
   agentTemplateConfig,
   agentTemplateName,
+  defaultAgentTools,
 } from '@/components/agents/agentTemplates'
 import { ConfirmDiscardYamlDialog } from '@/components/agents/ConfirmDiscardYamlDialog'
 import { PillTabs } from '@/components/agents/PillTabs'
 import {
   type BasicConfig,
   createBasicConfigSession,
+  emptyBasicConfig,
   useAgentBuilderForm,
 } from '@/components/agents/useAgentBuilderForm'
 import { PageBreadcrumb } from '@/components/layout/PageBreadcrumb'
 import { Button } from '@/components/ui/button'
-import { Field, FieldGroup, FieldLabel } from '@/components/ui/field'
+import { Field, FieldGroup, RequiredFieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import type { SubmitStatus } from '@/lib/submit-status'
 import { idle, settleSubmission, statusError, submitError, submitting } from '@/lib/submit-status'
@@ -42,7 +45,6 @@ type SubmitAction = 'profile' | 'launch'
 
 interface CreateAgentDraft {
   name: string
-  message: string
   status: SubmitStatus
 }
 
@@ -78,16 +80,17 @@ export function CreateAgentFormView({
   )
   const [draft, setDraft] = useState<CreateAgentDraft>(() => ({
     name: initialTemplate?.name ?? '',
-    message: '',
     status: idle,
   }))
-  const [appliedTemplate, setAppliedTemplate] = useState<AgentTemplate | null>(
-    initialTemplate ?? null,
-  )
   const [pendingAction, setPendingAction] = useState<SubmitAction | null>(null)
   const savedProfile = useRef<SavedProfile | null>(null)
   const [session, setSession] = useState(() => createBasicConfigSession(''))
-  const form = useAgentBuilderForm(session, initialTemplate && templateBasicConfig(initialTemplate))
+  const form = useAgentBuilderForm(
+    session,
+    initialTemplate
+      ? templateBasicConfig(initialTemplate)
+      : { ...emptyBasicConfig, tools: defaultAgentTools(catalog) },
+  )
   const switchMode = (nextMode: AgentConfigMode) => {
     if (nextMode === 'builder' && mode.editorYaml !== null) {
       const adopted = createBasicConfigSession(mode.editorYaml)
@@ -118,7 +121,6 @@ export function CreateAgentFormView({
     }
     form.reset(next)
     setDraft((prev) => ({ ...prev, name: agentTemplateName(prev.name, template) }))
-    setAppliedTemplate(template)
   }
 
   if (project == null) return null
@@ -159,7 +161,6 @@ export function CreateAgentFormView({
         const launch = await createAgent.mutateAsync({
           profile: profile.profileId,
           config: profile.configId,
-          message: draft.message.trim() === '' ? undefined : draft.message,
         })
         await navigate({
           to: '/projects/$projectId/agents/$agentId',
@@ -191,6 +192,7 @@ export function CreateAgentFormView({
 
   return (
     <form
+      noValidate
       className="mx-auto flex w-full max-w-6xl flex-col gap-6"
       onSubmit={(event: SyntheticEvent<HTMLFormElement>) => {
         event.preventDefault()
@@ -210,7 +212,7 @@ export function CreateAgentFormView({
           { id: 'new-agent', label: 'New agent' },
         ]}
       />
-      <div className="flex flex-wrap items-center justify-between gap-2">
+      <div className="mx-auto flex w-full max-w-3xl flex-wrap items-center justify-between gap-2">
         <h1 className="text-2xl font-bold tracking-tight">New agent</h1>
         <div className="flex items-center gap-2">
           {showBuilder && <AgentTemplateMenu disabled={!templatesReady} onApply={applyTemplate} />}
@@ -225,20 +227,31 @@ export function CreateAgentFormView({
         </div>
       </div>
 
-      <FieldGroup className="max-w-3xl gap-8">
-        <Field>
-          <FieldLabel htmlFor="agent-config-name">Name</FieldLabel>
-          <Input
-            id="agent-config-name"
-            required
-            value={draft.name}
-            placeholder="Demo research agent"
-            className="max-w-md"
-            onChange={(event) => {
-              setDraft((prev) => ({ ...prev, name: event.target.value }))
-            }}
-          />
-        </Field>
+      <FieldGroup className="mx-auto w-full max-w-3xl gap-8">
+        <div className={cn(showBuilder && 'grid gap-6 sm:grid-cols-2')}>
+          <Field>
+            <RequiredFieldLabel htmlFor="agent-config-name">Name</RequiredFieldLabel>
+            <Input
+              id="agent-config-name"
+              required
+              value={draft.name}
+              placeholder="Demo research agent"
+              className={cn(!showBuilder && 'max-w-md')}
+              onChange={(event) => {
+                setDraft((prev) => ({ ...prev, name: event.target.value }))
+              }}
+            />
+          </Field>
+          {showBuilder && (
+            <AgentConfigModelField
+              orgId={activeOrg.id}
+              projectId={projectId}
+              value={form.model}
+              onChange={form.setModel}
+              onUnavailableChange={form.reportModelUnavailable}
+            />
+          )}
+        </div>
         <div className={cn('flex flex-col gap-8', !showBuilder && 'hidden')}>
           <AgentConfigBasicForm orgId={activeOrg.id} projectId={projectId} form={form} />
         </div>
@@ -252,19 +265,6 @@ export function CreateAgentFormView({
             }}
           />
         )}
-        <Field>
-          <FieldLabel htmlFor="agent-message">First message (optional)</FieldLabel>
-          <Input
-            id="agent-message"
-            value={draft.message}
-            placeholder={
-              appliedTemplate?.firstMessagePlaceholder ?? 'Kick the agent off with a message'
-            }
-            onChange={(event) => {
-              setDraft((prev) => ({ ...prev, message: event.target.value }))
-            }}
-          />
-        </Field>
       </FieldGroup>
       {/* -bottom-6 offsets the scroll container's p-6 so the bar sits flush with the viewport edge. */}
       <div className="bg-background sticky -bottom-6 z-10 -mb-6 flex items-center justify-between gap-4 border-t py-4">

--- a/frontend/apps/web/src/components/agents/agentTemplates.test.ts
+++ b/frontend/apps/web/src/components/agents/agentTemplates.test.ts
@@ -1,0 +1,40 @@
+import type { ToolCatalog, ToolCatalogEntry } from '@omnara/sdk'
+import { describe, expect, it } from 'vitest'
+
+import { defaultAgentTools } from './agentTemplates'
+
+function catalogEntry(name: string, mode: string): ToolCatalogEntry {
+  return {
+    name,
+    description: `${name} description`,
+    default_permission: { mode, parameters: {} },
+    permission_modes: [],
+  }
+}
+
+describe('defaultAgentTools', () => {
+  it('selects web tools in order with catalog permissions', () => {
+    const webFetch = catalogEntry('web_fetch', 'always_allow')
+    const webSearch = catalogEntry('web_search', 'always_ask')
+    const catalog: ToolCatalog = {
+      built_in_tools: [catalogEntry('ask_question', 'always_allow'), webFetch, webSearch],
+      custom_tool_permissions: {
+        default_permission: { mode: 'always_ask', parameters: {} },
+        permission_modes: [],
+      },
+      mcp_tool_permissions: {
+        default_permission: { mode: 'always_ask', parameters: {} },
+        permission_modes: [],
+      },
+    }
+
+    const tools = defaultAgentTools(catalog)
+
+    expect(tools).toEqual([
+      { name: 'web_search', permission: webSearch.default_permission },
+      { name: 'web_fetch', permission: webFetch.default_permission },
+    ])
+    expect(tools[0]?.permission).not.toBe(webSearch.default_permission)
+    expect(tools[1]?.permission).not.toBe(webFetch.default_permission)
+  })
+})

--- a/frontend/apps/web/src/components/agents/agentTemplates.ts
+++ b/frontend/apps/web/src/components/agents/agentTemplates.ts
@@ -8,8 +8,9 @@ export interface AgentTemplate {
   name: string
   description: string
   instruction: string
-  firstMessagePlaceholder: string
 }
+
+const defaultAgentToolNames = ['web_search', 'web_fetch'] as const
 
 const templateToolNames = [
   'run_command',
@@ -30,7 +31,6 @@ const generalAgent: AgentTemplate = {
   description: 'Researches, writes code, runs commands, and uses tools to finish tasks end to end.',
   instruction:
     "You are a general-purpose agent that can research, write code, run commands, and use connected tools to complete the user's task end to end.",
-  firstMessagePlaceholder: 'Research the top 3 CI providers and summarize the trade-offs',
 }
 
 const deepResearcher: AgentTemplate = {
@@ -45,8 +45,6 @@ const deepResearcher: AgentTemplate = {
 4. Synthesize a report that answers the original question. Structure it by sub-question, cite every non-obvious claim inline, and close with a "confidence & gaps" section noting where sources disagreed or where you couldn't find good coverage.
 
 Be skeptical. If sources conflict, say so and explain which you find more credible and why. Don't paper over uncertainty with confident-sounding prose.`,
-  firstMessagePlaceholder:
-    'How do the major vector databases compare on cost, latency, and recall?',
 }
 
 const structuredExtractor: AgentTemplate = {
@@ -61,7 +59,6 @@ const structuredExtractor: AgentTemplate = {
 4. Emit a single JSON object (or array, if the schema is a list) that validates against the schema. No prose, no markdown fences — just the JSON.
 
 When the input is ambiguous, pick the most conservative interpretation and note the ambiguity in a top-level "_extraction_notes" field only if the schema allows additionalProperties.`,
-  firstMessagePlaceholder: 'Paste raw text plus the JSON schema you want extracted',
 }
 
 export const agentTemplates = [generalAgent, deepResearcher, structuredExtractor]
@@ -78,7 +75,7 @@ export function agentTemplateConfig(
     instruction: template.instruction,
     providerConfig: defaultModel?.provider_config ?? '',
     modelName: defaultModel?.name ?? '',
-    tools: catalog ? agentTemplateTools(catalog) : [],
+    tools: catalogTools(catalog, templateToolNames),
     machineSources: defaultPool
       ? [
           {
@@ -98,10 +95,15 @@ export function agentTemplateName(currentName: string, template: AgentTemplate) 
   return trimmed === '' || isTemplateName ? template.name : currentName
 }
 
-function agentTemplateTools(catalog: ToolCatalog): BasicTool[] {
+export function defaultAgentTools(catalog?: ToolCatalog): BasicTool[] {
+  return catalogTools(catalog, defaultAgentToolNames)
+}
+
+function catalogTools(catalog: ToolCatalog | undefined, names: readonly string[]): BasicTool[] {
+  if (!catalog) return []
   const entries = new Map(catalog.built_in_tools.map((entry) => [entry.name, entry]))
   const tools: BasicTool[] = []
-  for (const name of templateToolNames) {
+  for (const name of names) {
     const entry = entries.get(name)
     if (entry == null) continue
     tools.push({ name, permission: structuredClone(entry.default_permission) })

--- a/frontend/apps/web/src/components/agents/builtInTools.ts
+++ b/frontend/apps/web/src/components/agents/builtInTools.ts
@@ -10,13 +10,6 @@ export const machineExecutionTools = [
   'inspect_machine',
 ] as const
 
-export const integrationTools = ['send_integration_message', 'set_integration_target'] as const
-
-export const builtInToolsets = [
-  { name: 'Machine tools', tools: machineExecutionTools },
-  { name: 'Integration tools', tools: integrationTools },
-] as const
-
 interface MachineSourceSelection {
   id: string
   name: string

--- a/frontend/apps/web/src/components/agents/useAgentBuilderForm.ts
+++ b/frontend/apps/web/src/components/agents/useAgentBuilderForm.ts
@@ -81,7 +81,7 @@ export function newMachineSource(kind: MachineSourceKind): BasicMachineSource {
   }
 }
 
-const emptyBasicConfig: BasicConfig = {
+export const emptyBasicConfig: BasicConfig = {
   instruction: '',
   providerConfig: '',
   modelName: '',

--- a/frontend/apps/web/src/components/ui/combobox.tsx
+++ b/frontend/apps/web/src/components/ui/combobox.tsx
@@ -11,7 +11,7 @@ function ComboboxInput({ className, ...props }: ComponentProps<typeof ComboboxPr
     <div className="relative">
       <ComboboxPrimitive.Input
         className={cn(
-          'border-input bg-background shadow-xs placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 h-9 w-full rounded-md border pl-3 pr-9 text-sm outline-none focus-visible:ring-[3px]',
+          'border-input shadow-xs placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40 h-9 w-full rounded-md border bg-transparent pl-3 pr-9 text-sm outline-none transition-[color,box-shadow] focus-visible:ring-[3px]',
           className,
         )}
         {...props}
@@ -28,7 +28,7 @@ function ComboboxChips({ className, ...props }: ComponentProps<typeof ComboboxPr
     <ComboboxPrimitive.InputGroup className="w-full">
       <ComboboxPrimitive.Chips
         className={cn(
-          'border-input bg-background shadow-xs focus-within:border-ring focus-within:ring-ring/50 flex min-h-9 w-full flex-wrap items-center gap-1 rounded-md border px-2 py-1 transition-[color,box-shadow] focus-within:ring-[3px]',
+          'border-input shadow-xs focus-within:border-ring focus-within:ring-ring/50 dark:bg-input/30 flex min-h-9 w-full flex-wrap items-center gap-1 rounded-md border bg-transparent px-2 py-1 transition-[color,box-shadow] focus-within:ring-[3px]',
           className,
         )}
         {...props}

--- a/frontend/apps/web/src/components/ui/field.tsx
+++ b/frontend/apps/web/src/components/ui/field.tsx
@@ -124,6 +124,19 @@ function FieldLabel({ className, ...props }: ComponentProps<typeof Label>) {
   )
 }
 
+function RequiredFieldLabel({ children, ...props }: ComponentProps<typeof FieldLabel>) {
+  return (
+    <FieldLabel {...props}>
+      <span>
+        {children}
+        <span className="text-destructive" aria-hidden="true">
+          {' *'}
+        </span>
+      </span>
+    </FieldLabel>
+  )
+}
+
 function FieldDescription({ className, ...props }: ComponentProps<'p'>) {
   return (
     <p
@@ -182,4 +195,5 @@ export {
   FieldGroup,
   FieldLabel,
   FieldSeparator,
+  RequiredFieldLabel,
 }

--- a/frontend/apps/web/src/components/ui/resource-combobox-core.ts
+++ b/frontend/apps/web/src/components/ui/resource-combobox-core.ts
@@ -25,6 +25,8 @@ export interface ResourceComboboxSearch {
 
 export interface ResourceComboboxBaseProps<TItem> {
   items: TItem[]
+  id?: string
+  required?: boolean
   search?: ResourceComboboxSearch
   query?: ResourceComboboxQuery
   pending?: boolean

--- a/frontend/apps/web/src/components/ui/resource-combobox.tsx
+++ b/frontend/apps/web/src/components/ui/resource-combobox.tsx
@@ -14,6 +14,8 @@ export type {
 export function createResourceCombobox<TItem>(config: ResourceComboboxConfig<TItem>) {
   return function BoundResourceCombobox({
     items,
+    id,
+    required,
     value,
     onValueChange,
     search,
@@ -37,6 +39,8 @@ export function createResourceCombobox<TItem>(config: ResourceComboboxConfig<TIt
     return (
       <Combobox
         {...rootProps}
+        id={id}
+        required={required}
         inputValue={inputValue}
         onInputValueChange={(nextValue, eventDetails) => {
           // Only user typing is a search query. Selection and popup lifecycle
@@ -46,7 +50,7 @@ export function createResourceCombobox<TItem>(config: ResourceComboboxConfig<TIt
         value={value}
         onValueChange={onValueChange}
       >
-        <ComboboxInput aria-label={placeholder} placeholder={placeholder} />
+        <ComboboxInput aria-label={id ? undefined : placeholder} placeholder={placeholder} />
         <ResourceComboboxContent
           config={config}
           pending={pending}

--- a/frontend/apps/web/src/routes/AgentView.tsx
+++ b/frontend/apps/web/src/routes/AgentView.tsx
@@ -73,7 +73,10 @@ export function AgentView() {
       className="h-[calc(100svh-3rem)] min-h-0 overflow-hidden"
       style={{ '--sidebar-width': '20rem' } as CSSProperties}
     >
-      <div className="mx-auto flex h-full w-full min-w-0 max-w-5xl flex-1 flex-col overflow-hidden">
+      <div
+        className="mx-auto flex h-full w-full min-w-0 max-w-5xl flex-1 flex-col overflow-hidden"
+        style={{ contain: 'paint' }}
+      >
         <header className="shrink-0 pb-4">
           <div className="flex min-w-0 items-center justify-between gap-2">
             <PageBreadcrumb
@@ -148,13 +151,15 @@ export function AgentView() {
             onResolve={resolve}
             canOperate={canOperate}
           />
-          <AgentComposer
-            chat={chat}
-            cancelPending={cancelAgent.isPending}
-            cancelError={cancelAgent.error}
-            onCancel={() => cancelAgent.mutateAsync()}
-            canOperate={canOperate}
-          />
+          {!configOpen && (
+            <AgentComposer
+              chat={chat}
+              cancelPending={cancelAgent.isPending}
+              cancelError={cancelAgent.error}
+              onCancel={() => cancelAgent.mutateAsync()}
+              canOperate={canOperate}
+            />
+          )}
         </div>
       </div>
       <AgentSidebar


### PR DESCRIPTION
- simplify the agent creation form with aligned required fields, compact optional capabilities, and consistent resource controls
- default new agents to web search and fetch, move model grants into the selector, and hide implicit skill and integration tools from the builder
- remove first-message setup

<img width="1302" height="858" alt="image" src="https://github.com/user-attachments/assets/22780a1a-5d9b-4bf2-af5b-51401cef7fa7" />
