### PR TITLE
feat: Add config attachments to agents

### DIFF
--- a/frontend/packages/cli/agent.yaml
+++ b/frontend/packages/cli/agent.yaml
@@ -1,0 +1,6 @@
+instruction: |
+  You are a coding agent running gpt-5.6-sol. Use the tools
+  you have available to solve coding problems for the user.
+model:
+  provider_config: omnara-openrouter
+  name: openai/gpt-5.6-sol

--- a/frontend/packages/cli/agent.yaml
+++ b/frontend/packages/cli/agent.yaml
@@ -1,6 +1,0 @@
-instruction: |
-  You are a coding agent running gpt-5.6-sol. Use the tools
-  you have available to solve coding problems for the user.
-model:
-  provider_config: omnara-openrouter
-  name: openai/gpt-5.6-sol

--- a/frontend/packages/cli/src/config-attachment.test.ts
+++ b/frontend/packages/cli/src/config-attachment.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 
 import { afterAll, describe, expect, it } from 'vitest'
 
-import { renderConfigAttachment } from './config-attachment.ts'
+import { renderConfigSource } from './config-attachment.ts'
 import { CliInputError } from './output.ts'
 
 const dir = mkdtempSync(join(tmpdir(), 'omnara-config-attachment-'))
@@ -18,10 +18,10 @@ function writeTemp(name: string, content: string): string {
   return filePath
 }
 
