### PR TITLE
fix: hide retryable model attempt errors from agent chat

### DIFF
--- a/frontend/packages/react/src/domains/agent-chat-stream.test.ts
+++ b/frontend/packages/react/src/domains/agent-chat-stream.test.ts
@@ -62,25 +62,50 @@ describe('AgentChatSession streaming', () => {
     session.disconnect()
   })
 
-  it('clears a model stream error when a durable event confirms recovery', async () => {
+  it('drops a failed model attempt preview while recovery continues', async () => {
     const session = startSession()
     const stream = await connection(0)
 
+    stream.push({ event: 'agent_input', data: userInputEvent() })
     stream.push({
       event: 'model_output_delta',
       data: delta(
         1,
+        { kind: 'block_start', block_index: 0, block: { kind: 'text' } },
+        { model_call_context_id: 'failed-call' },
+      ),
+    })
+    stream.push({
+      event: 'model_output_delta',
+      data: delta(
+        2,
+        { kind: 'text_delta', block_index: 0, delta: 'Partial' },
+        { model_call_context_id: 'failed-call' },
+      ),
+    })
+    await waitForSnapshot(session, (state) => messageText(state.messages.at(-1))[0] === 'Partial')
+
+    stream.push({
+      event: 'model_output_delta',
+      data: delta(
+        3,
         { kind: 'error', error: { message: 'model call failed' } },
         { model_call_context_id: 'failed-call' },
       ),
     })
-    const failed = await waitForSnapshot(session, (state) => state.status === 'error')
-    expect(failed.error?.message).toBe('model call failed')
+    const retrying = await waitForSnapshot(
+      session,
+      (state) =>
+        state.status === 'streaming' &&
+        !state.messages.some((message) => message.id === 'turn:turn'),
+    )
+    expect(retrying.error).toBeUndefined()
 
     stream.push({
       event: 'model_output',
       data: event({
         model_call_context_id: 'recovered-call',
+        sequence: 12,
         content_blocks: [{ type: 'text', text: 'Recovered' }],
       }),
     })
@@ -487,6 +512,7 @@ describe('AgentChatSession streaming', () => {
     })
     second.end()
     const recovered = await connection(2)
+    expect(read(session).error).toBeUndefined()
     recovered.push({ event: 'agent_input', data: userInputEvent() })
     await waitForSnapshot(session, (state) => state.status === 'streaming')
     recovered.end()
@@ -496,7 +522,6 @@ describe('AgentChatSession streaming', () => {
       .map((call) => call[1])
       .filter((delay) => delay === 1 || delay === 2)
     expect(reconnectDelays.slice(-3)).toEqual([1, 2, 1])
-    expect(read(session).error).toBeUndefined()
     expect(sdkMocks.openAgentEventStream).toHaveBeenCalledTimes(4)
     session.disconnect()
     setTimeout.mockRestore()

--- a/frontend/packages/react/src/domains/agent-chat.ts
+++ b/frontend/packages/react/src/domains/agent-chat.ts
@@ -105,7 +105,7 @@ export class AgentChatSession {
   private pendingInput: { id: string; text: string } | null = null
   private lastFailedSend: { id: string; text: string } | null = null
   private error: Error | undefined
-  private errorSource: 'send' | 'model' | 'stream' | undefined
+  private errorSource: 'send' | 'stream' | undefined
 
   private data: AgentChatData = {
     events: [],
@@ -234,7 +234,7 @@ export class AgentChatSession {
     if (this.cursor == null || sequence <= this.cursor) return
     this.cursor = sequence
     this.events = [...this.events, event]
-    if (this.errorSource === 'model' || this.errorSource === 'stream') {
+    if (this.errorSource === 'stream') {
       this.error = undefined
       this.errorSource = undefined
     }
@@ -274,19 +274,17 @@ export class AgentChatSession {
 
   private handleDelta(delta: ModelOutputDelta): void {
     if (this.completedCalls.has(delta.model_call_context_id)) return
+    if (this.errorSource === 'stream') {
+      this.error = undefined
+      this.errorSource = undefined
+    }
     if (delta.event.kind === 'error') {
       this.completedCalls.add(delta.model_call_context_id)
       this.deltas = this.deltas.filter(
         (candidate) => candidate.model_call_context_id !== delta.model_call_context_id,
       )
-      this.error = new Error(delta.event.error.message)
-      this.errorSource = 'model'
       this.notify()
       return
-    }
-    if (this.errorSource === 'model' || this.errorSource === 'stream') {
-      this.error = undefined
-      this.errorSource = undefined
     }
     this.deltas = [...this.deltas, delta]
     this.notify()
@@ -333,8 +331,8 @@ export class AgentChatSession {
           else if (parsed.kind === 'event') this.handleEvent(parsed.event)
         }
         if (streamError != null) {
-          this.handleStreamError(streamError.error)
           if (streamError.code !== 'service_unavailable') {
+            this.handleStreamError(streamError.error)
             this.disconnect()
             return
           }


### PR DESCRIPTION
- fixes [OMN2-268](https://linear.app/omnara/issue/OMN2-268/hide-retryable-model-attempt-errors-from-the-agent-chat-ui) by treating model-output error deltas as failed attempt boundaries instead of chat-level errors
- removes partial output from a failed attempt while allowing a later backend retry to render normally
- keeps durable terminal errors and non-retryable stream failures visible while retryable service-unavailable interruptions reconnect silently
- extends the existing chat-stream coverage for recovered model attempts and silent stream reconnection