### PR TITLE
feat: support home-relative machine paths

### DIFF
--- a/docs/machines/overview.mdx
+++ b/docs/machines/overview.mdx
@@ -65,6 +65,8 @@ A binding stores the working directory and environment for that agent. It also g
 ]
 ```
 
+In working-directory values, `~` and paths beginning with `~/` resolve using the machine daemon's home environment (`HOME` on macOS and Linux or `USERPROFILE` on Windows). The process fails to start if that value is unavailable. Omnara does not expand `~user`, environment variables, or globs.
+
 Bindings remain `attached` until released. Releasing a pool binding schedules its machine for deletion; releasing a BYO binding only detaches it from the agent. Archiving an agent releases all of its bindings. The [command and process tools](/tools/built-in#commands) use these bindings.
 
 ## Reading order

--- a/docs/machines/overview.mdx
+++ b/docs/machines/overview.mdx
@@ -65,8 +65,6 @@ A binding stores the working directory and environment for that agent. It also g
 ]
 ```
 
-In working-directory values, `~` and paths beginning with `~/` resolve using the machine daemon's home environment (`HOME` on macOS and Linux or `USERPROFILE` on Windows). The process fails to start if that value is unavailable. Omnara does not expand `~user`, environment variables, or globs.
-
 Bindings remain `attached` until released. Releasing a pool binding schedules its machine for deletion; releasing a BYO binding only detaches it from the agent. Archiving an agent releases all of its bindings. The [command and process tools](/tools/built-in#commands) use these bindings.
 
 ## Reading order

--- a/internal/machinedaemon/runner_subprocess.go
+++ b/internal/machinedaemon/runner_subprocess.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/omnara-ai/omnara/internal/machinedaemon/localstore"
 	"github.com/omnara-ai/omnara/internal/machinedaemon/statedb"
+	"github.com/omnara-ai/omnara/internal/processcmd"
 )
 
 const (
@@ -43,11 +44,12 @@ func (subprocessRunnerLauncher) Prepare(
 	assignment ProcessAssignment,
 ) (*processRuntime, error) {
 	if assignment.PreparationError == "" {
-		canonicalCwd, err := filepath.Abs(assignment.Process.Cwd)
+		canonicalCwd, err := canonicalProcessCwd(assignment.Process.Cwd, os.UserHomeDir)
 		if err != nil {
-			return nil, err
+			assignment.PreparationError = err.Error()
+		} else {
+			assignment.Process.Cwd = canonicalCwd
 		}
-		assignment.Process.Cwd = canonicalCwd
 	}
 	machine, err := c.machineStore()
 	if err != nil {
@@ -319,6 +321,24 @@ func (subprocessRunnerLauncher) Prepare(
 		return runtime, fail(err)
 	}
 	return runtime, nil
+}
+
+func canonicalProcessCwd(cwd string, userHomeDir func() (string, error)) (string, error) {
+	if processcmd.IsHomeRelativeCwd(cwd) {
+		home, err := userHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve process working directory home: %w", err)
+		}
+		if home == "" {
+			return "", errors.New("resolve process working directory home: home is empty")
+		}
+		if cwd == "~" {
+			cwd = home
+		} else {
+			cwd = filepath.Join(home, cwd[2:])
+		}
+	}
+	return filepath.Abs(cwd)
 }
 
 func (r *ipcProcessRunner) prepare(

--- a/internal/machinedaemon/runner_subprocess_test.go
+++ b/internal/machinedaemon/runner_subprocess_test.go
@@ -1,0 +1,66 @@
+package machinedaemon
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestCanonicalProcessCwd(t *testing.T) {
+	home := t.TempDir()
+	relative, err := filepath.Abs("relative")
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherUser, err := filepath.Abs("~other")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name           string
+		cwd            string
+		want           string
+		wantHomeLookup bool
+	}{
+		{name: "home", cwd: "~", want: home, wantHomeLookup: true},
+		{name: "home slash", cwd: "~/", want: home, wantHomeLookup: true},
+		{name: "home relative", cwd: "~/repo", want: filepath.Join(home, "repo"), wantHomeLookup: true},
+		{name: "home parent", cwd: "~/repo/../other", want: filepath.Join(home, "other"), wantHomeLookup: true},
+		{name: "absolute", cwd: home, want: home},
+		{name: "relative", cwd: "relative", want: relative},
+		{name: "other user", cwd: "~other", want: otherUser},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			homeLookups := 0
+			got, err := canonicalProcessCwd(test.cwd, func() (string, error) {
+				homeLookups++
+				return home, nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Fatalf("canonical cwd = %q, want %q", got, test.want)
+			}
+			if (homeLookups > 0) != test.wantHomeLookup {
+				t.Fatalf("home lookups = %d, want lookup %t", homeLookups, test.wantHomeLookup)
+			}
+		})
+	}
+}
+
+func TestCanonicalProcessCwdRequiresHome(t *testing.T) {
+	homeErr := errors.New("missing home")
+	_, err := canonicalProcessCwd("~/repo", func() (string, error) {
+		return "", homeErr
+	})
+	if !errors.Is(err, homeErr) {
+		t.Fatalf("canonical cwd error = %v, want %v", err, homeErr)
+	}
+	if _, err := canonicalProcessCwd("~/repo", func() (string, error) {
+		return "", nil
+	}); err == nil {
+		t.Fatal("expected empty home error")
+	}
+}

