### PR TITLE
feat: notify Slack users when agent launch fails

### DIFF
--- a/internal/harness/kernel/agent_executor.go
+++ b/internal/harness/kernel/agent_executor.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/omnara-ai/omnara/internal/harness/tools"
+	"github.com/omnara-ai/omnara/internal/integration/slack"
 	"github.com/omnara-ai/omnara/internal/mcp"
 	"github.com/omnara-ai/omnara/internal/model"
 	"github.com/omnara-ai/omnara/internal/modelcontext"
@@ -46,19 +47,11 @@ func (e AgentExecutor) ExecuteModelWork(ctx context.Context, input ModelWorkExec
 		input.Now = e.now()
 	}
 	builder := e.contextBuilder()
-	toolExecutor := e.configuredToolExecutor()
 	modelProducedResponse := false
 	defer func() {
-		if !shouldPostIntegrationRuntimeMessage(ctx, err, modelProducedResponse) {
-			return
+		if shouldPostIntegrationRuntimeMessage(ctx, err, modelProducedResponse) {
+			e.postIntegrationRuntimeError(ctx, input)
 		}
-		postCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
-		defer cancel()
-		_ = toolExecutor.PostIntegrationRuntimeMessage(
-			postCtx,
-			toToolTurn(input),
-			integrationRuntimeErrorMessage(err),
-		)
 	}()
 	if e.ModelResolver == nil {
 		return errors.New("kernel model resolver is required")
@@ -112,6 +105,19 @@ func (e AgentExecutor) ExecuteModelWork(ctx context.Context, input ModelWorkExec
 	default:
 		return fmt.Errorf("unsupported model step state %q", step.State)
 	}
+}
+
+func (e AgentExecutor) postIntegrationRuntimeError(
+	ctx context.Context,
+	input ModelWorkExecution,
+) {
+	postCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+	_ = e.configuredToolExecutor().PostIntegrationRuntimeMessage(
+		postCtx,
+		toToolTurn(input),
+		slack.AgentRequestFailureMessage,
+	)
 }
 
 func validateModelWorkExecution(input ModelWorkExecution) error {
@@ -176,11 +182,4 @@ func shouldPostIntegrationRuntimeError(ctx context.Context, err error) bool {
 		return false
 	}
 	return true
-}
-
-func integrationRuntimeErrorMessage(err error) string {
-	if errors.Is(err, storeerr.ErrModelGrantUnavailable) {
-		return "I couldn't continue because this project does not have access to the configured model. Ask an admin to grant access or update the agent configured model selection."
-	}
-	return "I couldn't complete this request because the agent hit a runtime error. Please check the agent logs for details."
 }

--- a/internal/harness/kernel/agent_executor_context.go
+++ b/internal/harness/kernel/agent_executor_context.go
@@ -12,6 +12,7 @@ import (
 	"github.com/omnara-ai/omnara/internal/modelretry"
 	"github.com/omnara-ai/omnara/internal/storage"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
+	"github.com/omnara-ai/omnara/internal/storage/storeerr"
 )
 
 type modelStepState string
@@ -61,23 +62,22 @@ func (e AgentExecutor) executeModelStep(
 		if err != nil {
 			return modelStep{}, err
 		}
-		if !claim.Claimed {
-			return modelStep{State: modelStepWaiting, Context: claim.Context}, nil
-		}
-		snapshot, err = e.Store.Execution().CaptureAgentConfigForEventWatermark(
-			ctx,
-			input.ProjectID,
-			input.AgentID,
-			claim.Context.InputEventSequence,
-		)
-		if err != nil {
-			return e.recordNormalPreSendFailure(
-				ctx, input, claim, model.ResolvedClient{}, err,
-				modelretry.PreSendFailure{
-					Code:    preSendErrorCodeCaptureAgentConfigFailed,
-					Message: "Omnara could not load the agent configuration for this model attempt.",
-				},
+		if claim.Claimed {
+			snapshot, err = e.Store.Execution().CaptureAgentConfigForEventWatermark(
+				ctx,
+				input.ProjectID,
+				input.AgentID,
+				claim.Context.InputEventSequence,
 			)
+			if err != nil {
+				return e.recordNormalPreSendFailure(
+					ctx, input, claim, model.ResolvedClient{}, err,
+					modelretry.PreSendFailure{
+						Code:    preSendErrorCodeCaptureAgentConfigFailed,
+						Message: "Omnara could not load the agent configuration for this model attempt.",
+					},
+				)
+			}
 		}
 	} else {
 		snapshot, err = e.Store.Execution().CaptureAgentConfigForModelContext(ctx, input.ProjectID, input.AgentID)
@@ -98,6 +98,11 @@ func (e AgentExecutor) executeModelStep(
 		return modelStep{}, err
 	}
 	if !claim.Claimed {
+		if claim.Created &&
+			claim.Context.ErrorCode == storeerr.ManagedWorkAdmissionDeniedCode &&
+			shouldPostIntegrationRuntimeError(ctx, storeerr.ErrManagedWorkAdmissionDenied) {
+			e.postIntegrationRuntimeError(ctx, input)
+		}
 		state := modelStepWaiting
 		if claim.Context.State != executionstore.ModelCallContextStarted &&
 			claim.Context.RecoveryKind != executionstore.ModelCallRecoveryRetry {
@@ -631,6 +636,9 @@ func (e AgentExecutor) recordNormalFailureForAttempt(
 	)
 	if err != nil {
 		return modelStep{}, errors.Join(cause, err)
+	}
+	if ctx.Err() == nil {
+		e.postIntegrationRuntimeError(ctx, input)
 	}
 	return modelStep{State: modelStepDone, Context: claim.Context, Resolved: resolved}, nil
 }

--- a/internal/harness/kernel/agent_executor_context_maintenance.go
+++ b/internal/harness/kernel/agent_executor_context_maintenance.go
@@ -240,5 +240,8 @@ func (e AgentExecutor) recordTerminalContextMaintenanceFailure(
 	if err != nil {
 		return modelStep{}, errors.Join(trigger.Cause, err)
 	}
+	if ctx.Err() == nil {
+		e.postIntegrationRuntimeError(ctx, input)
+	}
 	return modelStep{State: modelStepDone, Context: claim.Context, Resolved: resolved}, nil
 }

--- a/internal/harness/kernel/agent_executor_model_context_integration_test.go
+++ b/internal/harness/kernel/agent_executor_model_context_integration_test.go
@@ -5,6 +5,9 @@ package kernel
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -20,6 +23,7 @@ import (
 	"github.com/omnara-ai/omnara/internal/storage/integrationstore"
 	"github.com/omnara-ai/omnara/internal/storage/modelstore"
 	"github.com/omnara-ai/omnara/internal/storage/secretstore"
+	"github.com/omnara-ai/omnara/internal/testutil/storagetest"
 	"github.com/omnara-ai/omnara/internal/toolcatalog"
 	"github.com/omnara-ai/omnara/internal/toolpermission"
 )
@@ -235,6 +239,15 @@ model:
 	if err != nil {
 		t.Fatalf("launch agent: %v", err)
 	}
+	botToken := attachKernelSlackTarget(
+		t,
+		ctx,
+		fixture,
+		launch.Agent.ID,
+		profile.ID,
+		"unavailable-grant",
+		"C_UNAVAILABLE_GRANT:1.0",
+	)
 	config, found, err := fixture.Store.Execution().GetAgentConfig(ctx, kernelTestProjectID, profile.CurrentConfigID)
 	if err != nil {
 		t.Fatalf("load agent config: %v", err)
@@ -267,11 +280,39 @@ model:
 			{ID: "resp_unreachable", Content: []model.ResponsePart{{Type: "text", Text: "should not respond"}}, StopReason: model.StopReasonEndTurn},
 		},
 	}
+	var postedMessage struct {
+		Channel  string `json:"channel"`
+		Text     string `json:"text"`
+		ThreadTS string `json:"thread_ts"`
+	}
+	postCount := 0
+	postedPath := ""
+	postedAuthorization := ""
+	var postedDecodeErr error
+	integrationHTTPClient := &http.Client{Transport: kernelSlackRoundTripFunc(
+		func(req *http.Request) (*http.Response, error) {
+			postCount++
+			postedPath = req.URL.Path
+			postedAuthorization = req.Header.Get("Authorization")
+			postedDecodeErr = json.NewDecoder(req.Body).Decode(&postedMessage)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(
+					`{"ok":true,"channel":"C_UNAVAILABLE_GRANT","ts":"2.0"}`,
+				)),
+				Request: req,
+			}, nil
+		},
+	)}
 	executor := AgentExecutor{
 		Store:         fixture.Store,
 		ModelResolver: liveTestModelResolver(fixture.Store, modelClient),
-		ToolExecutor:  tools.Executor{Store: fixture.Store},
-		Now:           func() time.Time { return now.Add(4 * time.Millisecond) },
+		ToolExecutor: tools.Executor{
+			Store:                 fixture.Store,
+			IntegrationHTTPClient: integrationHTTPClient,
+		},
+		Now: func() time.Time { return now.Add(4 * time.Millisecond) },
 	}
 	err = executor.ExecuteModelWork(ctx, turn)
 	if err != nil {
@@ -279,6 +320,23 @@ model:
 	}
 	if len(modelClient.responses) != 1 {
 		t.Fatalf("model responded after unavailable grant; remaining responses=%d", len(modelClient.responses))
+	}
+	if postedDecodeErr != nil {
+		t.Fatalf("decode Slack runtime message: %v", postedDecodeErr)
+	}
+	if postCount != 1 {
+		t.Fatalf("Slack runtime message post count = %d, want 1", postCount)
+	}
+	if postedPath != "/api/chat.postMessage" {
+		t.Fatalf("Slack runtime message path = %q", postedPath)
+	}
+	if postedAuthorization != "Bearer "+botToken {
+		t.Fatalf("Slack runtime message authorization = %q", postedAuthorization)
+	}
+	if postedMessage.Channel != "C_UNAVAILABLE_GRANT" ||
+		postedMessage.ThreadTS != "1.0" ||
+		postedMessage.Text != slack.AgentRequestFailureMessage {
+		t.Fatalf("Slack runtime message = %+v", postedMessage)
 	}
 	assertDurableModelErrorForKernelTest(
 		t,
@@ -309,6 +367,85 @@ model:
 			providerResponseID,
 		)
 	}
+}
+
+type kernelSlackRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f kernelSlackRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func attachKernelSlackTarget(
+	t *testing.T,
+	ctx context.Context,
+	fixture kernelFixture,
+	agentID, agentProfileID storage.ID,
+	identifier, providerRef string,
+) string {
+	t.Helper()
+	botToken := "xoxb-" + identifier
+	secret, _, err := fixture.Store.Secrets().CreateSecret(
+		ctx,
+		secretstore.CreateSecretInput{
+			OrgID:          kernelTestOrgID,
+			OwnerKind:      secretstore.SecretOwnerProject,
+			OwnerProjectID: kernelTestProjectID,
+			Name:           "kernel-" + identifier + "-integration-credentials",
+			Material: secrets.SlackAppCredentialsMaterial{
+				AccessToken:   botToken,
+				ClientID:      "client-id",
+				ClientSecret:  "client-secret",
+				SigningSecret: "signing-secret",
+			},
+			Actor: kernelTestUserPrincipal(kernelTestUserID),
+		},
+	)
+	if err != nil {
+		t.Fatalf("create integration credential secret: %v", err)
+	}
+	install, err := fixture.Store.Integrations().UpsertIntegrationInstall(
+		ctx,
+		integrationstore.UpsertIntegrationInstallInput{
+			OrgID:              kernelTestOrgID,
+			ProjectID:          kernelTestProjectID,
+			AgentProfileID:     agentProfileID,
+			InstalledByUserID:  kernelTestUserID,
+			Provider:           integrationstore.IntegrationProviderSlack,
+			IntegrationKind:    slack.IntegrationKindAgentProfile,
+			ConnectionMode:     slack.ConnectionModeWebhook,
+			State:              integrationstore.IntegrationInstallStateActive,
+			ProviderTenantID:   "T_" + identifier,
+			ProviderAccountRef: "A_" + identifier,
+			CredentialSecretID: secret.ID,
+			ProviderIdentity:   json.RawMessage(`{"bot_user_id":"B_KERNEL_TEST"}`),
+		},
+	)
+	if err != nil {
+		t.Fatalf("create integration install: %v", err)
+	}
+	target, err := fixture.Store.Integrations().CreateIntegrationTarget(
+		ctx,
+		integrationstore.CreateIntegrationTargetInput{
+			ProjectID:            kernelTestProjectID,
+			AgentID:              agentID,
+			IntegrationInstallID: install.ID,
+			ProviderRef:          providerRef,
+			ProviderRefKind:      "thread",
+		},
+	)
+	if err != nil {
+		t.Fatalf("create integration target: %v", err)
+	}
+	if err := storagetest.SeedAgentIntegrationTarget(
+		ctx,
+		fixture.Pool,
+		kernelTestProjectID,
+		agentID,
+		target.ID,
+	); err != nil {
+		t.Fatalf("set current integration target: %v", err)
+	}
+	return botToken
 }
 
 func TestAgentExecutorSettlesTurnWhenConfiguredModelWasDeleted(t *testing.T) {

--- a/internal/harness/kernel/agent_executor_model_request_integration_test.go
+++ b/internal/harness/kernel/agent_executor_model_request_integration_test.go
@@ -6,11 +6,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/omnara-ai/omnara/internal/harness/tools"
+	"github.com/omnara-ai/omnara/internal/integration/slack"
 	"github.com/omnara-ai/omnara/internal/model"
 	"github.com/omnara-ai/omnara/internal/modelcontext"
 	"github.com/omnara-ai/omnara/internal/modelprotocol"
@@ -33,6 +36,19 @@ func TestAgentExecutorAppliesManagedWorkAdmissionAtModelClaim(t *testing.T) {
 		now,
 		kernelConfiguredModelOptions{},
 	)
+	agent, err := fixture.Store.Execution().GetAgentInProject(ctx, kernelTestProjectID, agentID)
+	if err != nil {
+		t.Fatalf("load managed-admission agent: %v", err)
+	}
+	attachKernelSlackTarget(
+		t,
+		ctx,
+		fixture,
+		agentID,
+		agent.AgentProfileID,
+		"managed-admission",
+		"C_MANAGED_ADMISSION:1.0",
+	)
 	turn := fixture.admitContentInputTurn(
 		t,
 		ctx,
@@ -50,14 +66,37 @@ func TestAgentExecutorAppliesManagedWorkAdmissionAtModelClaim(t *testing.T) {
 		}},
 	}
 	resolver := &selectionRecordingResolver{client: modelClient}
