### PR TITLE
feat: add steering queue controls

### DIFF
--- a/frontend/apps/web/package.json
+++ b/frontend/apps/web/package.json
@@ -14,6 +14,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@heroicons/react": "^2.2.0",

--- a/frontend/apps/web/src/components/agents/AgentComposer.tsx
+++ b/frontend/apps/web/src/components/agents/AgentComposer.tsx
@@ -4,7 +4,6 @@ import { type KeyboardEvent, type SyntheticEvent, useState } from 'react'
 import { SendHorizontal, Square } from '@/components/icons'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
-import { cn } from '@/lib/utils'
 
 export function AgentComposer({
   chat,
@@ -12,14 +11,12 @@ export function AgentComposer({
   cancelPending,
   cancelError,
   canOperate,
-  className,
 }: {
   chat: UseAgentChatResult
   onCancel: () => Promise<unknown>
   cancelPending: boolean
   cancelError?: Error | null
   canOperate: boolean
-  className?: string
 }) {
   const [text, setText] = useState('')
   const working = chat.isWorking
@@ -49,10 +46,7 @@ export function AgentComposer({
   }
 
   return (
-    <form
-      onSubmit={onSubmit}
-      className={cn('bg-background rounded-xl border p-2 shadow-sm', className)}
-    >
+    <form onSubmit={onSubmit} className="bg-background rounded-xl border p-2 shadow-sm">
       {chat.error && <p className="text-destructive px-2 pb-2 text-xs">{chat.error.message}</p>}
       {cancelError && <p className="text-destructive px-2 pb-2 text-xs">{cancelError.message}</p>}
       <Textarea

--- a/frontend/apps/web/src/components/agents/AgentComposer.tsx
+++ b/frontend/apps/web/src/components/agents/AgentComposer.tsx
@@ -4,6 +4,7 @@ import { type KeyboardEvent, type SyntheticEvent, useState } from 'react'
 import { SendHorizontal, Square } from '@/components/icons'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
+import { cn } from '@/lib/utils'
 
 export function AgentComposer({
   chat,
@@ -11,12 +12,14 @@ export function AgentComposer({
   cancelPending,
   cancelError,
   canOperate,
+  className,
 }: {
   chat: UseAgentChatResult
   onCancel: () => Promise<unknown>
   cancelPending: boolean
   cancelError?: Error | null
   canOperate: boolean
+  className?: string
 }) {
   const [text, setText] = useState('')
   const working = chat.isWorking
@@ -46,7 +49,10 @@ export function AgentComposer({
   }
 
   return (
-    <form onSubmit={onSubmit} className="bg-background rounded-xl border p-2 shadow-sm">
+    <form
+      onSubmit={onSubmit}
+      className={cn('bg-background rounded-xl border p-2 shadow-sm', className)}
+    >
       {chat.error && <p className="text-destructive px-2 pb-2 text-xs">{chat.error.message}</p>}
       {cancelError && <p className="text-destructive px-2 pb-2 text-xs">{cancelError.message}</p>}
       <Textarea

--- a/frontend/apps/web/src/components/agents/AgentInputQueue.test.tsx
+++ b/frontend/apps/web/src/components/agents/AgentInputQueue.test.tsx
@@ -1,0 +1,161 @@
+/** @vitest-environment happy-dom */
+
+import type { AgentInput } from '@omnara/sdk'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AgentInputQueue } from '@/components/agents/AgentInputQueue'
+
+function input(id: string, text: string): AgentInput {
+  return {
+    id,
+    agent_id: 'agent',
+    state: 'received',
+    delivery_mode: 'queued',
+    input_kind: 'content',
+    content_blocks: [
+      {
+        type: 'text',
+        text: 'Hidden web context',
+        metadata: { omnara_hidden: 'true' },
+      },
+      { type: 'text', text },
+    ],
+    queued_at: '2026-08-20T00:00:00Z',
+  }
+}
+
+describe('AgentInputQueue', () => {
+  it('renders every queued message with its queue order, preview, and actions', () => {
+    const firstInput = input('input-1', 'Raw message')
+    firstInput.content_blocks = [
+      { type: 'text', text: 'Hidden web context', metadata: { omnara_hidden: 'true' } },
+      { type: 'text', text: 'Raw message', metadata: { omnara_display_text: 'First message' } },
+    ]
+    const secondInput = input('input-2', '')
+    secondInput.content_blocks = [{ type: 'media_ref', artifact_id: 'artifact' }]
+
+    const html = renderToStaticMarkup(
+      <AgentInputQueue
+        inputs={[firstInput, secondInput]}
+        canOperate
+        canSendNow
+        actionPending={false}
+        onSendNow={vi.fn()}
+        onRemove={vi.fn()}
+        onMove={vi.fn()}
+      />,
+    )
+
+    expect(html).toContain('First message')
+    expect(html).not.toContain('Raw message')
+    expect(html).toContain('Attachment')
+    expect(html).toContain('Next')
+    expect(html).toContain('>2</span>')
+    expect(html).not.toContain('Hidden web context')
+    expect(html.match(/Send now/g)).toHaveLength(2)
+    expect(html.match(/Remove queued message/g)).toHaveLength(2)
+    expect(html.match(/Reorder queued message/g)).toHaveLength(2)
+  })
+
+  it('hides send-now actions when steering is unavailable', () => {
+    const html = renderToStaticMarkup(
+      <AgentInputQueue
+        inputs={[input('input-1', 'Message')]}
+        canOperate
+        canSendNow={false}
+        actionPending={false}
+        onSendNow={vi.fn()}
+        onRemove={vi.fn()}
+        onMove={vi.fn()}
+      />,
+    )
+
+    expect(html).not.toContain('Send now')
+    expect(html).toContain('Remove queued message')
+    expect(html).not.toContain('Reorder queued message')
+  })
+
+  it('moves a row relative to its drop target', async () => {
+    const container = document.createElement('div')
+    document.body.append(container)
+    const root = createRoot(container)
+    const onMove = vi.fn().mockResolvedValue(undefined)
+    const actEnvironment = globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean
+    }
+    const previousActEnvironment = actEnvironment.IS_REACT_ACT_ENVIRONMENT
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+
+    try {
+      act(() => {
+        root.render(
+          <AgentInputQueue
+            inputs={[
+              input('input-1', 'First message'),
+              input('input-2', 'Second message'),
+              input('input-3', 'Third message'),
+            ]}
+            canOperate
+            canSendNow
+            actionPending={false}
+            onSendNow={vi.fn()}
+            onRemove={vi.fn()}
+            onMove={onMove}
+          />,
+        )
+      })
+
+      const handles = Array.from(
+        container.querySelectorAll<HTMLButtonElement>('[aria-label^="Reorder queued message"]'),
+      )
+      handles.forEach((candidate, index) => {
+        const row = candidate.parentElement
+        if (!row) throw new Error('Missing queued message row')
+        row.getBoundingClientRect = () => ({
+          x: 0,
+          y: index * 40,
+          top: index * 40,
+          right: 600,
+          bottom: index * 40 + 40,
+          left: 0,
+          width: 600,
+          height: 40,
+          toJSON: () => undefined,
+        })
+      })
+      const handle = handles[2]
+      if (!handle) throw new Error('Missing reorder handle')
+
+      await act(async () => {
+        handle.focus()
+        handle.dispatchEvent(
+          new KeyboardEvent('keydown', { key: ' ', code: 'Space', bubbles: true }),
+        )
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      await act(async () => {
+        handle.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'ArrowUp', code: 'ArrowUp', bubbles: true }),
+        )
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      await act(async () => {
+        handle.dispatchEvent(
+          new KeyboardEvent('keydown', { key: ' ', code: 'Space', bubbles: true }),
+        )
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+
+      expect(onMove).toHaveBeenCalledWith('input-3', 'input-2', 'before')
+    } finally {
+      act(() => {
+        root.unmount()
+      })
+      container.remove()
+      actEnvironment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment
+    }
+  })
+})

--- a/frontend/apps/web/src/components/agents/AgentInputQueue.test.tsx
+++ b/frontend/apps/web/src/components/agents/AgentInputQueue.test.tsx
@@ -4,9 +4,27 @@ import type { AgentInput } from '@omnara/sdk'
 import { act } from 'react'
 import { createRoot } from 'react-dom/client'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AgentInputQueue } from '@/components/agents/AgentInputQueue'
+
+const backlogMocks = vi.hoisted(() => ({
+  inputs: [] as AgentInput[],
+  cancel: vi.fn(),
+  promote: vi.fn(),
+  move: vi.fn(),
+}))
+
+vi.mock('@omnara/react', () => ({
+  useAgentInputBacklog: () => ({
+    query: { data: { data: backlogMocks.inputs } },
+    cancel: { isPending: false, mutateAsync: backlogMocks.cancel },
+    promote: { isPending: false, mutateAsync: backlogMocks.promote },
+    move: { isPending: false, mutateAsync: backlogMocks.move },
+  }),
+}))
+
+const scope = { orgID: 'org', projectID: 'project', agentID: 'agent' }
 
 function input(id: string, text: string): AgentInput {
   return {
@@ -28,6 +46,12 @@ function input(id: string, text: string): AgentInput {
 }
 
 describe('AgentInputQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    backlogMocks.inputs = []
+    backlogMocks.move.mockResolvedValue(undefined)
+  })
+
   it('renders every queued message with its queue order, preview, and actions', () => {
     const firstInput = input('input-1', 'Raw message')
     firstInput.content_blocks = [
@@ -36,18 +60,9 @@ describe('AgentInputQueue', () => {
     ]
     const secondInput = input('input-2', '')
     secondInput.content_blocks = [{ type: 'media_ref', artifact_id: 'artifact' }]
+    backlogMocks.inputs = [firstInput, secondInput]
 
-    const html = renderToStaticMarkup(
-      <AgentInputQueue
-        inputs={[firstInput, secondInput]}
-        canOperate
-        canSendNow
-        actionPending={false}
-        onSendNow={vi.fn()}
-        onRemove={vi.fn()}
-        onMove={vi.fn()}
-      />,
-    )
+    const html = renderToStaticMarkup(<AgentInputQueue scope={scope} canOperate canSendNow />)
 
     expect(html).toContain('First message')
     expect(html).not.toContain('Raw message')
@@ -61,16 +76,9 @@ describe('AgentInputQueue', () => {
   })
 
   it('hides send-now actions when steering is unavailable', () => {
+    backlogMocks.inputs = [input('input-1', 'Message')]
     const html = renderToStaticMarkup(
-      <AgentInputQueue
-        inputs={[input('input-1', 'Message')]}
-        canOperate
-        canSendNow={false}
-        actionPending={false}
-        onSendNow={vi.fn()}
-        onRemove={vi.fn()}
-        onMove={vi.fn()}
-      />,
+      <AgentInputQueue scope={scope} canOperate canSendNow={false} />,
     )
 
     expect(html).not.toContain('Send now')
@@ -82,7 +90,11 @@ describe('AgentInputQueue', () => {
     const container = document.createElement('div')
     document.body.append(container)
     const root = createRoot(container)
-    const onMove = vi.fn().mockResolvedValue(undefined)
+    backlogMocks.inputs = [
+      input('input-1', 'First message'),
+      input('input-2', 'Second message'),
+      input('input-3', 'Third message'),
+    ]
     const actEnvironment = globalThis as typeof globalThis & {
       IS_REACT_ACT_ENVIRONMENT?: boolean
     }
@@ -91,21 +103,7 @@ describe('AgentInputQueue', () => {
 
     try {
       act(() => {
-        root.render(
-          <AgentInputQueue
-            inputs={[
-              input('input-1', 'First message'),
-              input('input-2', 'Second message'),
-              input('input-3', 'Third message'),
-            ]}
-            canOperate
-            canSendNow
-            actionPending={false}
-            onSendNow={vi.fn()}
-            onRemove={vi.fn()}
-            onMove={onMove}
-          />,
-        )
+        root.render(<AgentInputQueue scope={scope} canOperate canSendNow />)
       })
 
       const handles = Array.from(
@@ -149,7 +147,11 @@ describe('AgentInputQueue', () => {
         await new Promise((resolve) => setTimeout(resolve, 0))
       })
 
-      expect(onMove).toHaveBeenCalledWith('input-3', 'input-2', 'before')
+      expect(backlogMocks.move).toHaveBeenCalledWith({
+        inputID: 'input-3',
+        anchorInputID: 'input-2',
+        position: 'before',
+      })
     } finally {
       act(() => {
         root.unmount()

--- a/frontend/apps/web/src/components/agents/AgentInputQueue.tsx
+++ b/frontend/apps/web/src/components/agents/AgentInputQueue.tsx
@@ -15,9 +15,14 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+import { useAgentInputBacklog } from '@omnara/react'
 import type { AgentInput } from '@omnara/sdk'
 import { GripVertical, X } from 'lucide-react'
 import { useState } from 'react'
+
+import { errorMessage } from '@/lib/submit-status'
+
+type AgentInputBacklog = ReturnType<typeof useAgentInputBacklog>
 
 function inputPreview(input: AgentInput) {
   const blocks = input.content_blocks?.filter((block) => block.metadata?.omnara_hidden !== 'true')
@@ -39,27 +44,23 @@ function inputPreview(input: AgentInput) {
 }
 
 export function AgentInputQueue({
-  inputs,
+  scope,
   canOperate,
   canSendNow,
-  actionPending,
-  onSendNow,
-  onRemove,
-  onMove,
 }: {
-  inputs: AgentInput[]
+  scope: { orgID: string; projectID: string; agentID: string }
   canOperate: boolean
   canSendNow: boolean
-  actionPending: boolean
-  onSendNow: (inputID: string) => Promise<unknown>
-  onRemove: (inputID: string) => Promise<unknown>
-  onMove: (inputID: string, anchorInputID: string, position: 'before' | 'after') => Promise<unknown>
 }) {
+  const backlog = useAgentInputBacklog(scope)
   const [orderedInputs, setOrderedInputs] = useState<AgentInput[] | null>(null)
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   )
+  const inputs = backlog.query.data?.data ?? []
+  const actionPending =
+    backlog.cancel.isPending || backlog.promote.isPending || backlog.move.isPending
 
   if (inputs.length === 0) return null
 
@@ -73,13 +74,18 @@ export function AgentInputQueue({
     if (oldIndex === -1 || newIndex === -1) return
 
     setOrderedInputs(arrayMove(visibleInputs, oldIndex, newIndex))
-    await onMove(
-      String(active.id),
-      String(over.id),
-      oldIndex < newIndex ? 'after' : 'before',
-    ).finally(() => {
-      setOrderedInputs(null)
-    })
+    await backlog.move
+      .mutateAsync({
+        inputID: String(active.id),
+        anchorInputID: String(over.id),
+        position: oldIndex < newIndex ? 'after' : 'before',
+      })
+      .catch((err: unknown) => {
+        window.alert(errorMessage(err, 'Could not reorder this message'))
+      })
+      .finally(() => {
+        setOrderedInputs(null)
+      })
   }
 
   return (
@@ -94,7 +100,7 @@ export function AgentInputQueue({
       >
         <section
           aria-label="Queued messages"
-          className="bg-muted/50 divide-border divide-y rounded-t-xl border border-b-0"
+          className="bg-muted/50 divide-border divide-y rounded-t-xl border border-b-0 [&~form]:rounded-t-none"
         >
           {visibleInputs.map((input, index) => (
             <SortableQueueRow
@@ -105,8 +111,8 @@ export function AgentInputQueue({
               canOperate={canOperate}
               canSendNow={canSendNow}
               actionPending={actionPending}
-              onSendNow={onSendNow}
-              onRemove={onRemove}
+              promote={backlog.promote}
+              cancel={backlog.cancel}
             />
           ))}
         </section>
@@ -122,8 +128,8 @@ function SortableQueueRow({
   canOperate,
   canSendNow,
   actionPending,
-  onSendNow,
-  onRemove,
+  promote,
+  cancel,
 }: {
   input: AgentInput
   index: number
@@ -131,8 +137,8 @@ function SortableQueueRow({
   canOperate: boolean
   canSendNow: boolean
   actionPending: boolean
-  onSendNow: (inputID: string) => Promise<unknown>
-  onRemove: (inputID: string) => Promise<unknown>
+  promote: AgentInputBacklog['promote']
+  cancel: AgentInputBacklog['cancel']
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: input.id,
@@ -172,7 +178,11 @@ function SortableQueueRow({
           type="button"
           disabled={actionPending}
           className="text-muted-foreground hover:text-primary shrink-0 rounded px-1.5 py-1 text-xs font-medium transition-colors disabled:pointer-events-none disabled:opacity-50"
-          onClick={() => void onSendNow(input.id)}
+          onClick={() => {
+            void promote.mutateAsync(input.id).catch((err: unknown) => {
+              window.alert(errorMessage(err, 'Could not send this message now'))
+            })
+          }}
         >
           Send now
         </button>
@@ -182,7 +192,11 @@ function SortableQueueRow({
         aria-label="Remove queued message"
         disabled={!canOperate || actionPending}
         className="text-muted-foreground hover:bg-destructive/10 hover:text-destructive shrink-0 rounded p-1 transition-colors disabled:pointer-events-none disabled:opacity-50"
-        onClick={() => void onRemove(input.id)}
+        onClick={() => {
+          void cancel.mutateAsync(input.id).catch((err: unknown) => {
+            window.alert(errorMessage(err, 'Could not remove this message'))
+          })
+        }}
       >
         <X className="size-3.5" />
       </button>

--- a/frontend/apps/web/src/components/agents/AgentInputQueue.tsx
+++ b/frontend/apps/web/src/components/agents/AgentInputQueue.tsx
@@ -73,11 +73,13 @@ export function AgentInputQueue({
     if (oldIndex === -1 || newIndex === -1) return
 
     setOrderedInputs(arrayMove(visibleInputs, oldIndex, newIndex))
-    try {
-      await onMove(String(active.id), String(over.id), oldIndex < newIndex ? 'after' : 'before')
-    } finally {
+    await onMove(
+      String(active.id),
+      String(over.id),
+      oldIndex < newIndex ? 'after' : 'before',
+    ).finally(() => {
       setOrderedInputs(null)
-    }
+    })
   }
 
   return (

--- a/frontend/apps/web/src/components/agents/AgentInputQueue.tsx
+++ b/frontend/apps/web/src/components/agents/AgentInputQueue.tsx
@@ -1,0 +1,189 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import type { AgentInput } from '@omnara/sdk'
+import { GripVertical, X } from 'lucide-react'
+import { useState } from 'react'
+
+function inputPreview(input: AgentInput) {
+  const blocks = input.content_blocks?.filter((block) => block.metadata?.omnara_hidden !== 'true')
+  const text = blocks
+    ?.flatMap((block) =>
+      block.type === 'text'
+        ? [
+            (typeof block.metadata?.omnara_display_text === 'string'
+              ? block.metadata.omnara_display_text
+              : block.text
+            ).trim(),
+          ]
+        : [],
+    )
+    .filter(Boolean)
+    .join('\n')
+  if (text != null && text !== '') return text
+  return blocks?.some((block) => block.type === 'media_ref') ? 'Attachment' : 'Message'
+}
+
+export function AgentInputQueue({
+  inputs,
+  canOperate,
+  canSendNow,
+  actionPending,
+  onSendNow,
+  onRemove,
+  onMove,
+}: {
+  inputs: AgentInput[]
+  canOperate: boolean
+  canSendNow: boolean
+  actionPending: boolean
+  onSendNow: (inputID: string) => Promise<unknown>
+  onRemove: (inputID: string) => Promise<unknown>
+  onMove: (inputID: string, anchorInputID: string, position: 'before' | 'after') => Promise<unknown>
+}) {
+  const [orderedInputs, setOrderedInputs] = useState<AgentInput[] | null>(null)
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
+
+  if (inputs.length === 0) return null
+
+  const visibleInputs = orderedInputs ?? inputs
+
+  async function handleDragEnd({ active, over }: DragEndEvent) {
+    if (over == null || active.id === over.id) return
+
+    const oldIndex = visibleInputs.findIndex((input) => input.id === active.id)
+    const newIndex = visibleInputs.findIndex((input) => input.id === over.id)
+    if (oldIndex === -1 || newIndex === -1) return
+
+    setOrderedInputs(arrayMove(visibleInputs, oldIndex, newIndex))
+    try {
+      await onMove(String(active.id), String(over.id), oldIndex < newIndex ? 'after' : 'before')
+    } finally {
+      setOrderedInputs(null)
+    }
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={(event) => void handleDragEnd(event)}
+    >
+      <SortableContext
+        items={visibleInputs.map((input) => input.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <section
+          aria-label="Queued messages"
+          className="bg-muted/50 divide-border divide-y rounded-t-xl border border-b-0"
+        >
+          {visibleInputs.map((input, index) => (
+            <SortableQueueRow
+              key={input.id}
+              input={input}
+              index={index}
+              reorderable={visibleInputs.length >= 2}
+              canOperate={canOperate}
+              canSendNow={canSendNow}
+              actionPending={actionPending}
+              onSendNow={onSendNow}
+              onRemove={onRemove}
+            />
+          ))}
+        </section>
+      </SortableContext>
+    </DndContext>
+  )
+}
+
+function SortableQueueRow({
+  input,
+  index,
+  reorderable,
+  canOperate,
+  canSendNow,
+  actionPending,
+  onSendNow,
+  onRemove,
+}: {
+  input: AgentInput
+  index: number
+  reorderable: boolean
+  canOperate: boolean
+  canSendNow: boolean
+  actionPending: boolean
+  onSendNow: (inputID: string) => Promise<unknown>
+  onRemove: (inputID: string) => Promise<unknown>
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: input.id,
+    disabled: !reorderable || !canOperate || actionPending,
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`relative flex min-w-0 items-center gap-2 px-3 py-2 ${isDragging ? 'bg-background shadow-sm' : ''}`}
+      style={{
+        transform: CSS.Transform.toString(transform && { ...transform, x: 0 }),
+        transition,
+        opacity: isDragging ? 0.7 : undefined,
+        zIndex: isDragging ? 1 : undefined,
+      }}
+    >
+      {reorderable && (
+        <button
+          type="button"
+          aria-label={`Reorder queued message ${index + 1}`}
+          title="Drag to reorder"
+          disabled={!canOperate || actionPending}
+          className="text-muted-foreground hover:text-foreground cursor-grab touch-none rounded p-1.5 transition-colors active:cursor-grabbing disabled:pointer-events-none disabled:opacity-50"
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="size-3.5" />
+        </button>
+      )}
+      <span className="text-muted-foreground w-8 shrink-0 text-xs font-medium tabular-nums">
+        {index === 0 ? 'Next' : index + 1}
+      </span>
+      <p className="text-foreground min-w-0 flex-1 truncate text-sm">{inputPreview(input)}</p>
+      {canSendNow && (
+        <button
+          type="button"
+          disabled={actionPending}
+          className="text-muted-foreground hover:text-primary shrink-0 rounded px-1.5 py-1 text-xs font-medium transition-colors disabled:pointer-events-none disabled:opacity-50"
+          onClick={() => void onSendNow(input.id)}
+        >
+          Send now
+        </button>
+      )}
+      <button
+        type="button"
+        aria-label="Remove queued message"
+        disabled={!canOperate || actionPending}
+        className="text-muted-foreground hover:bg-destructive/10 hover:text-destructive shrink-0 rounded p-1 transition-colors disabled:pointer-events-none disabled:opacity-50"
+        onClick={() => void onRemove(input.id)}
+      >
+        <X className="size-3.5" />
+      </button>
+    </div>
+  )
+}

--- a/frontend/apps/web/src/routes/AgentView.tsx
+++ b/frontend/apps/web/src/routes/AgentView.tsx
@@ -1,7 +1,6 @@
 import {
   useAgent,
   useAgentChat,
-  useAgentInputBacklog,
   useAgentInteractions,
   useAgentProfileQuery,
   useCancelAgent,
@@ -54,15 +53,10 @@ export function AgentView() {
   const interactions = useAgentInteractions(activeOrg.id, projectId, agentId, chat.isWorking)
   const resolveInteraction = useResolveAgentInteraction(activeOrg.id, projectId, agentId)
   const cancelAgent = useCancelAgent(activeOrg.id, projectId, agentId)
-  const backlogScope = { orgID: activeOrg.id, projectID: projectId, agentID: agentId }
-  const backlog = useAgentInputBacklog(backlogScope)
   const currentActorId = useCurrentActorId(activeOrg.id, projectId, me.user.id)
   const canOperate = project?.access.can_operate ?? false
   const [configOpen, setConfigOpen] = useState(false)
   const configDirty = useRef(false)
-  const queuedInputs = backlog.query.data?.data ?? []
-  const queueActionPending =
-    backlog.cancel.isPending || backlog.promote.isPending || backlog.move.isPending
   const canSendNow = canOperate && interactions.data?.data.length === 0
 
   function closeConfig() {
@@ -75,34 +69,6 @@ export function AgentView() {
     body: Parameters<typeof resolveInteraction.mutateAsync>[0]['body'],
   ) {
     return resolveInteraction.mutateAsync({ interactionID, body })
-  }
-
-  async function sendQueuedInputNow(inputID: string) {
-    try {
-      await backlog.promote.mutateAsync(inputID)
-    } catch (err) {
-      window.alert(errorMessage(err, 'Could not send this message now'))
-    }
-  }
-
-  async function removeQueuedInput(inputID: string) {
-    try {
-      await backlog.cancel.mutateAsync(inputID)
-    } catch (err) {
-      window.alert(errorMessage(err, 'Could not remove this message'))
-    }
-  }
-
-  async function moveQueuedInput(
-    inputID: string,
-    anchorInputID: string,
-    position: 'before' | 'after',
-  ) {
-    try {
-      await backlog.move.mutateAsync({ inputID, anchorInputID, position })
-    } catch (err) {
-      window.alert(errorMessage(err, 'Could not reorder this message'))
-    }
   }
 
   return (
@@ -192,35 +158,33 @@ export function AgentView() {
               canOperate={canOperate}
             />
           )}
-          {!configOpen &&
-            (archived ? (
+          {archived ? (
+            !configOpen && (
               <div className="bg-muted/30 rounded-xl border px-4 py-3 text-center">
                 <p className="text-sm font-medium">This agent is archived</p>
                 <p className="text-muted-foreground mt-1 text-xs">
                   You can view its conversation, but it can no longer receive messages.
                 </p>
               </div>
-            ) : (
-              <div className="min-w-0">
-                <AgentInputQueue
-                  inputs={queuedInputs}
-                  canOperate={canOperate}
-                  canSendNow={canSendNow}
-                  actionPending={queueActionPending}
-                  onSendNow={sendQueuedInputNow}
-                  onRemove={removeQueuedInput}
-                  onMove={moveQueuedInput}
-                />
+            )
+          ) : (
+            <div className={cn('min-w-0', configOpen && 'hidden')}>
+              <AgentInputQueue
+                scope={{ orgID: activeOrg.id, projectID: projectId, agentID: agentId }}
+                canOperate={canOperate}
+                canSendNow={canSendNow}
+              />
+              {!configOpen && (
                 <AgentComposer
                   chat={chat}
                   cancelPending={cancelAgent.isPending}
                   cancelError={cancelAgent.error}
                   onCancel={() => cancelAgent.mutateAsync()}
                   canOperate={canOperate}
-                  className={queuedInputs.length > 0 ? 'rounded-t-none' : undefined}
                 />
-              </div>
-            ))}
+              )}
+            </div>
+          )}
         </div>
       </div>
       <AgentSidebar

--- a/frontend/apps/web/src/routes/AgentView.tsx
+++ b/frontend/apps/web/src/routes/AgentView.tsx
@@ -1,6 +1,7 @@
 import {
   useAgent,
   useAgentChat,
+  useAgentInputBacklog,
   useAgentInteractions,
   useAgentProfileQuery,
   useCancelAgent,
@@ -14,6 +15,7 @@ import { type CSSProperties, useRef, useState } from 'react'
 import { AgentComposer } from '@/components/agents/AgentComposer'
 import { AgentConfigPanel, discardConfigEditsPrompt } from '@/components/agents/AgentConfigPanel'
 import { AgentConversation } from '@/components/agents/AgentConversation'
+import { AgentInputQueue } from '@/components/agents/AgentInputQueue'
 import { AgentInteractions } from '@/components/agents/AgentInteractions'
 import {
   AgentSidebar,
@@ -52,10 +54,16 @@ export function AgentView() {
   const interactions = useAgentInteractions(activeOrg.id, projectId, agentId, chat.isWorking)
   const resolveInteraction = useResolveAgentInteraction(activeOrg.id, projectId, agentId)
   const cancelAgent = useCancelAgent(activeOrg.id, projectId, agentId)
+  const backlogScope = { orgID: activeOrg.id, projectID: projectId, agentID: agentId }
+  const backlog = useAgentInputBacklog(backlogScope)
   const currentActorId = useCurrentActorId(activeOrg.id, projectId, me.user.id)
   const canOperate = project?.access.can_operate ?? false
   const [configOpen, setConfigOpen] = useState(false)
   const configDirty = useRef(false)
+  const queuedInputs = backlog.query.data?.data ?? []
+  const queueActionPending =
+    backlog.cancel.isPending || backlog.promote.isPending || backlog.move.isPending
+  const canSendNow = canOperate && interactions.data?.data.length === 0
 
   function closeConfig() {
     configDirty.current = false
@@ -67,6 +75,34 @@ export function AgentView() {
     body: Parameters<typeof resolveInteraction.mutateAsync>[0]['body'],
   ) {
     return resolveInteraction.mutateAsync({ interactionID, body })
+  }
+
+  async function sendQueuedInputNow(inputID: string) {
+    try {
+      await backlog.promote.mutateAsync(inputID)
+    } catch (err) {
+      window.alert(errorMessage(err, 'Could not send this message now'))
+    }
+  }
+
+  async function removeQueuedInput(inputID: string) {
+    try {
+      await backlog.cancel.mutateAsync(inputID)
+    } catch (err) {
+      window.alert(errorMessage(err, 'Could not remove this message'))
+    }
+  }
+
+  async function moveQueuedInput(
+    inputID: string,
+    anchorInputID: string,
+    position: 'before' | 'after',
+  ) {
+    try {
+      await backlog.move.mutateAsync({ inputID, anchorInputID, position })
+    } catch (err) {
+      window.alert(errorMessage(err, 'Could not reorder this message'))
+    }
   }
 
   return (
@@ -165,13 +201,25 @@ export function AgentView() {
                 </p>
               </div>
             ) : (
-              <AgentComposer
-                chat={chat}
-                cancelPending={cancelAgent.isPending}
-                cancelError={cancelAgent.error}
-                onCancel={() => cancelAgent.mutateAsync()}
-                canOperate={canOperate}
-              />
+              <div className="min-w-0">
+                <AgentInputQueue
+                  inputs={queuedInputs}
+                  canOperate={canOperate}
+                  canSendNow={canSendNow}
+                  actionPending={queueActionPending}
+                  onSendNow={sendQueuedInputNow}
+                  onRemove={removeQueuedInput}
+                  onMove={moveQueuedInput}
+                />
+                <AgentComposer
+                  chat={chat}
+                  cancelPending={cancelAgent.isPending}
+                  cancelError={cancelAgent.error}
+                  onCancel={() => cancelAgent.mutateAsync()}
+                  canOperate={canOperate}
+                  className={queuedInputs.length > 0 ? 'rounded-t-none' : undefined}
+                />
+              </div>
             ))}
         </div>
       </div>

--- a/frontend/packages/react/src/domains/agent-chat-session.test.ts
+++ b/frontend/packages/react/src/domains/agent-chat-session.test.ts
@@ -5,7 +5,6 @@ import {
   chatSdkMocks,
   client,
   connection,
-  controlEvent,
   createChatTestSession,
   event,
   messageText,
@@ -150,29 +149,23 @@ describe('AgentChatSession input lifecycle', () => {
     session.disconnect()
   })
 
-  it('keeps an optimistic input while cancellation races its durable event', async () => {
+  it('clears an optimistic input once the server accepts it', async () => {
     const queryClient = new QueryClient()
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue()
     const session = startSession([], client(), queryClient)
     const stream = await connection(0)
 
     await session.sendMessage({ text: 'Hello' })
-    stream.push({
-      event: 'agent_input',
-      data: controlEvent({ sequence: 12 }),
+    const accepted = read(session)
+    expect(accepted.status).toBe('ready')
+    expect(accepted.messages.some((message) => message.id.startsWith('local:'))).toBe(false)
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: [expect.objectContaining({ _id: 'listQueuedBacklogInputs' })],
     })
-    await vi.waitFor(() => {
-      expect(invalidate).toHaveBeenCalledTimes(1)
-    })
-
-    const cancelled = read(session)
-    expect(cancelled.status).toBe('submitted')
-    expect(cancelled.messages.at(-1)?.id).toMatch(/^local:/)
-    expect(messageText(cancelled.messages.at(-1))).toEqual(['Hello'])
 
     stream.push({
       event: 'agent_input',
-      data: userInputEvent({ sequence: 13, input_idempotency_key: sentIdempotencyKey() }),
+      data: userInputEvent({ sequence: 12, input_idempotency_key: sentIdempotencyKey() }),
     })
     const durable = await waitForSnapshot(
       session,
@@ -182,7 +175,7 @@ describe('AgentChatSession input lifecycle', () => {
     session.disconnect()
   })
 
-  it('keeps a pending send until its own durable event lands, not any teammate message', async () => {
+  it('keeps teammate and own durable inputs distinct after a send is accepted', async () => {
     const session = startSession()
     await connection(0)
     const stream = await connection(0)
@@ -200,9 +193,9 @@ describe('AgentChatSession input lifecycle', () => {
       }),
     })
     await waitForSnapshot(session, (state) => state.messages.some((m) => m.id === 'teammate-event'))
-    const stillPending = read(session)
-    expect(stillPending.status).toBe('submitted')
-    expect(stillPending.messages.some((message) => message.id.startsWith('local:'))).toBe(true)
+    const teammateLoaded = read(session)
+    expect(teammateLoaded.messages.some((message) => message.id.startsWith('local:'))).toBe(false)
+    expect(teammateLoaded.messages.filter((message) => message.role === 'user')).toHaveLength(1)
 
     stream.push({
       event: 'agent_input',
@@ -212,9 +205,12 @@ describe('AgentChatSession input lifecycle', () => {
         input_idempotency_key: sentIdempotencyKey(),
       }),
     })
-    const durable = await waitForSnapshot(session, (state) => state.status === 'streaming')
+    const durable = await waitForSnapshot(session, (state) =>
+      state.messages.some((message) => message.id === 'own-event'),
+    )
     expect(durable.messages.some((message) => message.id === 'own-event')).toBe(true)
     expect(durable.messages.some((message) => message.id.startsWith('local:'))).toBe(false)
+    expect(durable.messages.filter((message) => message.role === 'user')).toHaveLength(2)
     session.disconnect()
   })
 

--- a/frontend/packages/react/src/domains/agent-chat-stream.test.ts
+++ b/frontend/packages/react/src/domains/agent-chat-stream.test.ts
@@ -396,7 +396,13 @@ describe('AgentChatSession streaming', () => {
 
     stream.push({ event: 'agent_input', data: userInputEvent() })
     await waitForSnapshot(session, (s) => s.status === 'streaming')
-    expect(invalidate).not.toHaveBeenCalled()
+    await vi.waitFor(() => {
+      expect(invalidate).toHaveBeenCalledTimes(1)
+    })
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: [expect.objectContaining({ _id: 'listQueuedBacklogInputs' })],
+    })
+    invalidate.mockClear()
 
     stream.push({
       event: 'model_output',

--- a/frontend/packages/react/src/domains/agent-chat.ts
+++ b/frontend/packages/react/src/domains/agent-chat.ts
@@ -29,6 +29,7 @@ import {
   projectAgentChat,
   sequenceNumber,
 } from './agent-chat-messages'
+import { agentInputBacklogQueryKey } from './agent-input-backlog'
 import { openAgentInteractionsQueryKey } from './agent-interactions'
 
 export type {
@@ -172,7 +173,10 @@ export class AgentChatSession {
         },
       })
       this.lastFailedSend = null
-      if (this.inputEchoLoaded(id)) this.clearPendingInput(id)
+      this.clearPendingInput(id)
+      void this.queryClient.invalidateQueries({
+        queryKey: agentInputBacklogQueryKey(this.client, this.scope),
+      })
       void this.queryClient.invalidateQueries({
         predicate: projectActorsQueryPredicate(this.scope.orgID, this.scope.projectID),
       })
@@ -253,6 +257,11 @@ export class AgentChatSession {
       }
       void this.queryClient.invalidateQueries({
         predicate: projectActorsQueryPredicate(this.scope.orgID, this.scope.projectID),
+      })
+    }
+    if (event.event_kind === 'agent_input' && event.input_kind === 'content') {
+      void this.queryClient.invalidateQueries({
+        queryKey: agentInputBacklogQueryKey(this.client, this.scope),
       })
     }
     if (event.event_kind === 'model_output') {

--- a/frontend/packages/react/src/domains/agent-input-backlog.ts
+++ b/frontend/packages/react/src/domains/agent-input-backlog.ts
@@ -1,0 +1,79 @@
+import { type OmnaraClient, sdk } from '@omnara/sdk'
+import {
+  listQueuedBacklogInputsOptions,
+  listQueuedBacklogInputsQueryKey,
+} from '@omnara/sdk/tanstack'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { useOmnaraClient } from '../omnara-client'
+
+const backlogQuery = { limit: 100 } as const
+
+interface AgentInputBacklogScope {
+  orgID: string
+  projectID: string
+  agentID: string
+}
+
+export function agentInputBacklogQueryKey(client: OmnaraClient, path: AgentInputBacklogScope) {
+  return listQueuedBacklogInputsQueryKey({ path, query: backlogQuery, client })
+}
+
+export function useAgentInputBacklog(path: AgentInputBacklogScope) {
+  const client = useOmnaraClient()
+  const queryClient = useQueryClient()
+  const query = useQuery(listQueuedBacklogInputsOptions({ path, query: backlogQuery, client }))
+  const cancel = useMutation({
+    mutationFn: async (inputID: string) => {
+      const { data } = await sdk.cancelQueuedBacklogInput({
+        path: { ...path, inputID },
+        client,
+      })
+      return data
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: agentInputBacklogQueryKey(client, path),
+      })
+    },
+  })
+  const promote = useMutation({
+    mutationFn: async (inputID: string) => {
+      const { data } = await sdk.promoteQueuedInputToSteering({
+        path: { ...path, inputID },
+        client,
+      })
+      return data
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: agentInputBacklogQueryKey(client, path),
+      })
+    },
+  })
+  const move = useMutation({
+    mutationFn: async ({
+      inputID,
+      anchorInputID,
+      position,
+    }: {
+      inputID: string
+      anchorInputID: string
+      position: 'before' | 'after'
+    }) => {
+      const { data } = await sdk.moveQueuedBacklogInput({
+        path: { ...path, inputID },
+        body: { position, anchor_input_id: anchorInputID },
+        client,
+      })
+      return data
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: agentInputBacklogQueryKey(client, path),
+      })
+    },
+  })
+
+  return { query, cancel, promote, move }
+}

--- a/frontend/packages/react/src/index.ts
+++ b/frontend/packages/react/src/index.ts
@@ -12,6 +12,7 @@ export {
   useAgentChat,
   type UseAgentChatResult,
 } from './domains/agent-chat'
+export { useAgentInputBacklog } from './domains/agent-input-backlog'
 export {
   useAgentInteractions,
   useCancelAgent,

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -47,6 +47,15 @@ importers:
       '@base-ui/react':
         specifier: ^1.6.0
         version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.7)
       '@fontsource-variable/geist':
         specifier: ^5.2.8
         version: 5.2.9
@@ -450,6 +459,28 @@ packages:
   '@clack/prompts@1.7.0':
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@dotenvx/dotenvx@1.75.1':
     resolution: {integrity: sha512-/BITOC9dmS/edY2zQwZNicQ059O6RKabtQfyEafV0nGtfYRNHYy1DIPiYVcov40+tob9hfmBnbR963dS+EQ1DQ==}
@@ -5753,6 +5784,31 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      react: 19.2.7
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
 
   '@dotenvx/dotenvx@1.75.1':
     dependencies:

--- a/internal/httpapi/public_api_events_workflow_integration_test.go
+++ b/internal/httpapi/public_api_events_workflow_integration_test.go
@@ -207,9 +207,11 @@ func TestPublicAuthenticatedInputFlow(t *testing.T) {
 		http.StatusOK,
 		authHeaders(viewerPAT.Token),
 	)
-	if len(viewerBacklog["data"].([]any)) != 2 {
+	viewerBacklogData := viewerBacklog["data"].([]any)
+	if len(viewerBacklogData) != 2 ||
+		!publicEventTextEquals(viewerBacklogData[0].(map[string]any), "first") {
 		t.Fatalf(
-			"viewer should be able to read queued backlog, got %+v",
+			"viewer should be able to read queued backlog content, got %+v",
 			viewerBacklog,
 		)
 	}

--- a/internal/httpapi/public_projection.go
+++ b/internal/httpapi/public_projection.go
@@ -195,7 +195,7 @@ func publicToolResultFromRecord(
 }
 
 func publicAgentInputResponseFromRecord(record executionstore.AgentInputRecord) (openapi.AgentInput, error) {
-	return publicAgentInputResponseFromRecordWithContent(record, nil)
+	return publicAgentInputResponseFromRecordWithContent(record, record.ContentBlocks)
 }
 
 func publicAgentInputResponseFromRecordWithContent(

--- a/internal/storage/executionstore/agent_content_inputs_store.go
+++ b/internal/storage/executionstore/agent_content_inputs_store.go
@@ -157,16 +157,17 @@ func createAgentContentInputTx(
 			if err != nil {
 				return createAgentContentInputTxResult{}, err
 			}
-			existingContentBlocks, err := agentInputContentBlocksTx(
+			existingContentBlocksByInput, err := agentInputContentBlocks(
 				ctx,
-				tx,
+				qtx,
 				existingInput.ProjectID,
 				existingInput.AgentID,
-				existingInput.ID,
+				[]ID{existingInput.ID},
 			)
 			if err != nil {
 				return createAgentContentInputTxResult{}, err
 			}
+			existingContentBlocks := existingContentBlocksByInput[existingInput.ID]
 			if !actorFound ||
 				existingInput.DeliveryMode != input.DeliveryMode ||
 				existingInput.ActorID != existingActorID ||
@@ -274,21 +275,25 @@ func createAgentInputContentBlocksTx(
 	return nil
 }
 
-func agentInputContentBlocksTx(
+func agentInputContentBlocks(
 	ctx context.Context,
-	tx pgx.Tx,
-	projectID, agentID, inputID ID,
-) (json.RawMessage, error) {
-	rows, err := dbsqlc.New(tx).
-		ListContentBlocksForAgentInput(ctx, dbsqlc.ListContentBlocksForAgentInputParams{
-			ProjectID:    projectID,
-			AgentID:      agentID,
-			AgentInputID: &inputID,
-		})
+	q *dbsqlc.Queries,
+	projectID, agentID ID,
+	inputIDs []ID,
+) (map[ID]json.RawMessage, error) {
+	contentBlocks := make(map[ID]json.RawMessage, len(inputIDs))
+	if len(inputIDs) == 0 {
+		return contentBlocks, nil
+	}
+	rows, err := q.ListContentBlocksForAgentInputs(ctx, dbsqlc.ListContentBlocksForAgentInputsParams{
+		ProjectID:     projectID,
+		AgentID:       agentID,
+		AgentInputIds: inputIDs,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("list agent input content blocks: %w", err)
 	}
-	blocks := make([]CreateContentBlockInput, 0, len(rows))
+	blocksByInput := make(map[ID][]CreateContentBlockInput, len(inputIDs))
 	for _, row := range rows {
 		metadata, err := resourcemeta.FromJSON(row.Metadata)
 		if err != nil {
@@ -303,13 +308,17 @@ func agentInputContentBlocksTx(
 		if row.ArtifactID != nil {
 			block.ArtifactID = *row.ArtifactID
 		}
-		blocks = append(blocks, block)
+		inputID := *row.OwnerAgentInputID
+		blocksByInput[inputID] = append(blocksByInput[inputID], block)
 	}
-	body, err := marshalAgentInputContentBlocks(blocks)
-	if err != nil {
-		return nil, fmt.Errorf("marshal agent input content parts: %w", err)
+	for _, inputID := range inputIDs {
+		body, err := marshalAgentInputContentBlocks(blocksByInput[inputID])
+		if err != nil {
+			return nil, fmt.Errorf("marshal agent input content parts: %w", err)
+		}
+		contentBlocks[inputID] = body
 	}
-	return body, nil
+	return contentBlocks, nil
 }
 
 type CreateAgentContentInputInput struct {

--- a/internal/storage/executionstore/agent_inputs_ingress_store.go
+++ b/internal/storage/executionstore/agent_inputs_ingress_store.go
@@ -35,6 +35,7 @@ type AgentInputRecord struct {
 	ResolvedAt          *time.Time             `json:"resolved_at,omitempty"`
 	RejectedReason      string                 `json:"rejected_reason,omitempty"`
 	Metadata            json.RawMessage        `json:"metadata"`
+	ContentBlocks       json.RawMessage        `json:"-"`
 }
 
 type AgentInputQueueCursor struct {

--- a/internal/storage/executionstore/agent_inputs_store.go
+++ b/internal/storage/executionstore/agent_inputs_store.go
@@ -473,8 +473,18 @@ func (s *Store) ListQueuedBacklogInputs(
 		rows = rows[:input.Limit]
 	}
 	result.Inputs = make([]AgentInputRecord, 0, len(rows))
+	inputIDs := make([]ID, 0, len(rows))
 	for _, row := range rows {
-		result.Inputs = append(result.Inputs, agentInputRecordFromBacklogSQLC(row))
+		record := agentInputRecordFromBacklogSQLC(row)
+		result.Inputs = append(result.Inputs, record)
+		inputIDs = append(inputIDs, record.ID)
+	}
+	contentBlocks, err := agentInputContentBlocks(ctx, s.q, input.ProjectID, input.AgentID, inputIDs)
+	if err != nil {
+		return ListQueuedBacklogInputsResult{}, err
+	}
+	for index := range result.Inputs {
+		result.Inputs[index].ContentBlocks = contentBlocks[result.Inputs[index].ID]
 	}
 	return result, nil
 }

--- a/internal/storage/internal/dbsqlc/kernel_event_authority.sql.go
+++ b/internal/storage/internal/dbsqlc/kernel_event_authority.sql.go
@@ -885,7 +885,7 @@ func (q *Queries) InsertTypedAgentEvent(ctx context.Context, arg InsertTypedAgen
 	return i, err
 }
 
-const listContentBlocksForAgentInput = `-- name: ListContentBlocksForAgentInput :many
+const listContentBlocksForAgentInputs = `-- name: ListContentBlocksForAgentInputs :many
 SELECT block.id, agent.project_id, block.agent_id, block.owner_kind,
        block.owner_agent_input_id, block.owner_model_output_id,
        block.owner_tool_call_result_id, block.ordinal, block.block_kind,
@@ -895,17 +895,17 @@ FROM content_blocks block
 JOIN agents agent ON agent.id = block.agent_id
 WHERE agent.project_id = $1
   AND block.agent_id = $2
-  AND block.owner_agent_input_id = $3
-ORDER BY block.ordinal ASC, block.id ASC
+  AND block.owner_agent_input_id = ANY($3::uuid[])
+ORDER BY block.owner_agent_input_id ASC, block.ordinal ASC, block.id ASC
 `
 
-type ListContentBlocksForAgentInputParams struct {
-	ProjectID    uuid.UUID
-	AgentID      uuid.UUID
-	AgentInputID *uuid.UUID
+type ListContentBlocksForAgentInputsParams struct {
+	ProjectID     uuid.UUID
+	AgentID       uuid.UUID
+	AgentInputIds []uuid.UUID
 }
 
-type ListContentBlocksForAgentInputRow struct {
+type ListContentBlocksForAgentInputsRow struct {
 	ID                    uuid.UUID
 	ProjectID             uuid.UUID
 	AgentID               uuid.UUID
@@ -923,15 +923,15 @@ type ListContentBlocksForAgentInputRow struct {
 	CreatedAt             time.Time
 }
 
-func (q *Queries) ListContentBlocksForAgentInput(ctx context.Context, arg ListContentBlocksForAgentInputParams) ([]ListContentBlocksForAgentInputRow, error) {
-	rows, err := q.db.Query(ctx, listContentBlocksForAgentInput, arg.ProjectID, arg.AgentID, arg.AgentInputID)
+func (q *Queries) ListContentBlocksForAgentInputs(ctx context.Context, arg ListContentBlocksForAgentInputsParams) ([]ListContentBlocksForAgentInputsRow, error) {
+	rows, err := q.db.Query(ctx, listContentBlocksForAgentInputs, arg.ProjectID, arg.AgentID, arg.AgentInputIds)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ListContentBlocksForAgentInputRow{}
+	items := []ListContentBlocksForAgentInputsRow{}
 	for rows.Next() {
-		var i ListContentBlocksForAgentInputRow
+		var i ListContentBlocksForAgentInputsRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.ProjectID,

--- a/internal/storage/queries/kernel_event_authority.sql
+++ b/internal/storage/queries/kernel_event_authority.sql
@@ -325,7 +325,7 @@ WHERE agent.project_id = sqlc.arg(project_id)
   AND block.owner_model_output_id = sqlc.arg(model_output_id)
 ORDER BY block.ordinal ASC, block.id ASC;
 
--- name: ListContentBlocksForAgentInput :many
+-- name: ListContentBlocksForAgentInputs :many
 SELECT block.id, agent.project_id, block.agent_id, block.owner_kind,
        block.owner_agent_input_id, block.owner_model_output_id,
        block.owner_tool_call_result_id, block.ordinal, block.block_kind,
@@ -335,8 +335,8 @@ FROM content_blocks block
 JOIN agents agent ON agent.id = block.agent_id
 WHERE agent.project_id = sqlc.arg(project_id)
   AND block.agent_id = sqlc.arg(agent_id)
-  AND block.owner_agent_input_id = sqlc.arg(agent_input_id)
-ORDER BY block.ordinal ASC, block.id ASC;
+  AND block.owner_agent_input_id = ANY(sqlc.arg(agent_input_ids)::uuid[])
+ORDER BY block.owner_agent_input_id ASC, block.ordinal ASC, block.id ASC;
 
 -- name: GetToolCallProviderCallID :one
 SELECT provider_call_id


### PR DESCRIPTION
- show queued steering messages with their actual content while an agent is working
- let users send queued messages immediately, remove them, or drag to reorder when multiple messages are waiting
- keep the queue synchronized with agent input events and load queued content blocks with a single batched query