--- a/internal/machinedaemon/supervisor_subprocess_test.go
+++ b/internal/machinedaemon/supervisor_subprocess_test.go
@@ -937,6 +937,37 @@ func TestDetachedSupervisorPreparationErrorNeedsNoCommand(t *testing.T) {
 	}
 }
 
+func TestDetachedSupervisorCwdHomeErrorIsTerminal(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test requires Unix HOME semantics")
+	}
+	t.Setenv("HOME", "")
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	fixture := newDetachedSupervisorTestFixture(
+		t,
+		ctx,
+		ProcessAssignment{
+			ID: "prc_cwd_home_error",
+			Process: Process{
+				Cwd: "~/repo",
+			},
+		},
+	)
+	fixture.acceptAndStart(t, ctx)
+	process := fixture.waitClosed(t, 10*time.Second)
+	if process.ExecCommitted || process.Phase != statedb.ProcessTerminal {
+		t.Fatalf("cwd home failure state = %+v", process)
+	}
+	_, terminal := fixture.terminalEvent(t)
+	if terminal.State != "failed" ||
+		terminal.StateReasonCode != "start_failed" ||
+		!strings.Contains(terminal.StateReasonMessage, "resolve process working directory home") {
+		t.Fatalf("cwd home failure evidence = %+v", terminal)
+	}
+}
+
 func TestDetachedSupervisorFastExitFreezesOnlyTerminalReport(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/processcmd/processcmd.go
+++ b/internal/processcmd/processcmd.go
@@ -84,6 +84,10 @@ func NormalizeIOMode(value IOMode) (IOMode, error) {
 	}
 }
 
+func IsHomeRelativeCwd(cwd string) bool {
+	return cwd == "~" || strings.HasPrefix(cwd, "~/")
+}
+
 func ResolveShellCommand(command string, shell ShellSelector, goos string) ([]string, error) {
 	spec, err := NormalizeShellCommand(command, shell)
 	if err != nil {

--- a/internal/storage/executionstore/machine_config.go
+++ b/internal/storage/executionstore/machine_config.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/omnara-ai/omnara/internal/agentconfig"
+	"github.com/omnara-ai/omnara/internal/processcmd"
 	"github.com/omnara-ai/omnara/internal/publicid"
 	"github.com/omnara-ai/omnara/internal/secrets"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
@@ -913,8 +914,14 @@ func resolveProcessCwd(machineCwd, bindingCwd, requestedCwd string) string {
 	if requestedCwd == "" {
 		return base
 	}
+	if processcmd.IsHomeRelativeCwd(requestedCwd) {
+		return requestedCwd
+	}
 	if path.IsAbs(requestedCwd) || base == "" {
 		return path.Clean(requestedCwd)
+	}
+	if processcmd.IsHomeRelativeCwd(base) {
+		return strings.TrimSuffix(base, "/") + "/" + requestedCwd
 	}
 	return path.Join(base, requestedCwd)
 }

--- a/internal/storage/executionstore/machine_config_store_test.go
+++ b/internal/storage/executionstore/machine_config_store_test.go
@@ -499,6 +499,18 @@ func TestResolveProcessCwd(t *testing.T) {
 	if got := resolveProcessCwd("/machine", "/binding", "/requested"); got != "/requested" {
 		t.Fatalf("resolved absolute process cwd = %q, want /requested", got)
 	}
+	if got := resolveProcessCwd("/machine", "/binding", "~"); got != "~" {
+		t.Fatalf("resolved home process cwd = %q, want ~", got)
+	}
+	if got := resolveProcessCwd("/machine", "/binding", "~/requested"); got != "~/requested" {
+		t.Fatalf("resolved home-relative process cwd = %q, want ~/requested", got)
+	}
+	if got := resolveProcessCwd("~/machine", "", "src"); got != "~/machine/src" {
+		t.Fatalf("resolved relative home machine cwd = %q, want ~/machine/src", got)
+	}
+	if got := resolveProcessCwd("/machine", "~/binding", "../src"); got != "~/binding/../src" {
+		t.Fatalf("resolved relative home binding cwd = %q, want ~/binding/../src", got)
+	}
 }
 
 func TestCheckLaunchAggregateCap(t *testing.T) {


### PR DESCRIPTION
- Preserve home-relative working directories through machine, binding, and command-level path resolution.
- Expand ~ and ~/ paths on the machine daemon using its home environment, with failures reported through the existing terminal start-failure flow.
- Cover path composition, canonicalization, and missing-home behavior.