+	postCount := 0
+	integrationHTTPClient := &http.Client{Transport: kernelSlackRoundTripFunc(
+		func(req *http.Request) (*http.Response, error) {
+			postCount++
+			if req.URL.Path != "/api/chat.postMessage" {
+				t.Fatalf("Slack runtime message path = %q", req.URL.Path)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(
+					`{"ok":true,"channel":"C_MANAGED_ADMISSION","ts":"2.0"}`,
+				)),
+				Request: req,
+			}, nil
+		},
+	)}
 	executor := AgentExecutor{
 		Store:         fixture.Store,
 		ModelResolver: resolver,
-		ToolExecutor:  tools.Executor{Store: fixture.Store},
-		Now:           func() time.Time { return now.Add(2 * time.Millisecond) },
+		ToolExecutor: tools.Executor{
+			Store:                 fixture.Store,
+			IntegrationHTTPClient: integrationHTTPClient,
+		},
+		Now: func() time.Time { return now.Add(2 * time.Millisecond) },
 	}
 	if err := executor.ExecuteModelWork(ctx, turn); err != nil {
 		t.Fatalf("execute denied managed model work: %v", err)
+	}
+	if postCount != 1 {
+		t.Fatalf("Slack runtime message post count = %d, want 1", postCount)
 	}
 	if len(resolver.selections) != 0 || modelClient.preparedCount() != 0 || modelClient.respondedCount() != 0 {
 		t.Fatalf(
@@ -698,6 +737,19 @@ func TestAgentExecutorStopsSerializedProviderRequestOverflowWhenOpeningIsIrreduc
 	fixture := newKernelFixture(t, ctx)
 	now := fixture.Now
 	agentID, userID := fixture.createAgent(t, ctx, "openai/serialized-overflow-model", now)
+	agent, err := fixture.Store.Execution().GetAgentInProject(ctx, kernelTestProjectID, agentID)
+	if err != nil {
+		t.Fatalf("load irreducible-overflow agent: %v", err)
+	}
+	attachKernelSlackTarget(
+		t,
+		ctx,
+		fixture,
+		agentID,
+		agent.AgentProfileID,
+		"irreducible-overflow",
+		"C_IRREDUCIBLE_OVERFLOW:1.0",
+	)
 	turn := fixture.admitContentInputTurn(t, ctx, agentID, userID, "hello", now.Add(time.Millisecond))
 	modelClient := &sequenceKernelModel{
 		providerModelSlug:          "serialized-overflow-model",
@@ -708,14 +760,50 @@ func TestAgentExecutorStopsSerializedProviderRequestOverflowWhenOpeningIsIrreduc
 			StopReason: model.StopReasonEndTurn,
 		}},
 	}