-describe('renderConfigAttachment', () => {
+describe('renderConfigSource', () => {
   it('reads a yaml file', () => {
     const file = writeTemp('agent.yaml', 'instruction: hi\n')
-    expect(renderConfigAttachment({ file })).toEqual({
+    expect(renderConfigSource({ file })).toEqual({
       source: 'instruction: hi\n',
       source_format: 'yaml',
     })
@@ -29,35 +29,40 @@ describe('renderConfigAttachment', () => {
 
   it('reads a json file', () => {
     const file = writeTemp('agent.json', '{"instruction":"hi"}\n')
-    expect(renderConfigAttachment({ file })).toEqual({
+    expect(renderConfigSource({ file })).toEqual({
       source: '{"instruction":"hi"}\n',
       source_format: 'json',
     })
   })
 
   it('rejects a file with an unknown extension', () => {
-    expect(() => renderConfigAttachment({ file: join(dir, 'agent.toml') })).toThrow(CliInputError)
+    expect(() => renderConfigSource({ file: join(dir, 'agent.toml') })).toThrow(CliInputError)
   })
 
   it('rejects a missing file', () => {
-    expect(() => renderConfigAttachment({ file: join(dir, 'absent.yaml') })).toThrow(CliInputError)
+    expect(() => renderConfigSource({ file: join(dir, 'absent.yaml') })).toThrow(CliInputError)
   })
 
   it('detects inline json', () => {
-    expect(renderConfigAttachment({ source: '{"instruction": "hi"}' })).toEqual({
+    expect(renderConfigSource({ source: '{"instruction": "hi"}' })).toEqual({
       source: '{"instruction": "hi"}',
       source_format: 'json',
     })
   })
 
   it('detects inline yaml', () => {
-    expect(renderConfigAttachment({ source: 'instruction: hi' })).toEqual({
+    expect(renderConfigSource({ source: 'instruction: hi' })).toEqual({
       source: 'instruction: hi',
       source_format: 'yaml',
     })
   })
 
   it('rejects an empty attachment', () => {
-    expect(() => renderConfigAttachment({})).toThrow(CliInputError)
+    expect(() => renderConfigSource({})).toThrow(CliInputError)
+  })
+
+  it('rejects a file and inline source together', () => {
+    const file = writeTemp('agent.yaml', 'instruction: hi\n')
+    expect(() => renderConfigSource({ file, source: 'instruction: hi' })).toThrow(CliInputError)
   })
 })

--- a/frontend/packages/cli/src/config-attachment.test.ts
+++ b/frontend/packages/cli/src/config-attachment.test.ts
@@ -1,0 +1,63 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterAll, describe, expect, it } from 'vitest'
+
+import { renderConfigAttachment } from './config-attachment.ts'
+import { CliInputError } from './output.ts'
+
+const dir = mkdtempSync(join(tmpdir(), 'omnara-config-attachment-'))
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function writeTemp(name: string, content: string): string {
+  const filePath = join(dir, name)
+  writeFileSync(filePath, content)
+  return filePath
+}
+
+describe('renderConfigAttachment', () => {
+  it('reads a yaml file', () => {
+    const file = writeTemp('agent.yaml', 'instruction: hi\n')
+    expect(renderConfigAttachment({ file })).toEqual({
+      source: 'instruction: hi\n',
+      source_format: 'yaml',
+    })
+  })
+
+  it('reads a json file', () => {
+    const file = writeTemp('agent.json', '{"instruction":"hi"}\n')
+    expect(renderConfigAttachment({ file })).toEqual({
+      source: '{"instruction":"hi"}\n',
+      source_format: 'json',
+    })
+  })
+
+  it('rejects a file with an unknown extension', () => {
+    expect(() => renderConfigAttachment({ file: join(dir, 'agent.toml') })).toThrow(CliInputError)
+  })
+
+  it('rejects a missing file', () => {
+    expect(() => renderConfigAttachment({ file: join(dir, 'absent.yaml') })).toThrow(CliInputError)
+  })
+
+  it('detects inline json', () => {
+    expect(renderConfigAttachment({ source: '{"instruction": "hi"}' })).toEqual({
+      source: '{"instruction": "hi"}',
+      source_format: 'json',
+    })
+  })
+
+  it('detects inline yaml', () => {
+    expect(renderConfigAttachment({ source: 'instruction: hi' })).toEqual({
+      source: 'instruction: hi',
+      source_format: 'yaml',
+    })
+  })
+
+  it('rejects an empty attachment', () => {
+    expect(() => renderConfigAttachment({})).toThrow(CliInputError)
+  })
+})

--- a/frontend/packages/cli/src/config-attachment.ts
+++ b/frontend/packages/cli/src/config-attachment.ts
@@ -6,14 +6,20 @@ import * as z from 'zod'
 
 import { CliInputError } from './output.ts'
 
-export const zConfigAttachment = z.object({
-  config: zAgentConfigId.optional().describe('existing agent config ID'),
+export const zConfigSourceAttachment = z.object({
   file: z
     .string()
     .min(1)
     .optional()
     .describe('path to an agent config file (.yaml, .yml, or .json)'),
   source: z.string().min(1).optional().describe('inline agent config source (YAML or JSON)'),
+})
+
+export type ConfigSourceAttachment = z.output<typeof zConfigSourceAttachment>
+
+export const zConfigAttachment = z.object({
+  config: zAgentConfigId.optional().describe('existing agent config ID'),
+  ...zConfigSourceAttachment.shape,
 })
 
 export type ConfigAttachment = z.output<typeof zConfigAttachment>
@@ -24,17 +30,11 @@ export interface ConfigSource {
 }
 
 const ATTACHMENT_HINT = 'pass exactly one of --config, --file, or --source'
+const SOURCE_HINT = 'pass exactly one of --file or --source'
 
-const zProjectScope = z.object({
-  orgID: z.string().min(1),
-  projectID: z.string().min(1),
-})
-
-function requireExactlyOne(attachment: ConfigAttachment): void {
-  const provided = [attachment.config, attachment.file, attachment.source].filter(
-    (value) => value !== undefined,
-  )
-  if (provided.length !== 1) throw new CliInputError(ATTACHMENT_HINT)
+function requireExactlyOne(values: (string | undefined)[], hint: string): void {
+  const provided = values.filter((value) => value !== undefined)
+  if (provided.length !== 1) throw new CliInputError(hint)
 }
 
 function fileFormat(filePath: string): 'yaml' | 'json' {
@@ -53,7 +53,8 @@ function inlineFormat(source: string): 'yaml' | 'json' {
   }
 }
 
-export function renderConfigAttachment(attachment: ConfigAttachment): ConfigSource {
+export function renderConfigSource(attachment: ConfigSourceAttachment): ConfigSource {
+  requireExactlyOne([attachment.file, attachment.source], SOURCE_HINT)
   if (attachment.file !== undefined) {
     const format = fileFormat(attachment.file)
     let source: string
@@ -67,39 +68,27 @@ export function renderConfigAttachment(attachment: ConfigAttachment): ConfigSour
   if (attachment.source !== undefined) {
     return { source: attachment.source, source_format: inlineFormat(attachment.source) }
   }
-  throw new CliInputError(ATTACHMENT_HINT)
+  throw new CliInputError(SOURCE_HINT)
 }
+
+const zProjectScope = z.object({
+  orgID: z.string().min(1),
+  projectID: z.string().min(1),
+})
 
 export async function resolveConfigId(
   client: OmnaraClient,
   path: Record<string, unknown>,
   attachment: ConfigAttachment,
 ): Promise<string> {
-  requireExactlyOne(attachment)
+  requireExactlyOne([attachment.config, attachment.file, attachment.source], ATTACHMENT_HINT)
   if (attachment.config !== undefined) return attachment.config
   const { data } = await sdk.createAgentConfig({
     client,
     path: zProjectScope.parse(path),
-    body: renderConfigAttachment(attachment),
+    body: renderConfigSource(attachment),
   })
   return data.id
-}
-
-export async function resolveConfigSource(
-  client: OmnaraClient,
-  path: Record<string, unknown>,
-  attachment: ConfigAttachment,
-): Promise<ConfigSource> {
-  requireExactlyOne(attachment)
-  if (attachment.config === undefined) return renderConfigAttachment(attachment)
-  const { data } = await sdk.getAgentConfig({
-    client,
-    path: { ...zProjectScope.parse(path), agentConfigID: attachment.config },
-  })
-  if (data.source === undefined || data.source_format === undefined) {
-    throw new CliInputError(`the source of agent config ${attachment.config} is unavailable`)
-  }
-  return { source: data.source, source_format: data.source_format }
 }
 
 const zProfilePath = zProjectScope.extend({ agentProfileID: z.string().min(1) })

--- a/frontend/packages/cli/src/config-attachment.ts
+++ b/frontend/packages/cli/src/config-attachment.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'node:fs'
+
+import { type OmnaraClient, sdk } from '@omnara/sdk'
+import { zAgentConfigId } from '@omnara/sdk/zod'
+import * as z from 'zod'
+
+import { CliInputError } from './output.ts'
+
+export const zConfigAttachment = z.object({
+  config: zAgentConfigId.optional().describe('existing agent config ID'),
+  file: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('path to an agent config file (.yaml, .yml, or .json)'),
+  source: z.string().min(1).optional().describe('inline agent config source (YAML or JSON)'),
+})
+
+export type ConfigAttachment = z.output<typeof zConfigAttachment>
+
+export interface ConfigSource {
+  source: string
+  source_format: 'yaml' | 'json'
+}
+
+const ATTACHMENT_HINT = 'pass exactly one of --config, --file, or --source'
+
+const zProjectScope = z.object({
+  orgID: z.string().min(1),
+  projectID: z.string().min(1),
+})
+
+function requireExactlyOne(attachment: ConfigAttachment): void {
+  const provided = [attachment.config, attachment.file, attachment.source].filter(
+    (value) => value !== undefined,
+  )
+  if (provided.length !== 1) throw new CliInputError(ATTACHMENT_HINT)
+}
+
+function fileFormat(filePath: string): 'yaml' | 'json' {
+  const lower = filePath.toLowerCase()
+  if (lower.endsWith('.json')) return 'json'
+  if (lower.endsWith('.yaml') || lower.endsWith('.yml')) return 'yaml'
+  throw new CliInputError(`config file must end in .yaml, .yml, or .json: ${filePath}`)
+}
+
+function inlineFormat(source: string): 'yaml' | 'json' {
+  try {
+    JSON.parse(source)
+    return 'json'
+  } catch {
+    return 'yaml'
+  }
+}
+
+export function renderConfigAttachment(attachment: ConfigAttachment): ConfigSource {
+  if (attachment.file !== undefined) {
+    const format = fileFormat(attachment.file)
+    let source: string
+    try {
+      source = readFileSync(attachment.file, 'utf8')
+    } catch {
+      throw new CliInputError(`could not read config file: ${attachment.file}`)
+    }
+    return { source, source_format: format }
+  }
+  if (attachment.source !== undefined) {
+    return { source: attachment.source, source_format: inlineFormat(attachment.source) }
+  }
+  throw new CliInputError(ATTACHMENT_HINT)
+}
+
+export async function resolveConfigId(
+  client: OmnaraClient,
+  path: Record<string, unknown>,
+  attachment: ConfigAttachment,
+): Promise<string> {
+  requireExactlyOne(attachment)
+  if (attachment.config !== undefined) return attachment.config
+  const { data } = await sdk.createAgentConfig({
+    client,
+    path: zProjectScope.parse(path),
+    body: renderConfigAttachment(attachment),
+  })
+  return data.id
+}
+
+export async function resolveConfigSource(
+  client: OmnaraClient,
+  path: Record<string, unknown>,
+  attachment: ConfigAttachment,
+): Promise<ConfigSource> {
+  requireExactlyOne(attachment)
+  if (attachment.config === undefined) return renderConfigAttachment(attachment)
+  const { data } = await sdk.getAgentConfig({
+    client,
+    path: { ...zProjectScope.parse(path), agentConfigID: attachment.config },
+  })
+  if (data.source === undefined || data.source_format === undefined) {
+    throw new CliInputError(`the source of agent config ${attachment.config} is unavailable`)
+  }
+  return { source: data.source, source_format: data.source_format }
+}
+
+const zProfilePath = zProjectScope.extend({ agentProfileID: z.string().min(1) })
+
+export async function currentProfileConfigId(
+  client: OmnaraClient,
+  path: Record<string, unknown>,
+): Promise<string> {
+  const { data } = await sdk.getAgentProfile({ client, path: zProfilePath.parse(path) })
+  return data.current_config_id
+}

--- a/frontend/packages/cli/src/factory.ts
+++ b/frontend/packages/cli/src/factory.ts
@@ -21,6 +21,11 @@ type ResponseOf<F extends SdkOperation> = F extends (options: never) => PromiseL
     : never
   : never
 
+export interface TransformBodyContext {
+  client: OmnaraClient
+  path: Record<string, unknown>
+}
+
 export interface OperationSpec<Response = never, ParsedBody = never> {
   type: 'op'
   verb: string
@@ -29,7 +34,7 @@ export interface OperationSpec<Response = never, ParsedBody = never> {
   path?: z.ZodObject<z.ZodRawShape>
   query?: z.ZodObject<z.ZodRawShape>
   body?: z.ZodType
-  transformBody?: (body: ParsedBody) => unknown
+  transformBody?: (body: ParsedBody, context: TransformBodyContext) => unknown
   positional?: string[]
   format: OutputFormat<Response>
 }
@@ -349,7 +354,12 @@ export function registerOperation(parent: Command, config: CliConfig, spec: Oper
           options.body === undefined ? {} : parseWithSchema(zBodyObject, options.body, '--body')
         const body = deepMerge(base, collectFlagValues(bodyFlags, options))
         const parsed = parseWithSchema(spec.body, body, 'request body')
-        input.body = spec.transformBody ? await spec.transformBody(parsed as never) : parsed
+        input.body = spec.transformBody
+          ? await spec.transformBody(parsed as never, {
+              client: config.client,
+              path: input.path ?? {},
+            })
+          : parsed
       }
       const data = await callOperation(spec, input)
       if (options.json === true) {

--- a/frontend/packages/cli/src/manifest.ts
+++ b/frontend/packages/cli/src/manifest.ts
@@ -4,9 +4,10 @@ import * as z from 'zod'
 
 import {
   currentProfileConfigId,
+  renderConfigSource,
   resolveConfigId,
-  resolveConfigSource,
   zConfigAttachment,
+  zConfigSourceAttachment,
 } from './config-attachment.ts'
 import { type CommandGroup, flowOp, op, type OperationSpec } from './factory.ts'
 import { formatRecord, formatTable, formatVoid } from './format.ts'
@@ -64,13 +65,13 @@ export const commandGroups: CommandGroup[] = [
         fn: sdk.updateAgentConfig,
         format: (response) => formatRecord()(response.agent_config),
         path: schemas.zUpdateAgentConfigPath,
-        body: zConfigAttachment.extend({
+        body: zConfigSourceAttachment.extend({
           expected_current_config_id: schemas.zAgentConfigId
             .optional()
             .describe('fail unless the agent still runs this config'),
         }),
-        transformBody: async ({ expected_current_config_id, ...attachment }, { client, path }) => ({
-          ...(await resolveConfigSource(client, path, attachment)),
+        transformBody: ({ expected_current_config_id, ...attachment }) => ({
+          ...renderConfigSource(attachment),
           expected_current_config_id,
         }),
       }),
@@ -644,11 +645,14 @@ export const commandGroups: CommandGroup[] = [
             .optional()
             .describe('fail unless the profile still points at this config'),
         }),
-        transformBody: async ({ expected_current_config_id, ...attachment }, { client, path }) => ({
-          config: await resolveConfigId(client, path, attachment),
-          expected_current_config_id:
-            expected_current_config_id ?? (await currentProfileConfigId(client, path)),
-        }),
+        transformBody: async ({ expected_current_config_id, ...attachment }, { client, path }) => {
+          const expected =
+            expected_current_config_id ?? (await currentProfileConfigId(client, path))
+          return {
+            config: await resolveConfigId(client, path, attachment),
+            expected_current_config_id: expected,
+          }
+        },
       }),
       op({
         verb: 'rename',

--- a/frontend/packages/cli/src/manifest.ts
+++ b/frontend/packages/cli/src/manifest.ts
@@ -2,6 +2,12 @@ import { sdk } from '@omnara/sdk'
 import * as schemas from '@omnara/sdk/zod'
 import * as z from 'zod'
 
+import {
+  currentProfileConfigId,
+  resolveConfigId,
+  resolveConfigSource,
+  zConfigAttachment,
+} from './config-attachment.ts'
 import { type CommandGroup, flowOp, op, type OperationSpec } from './factory.ts'
 import { formatRecord, formatTable, formatVoid } from './format.ts'
 import { runAgentMcpAdd, runProfileMcpAdd, zMcpAddBody } from './mcp-add.ts'
@@ -40,7 +46,33 @@ export const commandGroups: CommandGroup[] = [
         fn: sdk.createAgent,
         format: formatRecord(),
         path: schemas.zCreateAgentPath,
-        body: schemas.zCreateAgentBody,
+        body: zConfigAttachment.extend({
+          profile: schemas.zAgentProfileId.optional(),
+          name: z.string().optional(),
+          message: z.string().optional(),
+        }),
+        transformBody: async ({ profile, name, message, ...attachment }, { client, path }) => ({
+          profile,
+          name,
+          message,
+          config: await resolveConfigId(client, path, attachment),
+        }),
+      }),
+      op({
+        verb: 'update',
+        summary: "Replace a running agent's config",
+        fn: sdk.updateAgentConfig,
+        format: (response) => formatRecord()(response.agent_config),
+        path: schemas.zUpdateAgentConfigPath,
+        body: zConfigAttachment.extend({
+          expected_current_config_id: schemas.zAgentConfigId
+            .optional()
+            .describe('fail unless the agent still runs this config'),
+        }),
+        transformBody: async ({ expected_current_config_id, ...attachment }, { client, path }) => ({
+          ...(await resolveConfigSource(client, path, attachment)),
+          expected_current_config_id,
+        }),
       }),
       op({
         verb: 'cancel',
@@ -595,7 +627,28 @@ export const commandGroups: CommandGroup[] = [
         fn: sdk.createAgentProfile,
         format: formatRecord(),
         path: schemas.zCreateAgentProfilePath,
-        body: schemas.zCreateAgentProfileBody,
+        body: zConfigAttachment.extend({ name: z.string() }),
+        transformBody: async ({ name, ...attachment }, { client, path }) => ({
+          name,
+          config: await resolveConfigId(client, path, attachment),
+        }),
+      }),
+      op({
+        verb: 'update',
+        summary: 'Point an agent profile at a new config',
+        fn: sdk.updateAgentProfile,
+        format: formatRecord(),
+        path: schemas.zUpdateAgentProfilePath,
+        body: zConfigAttachment.extend({
+          expected_current_config_id: schemas.zAgentConfigId
+            .optional()
+            .describe('fail unless the profile still points at this config'),
+        }),
+        transformBody: async ({ expected_current_config_id, ...attachment }, { client, path }) => ({
+          config: await resolveConfigId(client, path, attachment),
+          expected_current_config_id:
+            expected_current_config_id ?? (await currentProfileConfigId(client, path)),
+        }),
       }),
       op({
         verb: 'rename',


### PR DESCRIPTION
Allow referencing yaml and json config files in agent upload and profile upload. also allow updating profiles and agent configs