+	postCount := 0
+	postedText := ""
+	var postedDecodeErr error
+	integrationHTTPClient := &http.Client{Transport: kernelSlackRoundTripFunc(
+		func(req *http.Request) (*http.Response, error) {
+			postCount++
+			if req.URL.Path != "/api/chat.postMessage" {
+				t.Fatalf("Slack runtime message path = %q", req.URL.Path)
+			}
+			var postedMessage struct {
+				Text string `json:"text"`
+			}
+			postedDecodeErr = json.NewDecoder(req.Body).Decode(&postedMessage)
+			postedText = postedMessage.Text
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(
+					`{"ok":true,"channel":"C_IRREDUCIBLE_OVERFLOW","ts":"2.0"}`,
+				)),
+				Request: req,
+			}, nil
+		},
+	)}
 	executor := AgentExecutor{
 		Store:         fixture.Store,
 		ModelResolver: liveTestModelResolver(fixture.Store, modelClient),
-		ToolExecutor:  tools.Executor{Store: fixture.Store},
-		Now:           func() time.Time { return now.Add(2 * time.Millisecond) },
+		ToolExecutor: tools.Executor{
+			Store:                 fixture.Store,
+			IntegrationHTTPClient: integrationHTTPClient,
+		},
+		Now: func() time.Time { return now.Add(2 * time.Millisecond) },
 	}
 	if err := executor.ExecuteModelWork(ctx, turn); err != nil {
 		t.Fatalf("execute turn: %v", err)
+	}
+	if postedDecodeErr != nil {
+		t.Fatalf("decode Slack runtime message: %v", postedDecodeErr)
+	}
+	if postCount != 1 {
+		t.Fatalf("Slack runtime message post count = %d, want 1", postCount)
+	}
+	if postedText != slack.AgentRequestFailureMessage {
+		t.Fatalf("Slack runtime message text = %q", postedText)
 	}
 	if len(modelClient.respondHadSink) != 0 {
 		t.Fatalf("provider respond calls = %d, want none", len(modelClient.respondHadSink))

--- a/internal/harness/kernel/agent_executor_retry_integration_test.go
+++ b/internal/harness/kernel/agent_executor_retry_integration_test.go
@@ -5,6 +5,8 @@ package kernel
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -201,6 +203,19 @@ func TestManagedModelRetryStopsAfterAdmissionCloses(t *testing.T) {
 		now,
 		kernelConfiguredModelOptions{},
 	)
+	agent, err := fixture.Store.Execution().GetAgentInProject(ctx, kernelTestProjectID, agentID)
+	if err != nil {
+		t.Fatalf("load managed-retry agent: %v", err)
+	}
+	attachKernelSlackTarget(
+		t,
+		ctx,
+		fixture,
+		agentID,
+		agent.AgentProfileID,
+		"managed-retry",
+		"C_MANAGED_RETRY:1.0",
+	)
 	work := fixture.admitContentInputTurn(
 		t,
 		ctx,
@@ -218,10 +233,30 @@ func TestManagedModelRetryStopsAfterAdmissionCloses(t *testing.T) {
 		}},
 	}
 	currentNow := now.Add(2 * time.Millisecond)
+	postCount := 0
+	integrationHTTPClient := &http.Client{Transport: kernelSlackRoundTripFunc(
+		func(req *http.Request) (*http.Response, error) {
+			postCount++
+			if req.URL.Path != "/api/chat.postMessage" {
+				t.Fatalf("Slack runtime message path = %q", req.URL.Path)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(
+					`{"ok":true,"channel":"C_MANAGED_RETRY","ts":"2.0"}`,
+				)),
+				Request: req,
+			}, nil
+		},
+	)}
 	executor := AgentExecutor{
-		Store:           fixture.Store,
-		ModelResolver:   liveTestModelResolver(fixture.Store, modelClient),
-		ToolExecutor:    tools.Executor{Store: fixture.Store},
+		Store:         fixture.Store,
+		ModelResolver: liveTestModelResolver(fixture.Store, modelClient),
+		ToolExecutor: tools.Executor{
+			Store:                 fixture.Store,
+			IntegrationHTTPClient: integrationHTTPClient,
+		},
 		StreamPublisher: &capturingStreamPublisher{},
 		Now:             func() time.Time { return currentNow },
 		ModelRetryDelay: immediateKernelModelRetryDelay,
@@ -231,6 +266,9 @@ func TestManagedModelRetryStopsAfterAdmissionCloses(t *testing.T) {
 	}
 	if modelClient.preparedCount() != 1 {
 		t.Fatalf("prepared requests after admitted attempt = %d, want 1", modelClient.preparedCount())
+	}
+	if postCount != 0 {
+		t.Fatalf("Slack runtime message post count after retryable failure = %d, want 0", postCount)
 	}
 	fixture.setManagedWorkAdmission(t, ctx, false)
 	if err := fixture.Store.Execution().ReleaseAgentRuntimeLock(
@@ -253,8 +291,18 @@ func TestManagedModelRetryStopsAfterAdmissionCloses(t *testing.T) {
 		retry.Model.ModelCallContextID == storage.NilID {
 		t.Fatalf("retry claim = %+v found=%v, want model retry continuation", retry, found)
 	}
-	if err := executor.ExecuteModelWork(ctx, modelWorkExecutionFromClaimForKernelTest(retry, currentNow)); err != nil {
+	retryInput := modelWorkExecutionFromClaimForKernelTest(retry, currentNow)
+	if err := executor.ExecuteModelWork(ctx, retryInput); err != nil {
 		t.Fatalf("deny managed model retry after admission closes: %v", err)
+	}
+	if postCount != 1 {
+		t.Fatalf("Slack runtime message post count after terminal denial = %d, want 1", postCount)
+	}
+	if err := executor.ExecuteModelWork(ctx, retryInput); err != nil {
+		t.Fatalf("replay denied managed model retry: %v", err)
+	}
+	if postCount != 1 {
+		t.Fatalf("Slack runtime message post count after replay = %d, want 1", postCount)
 	}
 	if modelClient.preparedCount() != 1 || modelClient.respondedCount() != 1 {
 		t.Fatalf(

--- a/internal/harness/kernel/agent_executor_unit_test.go
+++ b/internal/harness/kernel/agent_executor_unit_test.go
@@ -296,17 +296,6 @@ func TestShouldPostIntegrationRuntimeMessageAllowsUnavailableGrantAfterModelResp
 	}
 }
 
-func TestIntegrationRuntimeErrorMessage(t *testing.T) {
-	unavailable := integrationRuntimeErrorMessage(storeerr.ErrModelGrantUnavailable)
-	if !strings.Contains(unavailable, "does not have access to the configured model") {
-		t.Fatalf("unavailable model grant message = %q", unavailable)
-	}
-	generic := integrationRuntimeErrorMessage(errors.New("boom"))
-	if strings.Contains(generic, "configured model") {
-		t.Fatalf("generic runtime message used unavailable-grant wording: %q", generic)
-	}
-}
-
 func TestInvalidModelToolCallResponse(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/httpapi/integration_event_routes.go
+++ b/internal/httpapi/integration_event_routes.go
@@ -27,6 +27,8 @@ const (
 	integrationEventHTTPTimeout       = 2 * time.Second
 	integrationEventEnrichmentTimeout = 1500 * time.Millisecond
 	contentBlockMetadataValueMaxRunes = 512
+	slackAgentLaunchFailureMessage    = "I couldn't start an agent for this request. " +
+		"Please try again later or contact this bot's owner."
 )
 
 func (s *Server) integrationEventsRoute(w http.ResponseWriter, r *http.Request) {
@@ -142,6 +144,27 @@ func (s *Server) integrationEventsRoute(w http.ResponseWriter, r *http.Request) 
 		envelope,
 		route,
 	)
+	if errors.Is(err, integration.ErrAgentLaunchFailed) &&
+		errors.Is(err, storeerr.ErrStateTransitionConflict) {
+		logpkg.LoggerFromContext(r.Context()).Warn(
+			"slack integration agent launch failed",
+			"integration_install_id",
+			install.ID,
+			"provider_ref",
+			route.ProviderRef,
+			"error",
+			err,
+		)
+		go s.postSlackAgentLaunchFailure(
+			r.Context(),
+			install,
+			credentials.BotToken,
+			route,
+		)
+		logent.IntegrationEvent(r.Context(), install, "agent_launch_failed", envelope.Event.Type)
+		writeJSON(w, http.StatusOK, map[string]string{"ok": "launch_failed"})
+		return
+	}
 	if errors.Is(err, storeerr.ErrStateTransitionConflict) {
 		logent.IntegrationEvent(r.Context(), install, "ignored_agent_state", envelope.Event.Type)
 		writeJSON(w, http.StatusOK, map[string]string{"ok": "ignored"})
@@ -594,6 +617,48 @@ func (s *Server) addIntegrationInboundReaction(
 			result.Message,
 			"rate_limited",
 			result.RateLimited,
+		)
+	}
+}
+
+func (s *Server) postSlackAgentLaunchFailure(
+	parent context.Context,
+	install integrationstore.IntegrationInstallRecord,
+	token string,
+	route slack.InboundRoute,
+) {
+	logger := logpkg.LoggerFromContext(parent)
+	channel, threadTS, err := slack.Destination(route.ProviderRefKind, route.ProviderRef)
+	if err != nil {
+		logger.Warn(
+			"slack agent launch failure message failed",
+			"integration_install_id", install.ID,
+			"provider_ref", route.ProviderRef,
+			"error", err,
+		)
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(parent), integrationEventHTTPTimeout)
+	defer cancel()
+	result, err := slack.PostPlainMessage(
+		ctx,
+		s.slackOAuth,
+		slack.MessageTarget{
+			Channel:  channel,
+			ThreadTS: threadTS,
+			BotToken: token,
+		},
+		slackAgentLaunchFailureMessage,
+	)
+	if err != nil || result.MessageID == "" {
+		logger.Warn(
+			"slack agent launch failure message failed",
+			"integration_install_id", install.ID,
+			"provider_ref", route.ProviderRef,
+			"error", err,
+			"code", result.Code,
+			"message", result.Message,
+			"rate_limited", result.RateLimited,
 		)
 	}
 }

--- a/internal/httpapi/integration_event_routes.go
+++ b/internal/httpapi/integration_event_routes.go
@@ -142,7 +142,7 @@ func (s *Server) integrationEventsRoute(w http.ResponseWriter, r *http.Request) 
 		envelope,
 		route,
 	)
-	if errors.Is(err, integration.ErrAgentLaunchFailed) &&
+	if errors.Is(err, storeerr.ErrAgentLaunchFailed) &&
 		(errors.Is(err, storeerr.ErrStateTransitionConflict) ||
 			errors.Is(err, storeerr.ErrManagedWorkAdmissionDenied)) {
 		logpkg.LoggerFromContext(r.Context()).Warn(

--- a/internal/httpapi/integration_event_routes.go
+++ b/internal/httpapi/integration_event_routes.go
@@ -27,8 +27,6 @@ const (
 	integrationEventHTTPTimeout       = 2 * time.Second
 	integrationEventEnrichmentTimeout = 1500 * time.Millisecond
 	contentBlockMetadataValueMaxRunes = 512
-	slackAgentLaunchFailureMessage    = "I couldn't start an agent for this request. " +
-		"Please try again later or contact this bot's owner."
 )
 
 func (s *Server) integrationEventsRoute(w http.ResponseWriter, r *http.Request) {
@@ -648,7 +646,7 @@ func (s *Server) postSlackAgentLaunchFailure(
 			ThreadTS: threadTS,
 			BotToken: token,
 		},
-		slackAgentLaunchFailureMessage,
+		slack.AgentRequestFailureMessage,
 	)
 	if err != nil || result.MessageID == "" {
 		logger.Warn(

--- a/internal/httpapi/integration_event_routes.go
+++ b/internal/httpapi/integration_event_routes.go
@@ -143,7 +143,8 @@ func (s *Server) integrationEventsRoute(w http.ResponseWriter, r *http.Request) 
 		route,
 	)
 	if errors.Is(err, integration.ErrAgentLaunchFailed) &&
-		errors.Is(err, storeerr.ErrStateTransitionConflict) {
+		(errors.Is(err, storeerr.ErrStateTransitionConflict) ||
+			errors.Is(err, storeerr.ErrManagedWorkAdmissionDenied)) {
 		logpkg.LoggerFromContext(r.Context()).Warn(
 			"slack integration agent launch failed",
 			"integration_install_id",

--- a/internal/httpapi/integration_event_routes_integration_test.go
+++ b/internal/httpapi/integration_event_routes_integration_test.go
@@ -2871,7 +2871,7 @@ func TestSlackEventsPostsMessageWhenAgentLaunchFails(t *testing.T) {
 	select {
 	case message := <-postedMessages:
 		if message["channel"] != "C123" || message["thread_ts"] != "111.444" ||
-			message["text"] != slackAgentLaunchFailureMessage {
+			message["text"] != slack.AgentRequestFailureMessage {
 			t.Fatalf("slack launch failure message=%v", message)
 		}
 		if _, ok := message["metadata"]; ok {

--- a/internal/httpapi/integration_event_routes_integration_test.go
+++ b/internal/httpapi/integration_event_routes_integration_test.go
@@ -2710,6 +2710,200 @@ func TestSlackEventsLaunchesWithoutExplicitIntegrationSendTool(
 	}
 }
 
+func TestSlackEventsPostsMessageWhenAgentLaunchFails(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	pool := openIntegrationDB(t, ctx)
+	postedMessages := make(chan map[string]any, 1)
+	slackServer := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/oauth.v2.access":
+				writeJSON(
+					w,
+					http.StatusOK,
+					slackOAuthTestResponse("xoxb-events-token"),
+				)
+			case "/users.info":
+				writeSlackLookupTestResponse(t, w, r)
+			case "/chat.postMessage":
+				var payload map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					t.Fatalf("decode slack launch failure message: %v", err)
+				}
+				postedMessages <- payload
+				writeJSON(w, http.StatusOK, map[string]any{
+					"ok":      true,
+					"channel": "C123",
+					"ts":      "222.333",
+				})
+			default:
+				t.Fatalf("unexpected slack test path %s", r.URL.Path)
+			}
+		}),
+	)
+	defer slackServer.Close()
+	fixture := newSlackEventsIntegrationFixture(
+		t,
+		ctx,
+		pool,
+		slackServer,
+		"slack-events-launch-failure",
+	)
+
+	providerAuthSecret, _, err := fixture.Project.Store.Secrets().CreateSecret(
+		ctx,
+		secretstore.CreateSecretInput{
+			OrgID:     fixture.Project.OrgUUID,
+			OwnerKind: secretstore.SecretOwnerOrg,
+			Name:      "slack-launch-failure-provider-auth",
+			Material:  secrets.GenericMaterial{Value: "test-token"},
+			Actor:     httpUserPrincipal(fixture.Project.AdminUserUUID),
+		},
+	)
+	if err != nil {
+		t.Fatalf("create machine pool provider auth secret: %v", err)
+	}
+	one := 1
+	memoryMB := 1024
+	machinePool, err := fixture.Project.Store.Execution().CreateMachinePool(
+		ctx,
+		executionstore.CreateMachinePoolInput{
+			OrgID:                         fixture.Project.OrgUUID,
+			Name:                          "Slack Launch Failure Pool",
+			Provider:                      "unikraft",
+			DefaultMachineCPU:             &one,
+			DefaultMachineMemoryMB:        &memoryMB,
+			DefaultMachineEnv:             json.RawMessage(`{}`),
+			DefaultMachineProviderOptions: json.RawMessage(`{"image":"test","metro":"sfo"}`),
+			ProviderAuthSecretID:          providerAuthSecret.ID,
+			MaxTotalMachines:              1,
+			MaxTotalCPU:                   &one,
+			MaxTotalMemoryMB:              &memoryMB,
+			MaxMachineCPU:                 &one,
+			MaxMachineMemoryMB:            &memoryMB,
+		},
+	)
+	if err != nil {
+		t.Fatalf("create launch failure machine pool: %v", err)
+	}
+	zero := 0
+	if _, err := fixture.Project.Store.Execution().CreateProjectMachinePoolGrant(
+		ctx,
+		executionstore.CreateProjectMachinePoolGrantInput{
+			OrgID:            fixture.Project.OrgUUID,
+			ProjectID:        fixture.Project.ProjectUUID,
+			MachinePoolID:    machinePool.ID,
+			MaxTotalMachines: &zero,
+			IdempotencyKey:   "slack-launch-failure-pool-grant",
+		},
+	); err != nil {
+		t.Fatalf("create launch failure pool grant: %v", err)
+	}
+
+	profileID, err := publicid.Encode(
+		publicid.KindAgentProfile,
+		fixture.Install.AgentProfileID,
+	)
+	if err != nil {
+		t.Fatalf("encode profile id: %v", err)
+	}
+	profile, err := fixture.Project.Store.Execution().GetAgentProfile(
+		ctx,
+		fixture.Project.ProjectUUID,
+		fixture.Install.AgentProfileID,
+	)
+	if err != nil {
+		t.Fatalf("get agent profile: %v", err)
+	}
+	currentConfigID, err := publicid.Encode(
+		publicid.KindAgentConfig,
+		profile.CurrentConfigID,
+	)
+	if err != nil {
+		t.Fatalf("encode current config id: %v", err)
+	}
+	sourceYAML := "instruction: Help the user make progress.\n" +
+		"model:\n" +
+		"  provider_config: openai-prod\n" +
+		"  name: gpt-test\n" +
+		"machine_sources:\n" +
+		"  - machine_pool_name: Slack Launch Failure Pool\n" +
+		"    max_machines: 1\n" +
+		"    initial_num_machines: 1\n" +
+		"tools:\n" +
+		"  send_integration_message: {}\n"
+	config := createPublicHTTPAgentConfig(
+		t,
+		fixture.Handler,
+		fixture.Project,
+		"slack-events-launch-failure",
+		"yaml",
+		sourceYAML,
+		fixture.Project.AdminToken,
+		http.StatusCreated,
+	)
+	requestJSONWithHeaders(
+		t,
+		fixture.Handler,
+		http.MethodPost,
+		fixture.Project.ProjectPath+"/agent-profiles/"+profileID+"/config",
+		`{"config":"`+config["id"].(string)+`","expected_current_config_id":"`+currentConfigID+`"}`,
+		"idem-slack-events-launch-failure-config",
+		http.StatusOK,
+		authHeaders(fixture.Project.AdminToken),
+	)
+
+	body := `{"type":"event_callback","team_id":"T123","api_app_id":"A123","event_id":"Ev-launch-failure","authorizations":[{"team_id":"T123","user_id":"U_BOT","is_bot":true}],"event":{"type":"app_mention","user":"U123","text":"<@U_BOT> run","channel":"C123","channel_type":"channel","ts":"111.444","team":"T123"}}`
+	response := requestJSONWithHeaders(
+		t,
+		fixture.Handler,
+		http.MethodPost,
+		integrationEventsPath,
+		body,
+		"",
+		http.StatusOK,
+		unitSlackSignedHeaders(body, "signing-secret"),
+	)
+	if response["ok"] != "launch_failed" {
+		t.Fatalf("response=%v want launch_failed", response)
+	}
+	select {
+	case message := <-postedMessages:
+		if message["channel"] != "C123" || message["thread_ts"] != "111.444" ||
+			message["text"] != slackAgentLaunchFailureMessage {
+			t.Fatalf("slack launch failure message=%v", message)
+		}
+		if _, ok := message["metadata"]; ok {
+			t.Fatalf("slack launch failure message contains agent metadata: %v", message)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for Slack launch failure message")
+	}
+	if _, err := fixture.Project.Store.Integrations().GetIntegrationTargetByProviderRef(
+		ctx,
+		fixture.Project.ProjectUUID,
+		fixture.Install.ID,
+		"C123:111.444",
+	); !storeerr.IsNotFound(err) {
+		t.Fatalf("launch failure integration target err=%v want not found", err)
+	}
+	var agentCount int
+	idempotencyKey := "integration:" + fixture.Install.Provider + ":" +
+		fixture.Install.ID.String() + ":C123:111.444"
+	if err := pool.QueryRow(
+		ctx,
+		`SELECT count(*) FROM agents WHERE project_id = $1 AND idempotency_key = $2`,
+		fixture.Project.ProjectUUID,
+		idempotencyKey,
+	).Scan(&agentCount); err != nil {
+		t.Fatalf("count failed launch agents: %v", err)
+	}
+	if agentCount != 0 {
+		t.Fatalf("failed launch agent count=%d want 0", agentCount)
+	}
+}
+
 func TestSlackEventsRejectsNewTargetWhenIntegrationSendToolIsDisabled(
 	t *testing.T,
 ) {

--- a/internal/httpapi/integration_event_routes_integration_test.go
+++ b/internal/httpapi/integration_event_routes_integration_test.go
@@ -2710,7 +2710,7 @@ func TestSlackEventsLaunchesWithoutExplicitIntegrationSendTool(
 	}
 }
 
-func TestSlackEventsPostsMessageWhenAgentLaunchFails(t *testing.T) {
+func TestSlackEventsPostsMessageForKnownAgentLaunchFailures(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	pool := openIntegrationDB(t, ctx)
@@ -2751,54 +2751,37 @@ func TestSlackEventsPostsMessageWhenAgentLaunchFails(t *testing.T) {
 		"slack-events-launch-failure",
 	)
 
-	providerAuthSecret, _, err := fixture.Project.Store.Secrets().CreateSecret(
-		ctx,
-		secretstore.CreateSecretInput{
-			OrgID:     fixture.Project.OrgUUID,
-			OwnerKind: secretstore.SecretOwnerOrg,
-			Name:      "slack-launch-failure-provider-auth",
-			Material:  secrets.GenericMaterial{Value: "test-token"},
-			Actor:     httpUserPrincipal(fixture.Project.AdminUserUUID),
-		},
-	)
-	if err != nil {
-		t.Fatalf("create machine pool provider auth secret: %v", err)
-	}
 	one := 1
 	memoryMB := 1024
-	machinePool, err := fixture.Project.Store.Execution().CreateMachinePool(
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin launch failure pool setup: %v", err)
+	}
+	if err := fixture.Project.Store.Execution().ProvisionOrganizationDefaultsTx(
 		ctx,
-		executionstore.CreateMachinePoolInput{
-			OrgID:                         fixture.Project.OrgUUID,
+		tx,
+		fixture.Project.OrgUUID,
+		fixture.Project.ProjectUUID,
+		[]executionstore.DefaultMachinePoolTemplate{{
 			Name:                          "Slack Launch Failure Pool",
 			Provider:                      "unikraft",
+			ProviderAuthEnvVar:            "TEST_UNIKRAFT_TOKEN",
 			DefaultMachineCPU:             &one,
 			DefaultMachineMemoryMB:        &memoryMB,
 			DefaultMachineEnv:             json.RawMessage(`{}`),
 			DefaultMachineProviderOptions: json.RawMessage(`{"image":"test","metro":"sfo"}`),
-			ProviderAuthSecretID:          providerAuthSecret.ID,
-			MaxTotalMachines:              1,
+			MaxTotalMachines:              0,
 			MaxTotalCPU:                   &one,
 			MaxTotalMemoryMB:              &memoryMB,
 			MaxMachineCPU:                 &one,
 			MaxMachineMemoryMB:            &memoryMB,
-		},
-	)
-	if err != nil {
-		t.Fatalf("create launch failure machine pool: %v", err)
-	}
-	zero := 0
-	if _, err := fixture.Project.Store.Execution().CreateProjectMachinePoolGrant(
-		ctx,
-		executionstore.CreateProjectMachinePoolGrantInput{
-			OrgID:            fixture.Project.OrgUUID,
-			ProjectID:        fixture.Project.ProjectUUID,
-			MachinePoolID:    machinePool.ID,
-			MaxTotalMachines: &zero,
-			IdempotencyKey:   "slack-launch-failure-pool-grant",
-		},
+		}},
 	); err != nil {
-		t.Fatalf("create launch failure pool grant: %v", err)
+		_ = tx.Rollback(ctx)
+		t.Fatalf("provision launch failure pool: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit launch failure pool setup: %v", err)
 	}
 
 	profileID, err := publicid.Encode(
@@ -2854,54 +2837,85 @@ func TestSlackEventsPostsMessageWhenAgentLaunchFails(t *testing.T) {
 		authHeaders(fixture.Project.AdminToken),
 	)
 
-	body := `{"type":"event_callback","team_id":"T123","api_app_id":"A123","event_id":"Ev-launch-failure","authorizations":[{"team_id":"T123","user_id":"U_BOT","is_bot":true}],"event":{"type":"app_mention","user":"U123","text":"<@U_BOT> run","channel":"C123","channel_type":"channel","ts":"111.444","team":"T123"}}`
-	response := requestJSONWithHeaders(
-		t,
-		fixture.Handler,
-		http.MethodPost,
-		integrationEventsPath,
-		body,
-		"",
-		http.StatusOK,
-		unitSlackSignedHeaders(body, "signing-secret"),
-	)
-	if response["ok"] != "launch_failed" {
-		t.Fatalf("response=%v want launch_failed", response)
-	}
-	select {
-	case message := <-postedMessages:
-		if message["channel"] != "C123" || message["thread_ts"] != "111.444" ||
-			message["text"] != slack.AgentRequestFailureMessage {
-			t.Fatalf("slack launch failure message=%v", message)
+	assertLaunchFailure := func(eventID, threadTS string) {
+		t.Helper()
+		body := fmt.Sprintf(
+			`{"type":"event_callback","team_id":"T123","api_app_id":"A123","event_id":"%s","authorizations":[{"team_id":"T123","user_id":"U_BOT","is_bot":true}],"event":{"type":"app_mention","user":"U123","text":"<@U_BOT> run","channel":"C123","channel_type":"channel","ts":"%s","team":"T123"}}`,
+			eventID,
+			threadTS,
+		)
+		response := requestJSONWithHeaders(
+			t,
+			fixture.Handler,
+			http.MethodPost,
+			integrationEventsPath,
+			body,
+			"",
+			http.StatusOK,
+			unitSlackSignedHeaders(body, "signing-secret"),
+		)
+		if response["ok"] != "launch_failed" {
+			t.Fatalf("response=%v want launch_failed", response)
 		}
-		if _, ok := message["metadata"]; ok {
-			t.Fatalf("slack launch failure message contains agent metadata: %v", message)
+		select {
+		case message := <-postedMessages:
+			if message["channel"] != "C123" || message["thread_ts"] != threadTS ||
+				message["text"] != slack.AgentRequestFailureMessage {
+				t.Fatalf("slack launch failure message=%v", message)
+			}
+			if _, ok := message["metadata"]; ok {
+				t.Fatalf("slack launch failure message contains agent metadata: %v", message)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for Slack launch failure message")
 		}
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting for Slack launch failure message")
+		providerRef := "C123:" + threadTS
+		if _, err := fixture.Project.Store.Integrations().GetIntegrationTargetByProviderRef(
+			ctx,
+			fixture.Project.ProjectUUID,
+			fixture.Install.ID,
+			providerRef,
+		); !storeerr.IsNotFound(err) {
+			t.Fatalf("launch failure integration target err=%v want not found", err)
+		}
+		var agentCount int
+		idempotencyKey := "integration:" + fixture.Install.Provider + ":" +
+			fixture.Install.ID.String() + ":" + providerRef
+		if err := pool.QueryRow(
+			ctx,
+			`SELECT count(*) FROM agents WHERE project_id = $1 AND idempotency_key = $2`,
+			fixture.Project.ProjectUUID,
+			idempotencyKey,
+		).Scan(&agentCount); err != nil {
+			t.Fatalf("count failed launch agents: %v", err)
+		}
+		if agentCount != 0 {
+			t.Fatalf("failed launch agent count=%d want 0", agentCount)
+		}
 	}
-	if _, err := fixture.Project.Store.Integrations().GetIntegrationTargetByProviderRef(
-		ctx,
-		fixture.Project.ProjectUUID,
-		fixture.Install.ID,
-		"C123:111.444",
-	); !storeerr.IsNotFound(err) {
-		t.Fatalf("launch failure integration target err=%v want not found", err)
+
+	assertLaunchFailure("Ev-launch-capacity-failure", "111.444")
+	result, err := pool.Exec(ctx, `
+UPDATE machine_pools
+SET max_total_machines = 1,
+    updated_at = transaction_timestamp()
+WHERE org_id = $1 AND name = 'Slack Launch Failure Pool'
+`, fixture.Project.OrgUUID)
+	if err != nil {
+		t.Fatalf("open launch failure pool capacity: %v", err)
 	}
-	var agentCount int
-	idempotencyKey := "integration:" + fixture.Install.Provider + ":" +
-		fixture.Install.ID.String() + ":C123:111.444"
-	if err := pool.QueryRow(
-		ctx,
-		`SELECT count(*) FROM agents WHERE project_id = $1 AND idempotency_key = $2`,
-		fixture.Project.ProjectUUID,
-		idempotencyKey,
-	).Scan(&agentCount); err != nil {
-		t.Fatalf("count failed launch agents: %v", err)
+	if result.RowsAffected() != 1 {
+		t.Fatalf("updated launch failure pools=%d want 1", result.RowsAffected())
 	}
-	if agentCount != 0 {
-		t.Fatalf("failed launch agent count=%d want 0", agentCount)
+	if _, err := pool.Exec(ctx, `
+INSERT INTO org_managed_work_admission(org_id, new_managed_work_allowed)
+VALUES ($1, false)
+ON CONFLICT (org_id) DO UPDATE
+SET new_managed_work_allowed = EXCLUDED.new_managed_work_allowed
+`, fixture.Project.OrgUUID); err != nil {
+		t.Fatalf("disable managed work admission: %v", err)
 	}
+	assertLaunchFailure("Ev-launch-admission-failure", "111.445")
 }
 
 func TestSlackEventsRejectsNewTargetWhenIntegrationSendToolIsDisabled(

--- a/internal/integration/service.go
+++ b/internal/integration/service.go
@@ -17,8 +17,6 @@ type Service struct {
 	integrations integrationStore
 }
 
-var ErrAgentLaunchFailed = errors.New("launch agent for integration target")
-
 type executionStore interface {
 	GetAgentProfile(context.Context, executionstore.ID, executionstore.ID) (executionstore.AgentProfileRecord, error)
 	LaunchAgent(context.Context, executionstore.LaunchAgentInput) (executionstore.LaunchAgentResult, error)
@@ -97,7 +95,7 @@ func (s *Service) GetOrCreateTarget(
 		if err != nil {
 			return integrationstore.IntegrationTargetRecord{}, executionstore.LaunchAgentResult{}, fmt.Errorf(
 				"%w: %w",
-				ErrAgentLaunchFailed,
+				storeerr.ErrAgentLaunchFailed,
 				err,
 			)
 		}

--- a/internal/integration/service.go
+++ b/internal/integration/service.go
@@ -17,6 +17,8 @@ type Service struct {
 	integrations integrationStore
 }
 
+var ErrAgentLaunchFailed = errors.New("launch agent for integration target")
+
 type executionStore interface {
 	GetAgentProfile(context.Context, executionstore.ID, executionstore.ID) (executionstore.AgentProfileRecord, error)
 	LaunchAgent(context.Context, executionstore.LaunchAgentInput) (executionstore.LaunchAgentResult, error)
@@ -94,7 +96,8 @@ func (s *Service) GetOrCreateTarget(
 		})
 		if err != nil {
 			return integrationstore.IntegrationTargetRecord{}, executionstore.LaunchAgentResult{}, fmt.Errorf(
-				"launch agent for integration target: %w",
+				"%w: %w",
+				ErrAgentLaunchFailed,
 				err,
 			)
 		}

--- a/internal/integration/service_test.go
+++ b/internal/integration/service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 	"github.com/omnara-ai/omnara/internal/storage/integrationstore"
+	"github.com/omnara-ai/omnara/internal/storage/storeerr"
 )
 
 type integrationServiceExecutionStub struct{}
@@ -26,6 +27,26 @@ func (integrationServiceExecutionStub) LaunchAgent(
 	executionstore.LaunchAgentInput,
 ) (executionstore.LaunchAgentResult, error) {
 	return executionstore.LaunchAgentResult{}, errors.New("unexpected LaunchAgent call")
+}
+
+type integrationServiceLaunchFailureStub struct {
+	profile   executionstore.AgentProfileRecord
+	launchErr error
+}
+
+func (s integrationServiceLaunchFailureStub) GetAgentProfile(
+	context.Context,
+	executionstore.ID,
+	executionstore.ID,
+) (executionstore.AgentProfileRecord, error) {
+	return s.profile, nil
+}
+
+func (s integrationServiceLaunchFailureStub) LaunchAgent(
+	context.Context,
+	executionstore.LaunchAgentInput,
+) (executionstore.LaunchAgentResult, error) {
+	return executionstore.LaunchAgentResult{}, s.launchErr
 }
 
 type integrationServiceStoreStub struct {
@@ -100,5 +121,44 @@ func TestGetOrCreateTargetTreatsDatabaseNoRowsAsNotFound(t *testing.T) {
 	}
 	if store.createdInput != wantInput {
 		t.Fatalf("create input = %+v, want %+v", store.createdInput, wantInput)
+	}
+}
+
+func TestGetOrCreateTargetTagsAgentLaunchFailures(t *testing.T) {
+	installID := uuid.New()
+	projectID := uuid.New()
+	profileID := uuid.New()
+	configID := uuid.New()
+	store := &integrationServiceStoreStub{
+		install: integrationstore.IntegrationInstallRecord{
+			ID:                installID,
+			ProjectID:         projectID,
+			AgentProfileID:    profileID,
+			InstalledByUserID: uuid.New(),
+			State:             integrationstore.IntegrationInstallStateActive,
+		},
+		lookupErr: pgx.ErrNoRows,
+	}
+	execution := integrationServiceLaunchFailureStub{
+		profile:   executionstore.AgentProfileRecord{CurrentConfigID: configID},
+		launchErr: storeerr.ErrStateTransitionConflict,
+	}
+
+	_, _, err := New(execution, store).GetOrCreateTarget(
+		context.Background(),
+		GetOrCreateTargetInput{
+			IntegrationInstallID: installID,
+			ProviderRef:          "C123:111.222",
+			ProviderRefKind:      "thread",
+		},
+	)
+	if !errors.Is(err, ErrAgentLaunchFailed) {
+		t.Fatalf("error = %v, want ErrAgentLaunchFailed", err)
+	}
+	if !errors.Is(err, storeerr.ErrStateTransitionConflict) {
+		t.Fatalf("error = %v, want underlying state transition conflict", err)
+	}
+	if store.createdInput != (integrationstore.CreateIntegrationTargetInput{}) {
+		t.Fatalf("launch failure created integration target with input %+v", store.createdInput)
 	}
 }

--- a/internal/integration/service_test.go
+++ b/internal/integration/service_test.go
@@ -152,7 +152,7 @@ func TestGetOrCreateTargetTagsAgentLaunchFailures(t *testing.T) {
 			ProviderRefKind:      "thread",
 		},
 	)
-	if !errors.Is(err, ErrAgentLaunchFailed) {
+	if !errors.Is(err, storeerr.ErrAgentLaunchFailed) {
 		t.Fatalf("error = %v, want ErrAgentLaunchFailed", err)
 	}
 	if !errors.Is(err, storeerr.ErrStateTransitionConflict) {

--- a/internal/integration/slack/messages.go
+++ b/internal/integration/slack/messages.go
@@ -120,12 +120,38 @@ func PostMessage(
 	if target.ThreadTS != "" {
 		payload["thread_ts"] = target.ThreadTS
 	}
+	return postMessageAt(ctx, client, defaultAPIURL, target, payload)
+}
+
+func PostPlainMessage(
+	ctx context.Context,
+	config OAuthConfig,
+	target MessageTarget,
+	text string,
+) (APIResult, error) {
+	payload := map[string]any{
+		"channel": target.Channel,
+		"text":    text,
+	}
+	if target.ThreadTS != "" {
+		payload["thread_ts"] = target.ThreadTS
+	}
+	return postMessageAt(ctx, config.HTTPClient, config.APIURL, target, payload)
+}
+
+func postMessageAt(
+	ctx context.Context,
+	client *http.Client,
+	apiURL string,
+	target MessageTarget,
+	payload map[string]any,
+) (APIResult, error) {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return APIResult{}, err
 	}
 	var out postMessageResponse
-	result, err := callJSON(ctx, client, target.BotToken, "chat.postMessage", body, &out)
+	result, err := callJSONAt(ctx, client, apiURL, target.BotToken, "chat.postMessage", body, &out)
 	if err != nil {
 		return APIResult{}, err
 	}

--- a/internal/integration/slack/messages.go
+++ b/internal/integration/slack/messages.go
@@ -20,7 +20,9 @@ const (
 	readbackPageLimit    = 100
 	readbackMaxPages     = 8
 
-	MessageMarkerEventType = "omnara_integration_message"
+	MessageMarkerEventType     = "omnara_integration_message"
+	AgentRequestFailureMessage = "I couldn't complete this request. " +
+		"Please try again later or contact this bot's owner."
 )
 
 type MessageTarget struct {

--- a/internal/storage/storeerr/errors.go
+++ b/internal/storage/storeerr/errors.go
@@ -12,6 +12,7 @@ var (
 	ErrInvalidRequest                = errors.New("invalid request")
 	ErrNoClaimableAgentWakeup        = errors.New("no claimable agent wakeup")
 	ErrAgentNotAdvanceable           = errors.New("agent is not advanceable")
+	ErrAgentLaunchFailed             = errors.New("launch agent for integration target")
 	ErrRuntimeLockInactive           = errors.New("runtime lock is not active")
 	ErrToolCallInProgress            = errors.New("tool call is already in progress")
 	ErrInvalidToolCallDisposition    = errors.New("invalid tool call transaction disposition")


### PR DESCRIPTION
- notify Slack users when synchronous agent launches fail for known state, configuration, or capacity conflicts
- preserve existing handling for pre-launch conflicts and unexpected launch errors so unrelated failures do not generate misleading replies
- send the fallback through a metadata-free Slack message path and cover delivery plus transaction rollback with unit and database-backed integration tests