### PR TITLE
fix: surface insufficient Omnara credit errors

### DIFF
--- a/frontend/apps/web/src/components/agents/AgentChatMessage.tsx
+++ b/frontend/apps/web/src/components/agents/AgentChatMessage.tsx
@@ -4,10 +4,15 @@ import { useQuery } from '@tanstack/react-query'
 import { Streamdown } from 'streamdown'
 
 import { AgentAttachment } from '@/components/agents/AgentAttachment'
+import { InsufficientCreditsMessage } from '@/components/agents/InsufficientCreditsMessage'
 import { Brain, Check, ChevronRight, CircleDashed, Terminal } from '@/components/icons'
 import { Bubble, BubbleContent } from '@/components/ui/bubble'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { Message, MessageContent, MessageHeader } from '@/components/ui/message'
+import {
+  isInsufficientCreditsModelError,
+  isInsufficientCreditsToolError,
+} from '@/lib/insufficient-credits'
 
 function ActorLabel({
   actorID,
@@ -110,16 +115,25 @@ export function AgentChatMessage({
   currentActorId,
   orgID,
   projectID,
+  insufficientCredits,
 }: {
   message: OmnaraUIMessage
   currentActorId?: string
   orgID: string
   projectID: string
+  insufficientCredits?: { billingHref?: string }
 }) {
   const metadata = message.metadata
   const mine =
     message.role === 'user' &&
     (metadata == null || (metadata.actorId != null && metadata.actorId === currentActorId))
+  const showInsufficientCredits =
+    insufficientCredits != null &&
+    message.parts.some(
+      (part) =>
+        (part.type === 'data-model-error' && isInsufficientCreditsModelError(part.data.text)) ||
+        (part.type === 'dynamic-tool' && isInsufficientCreditsToolError(part.toolErrorCode)),
+    )
 
   return (
     <Message align={mine ? 'end' : 'start'}>
@@ -172,6 +186,9 @@ export function AgentChatMessage({
             return <AgentConfigDivider key={part.id} action={part.data.action} />
           }
           if (part.type === 'data-model-error') {
+            if (showInsufficientCredits && isInsufficientCreditsModelError(part.data.text)) {
+              return null
+            }
             return (
               <Bubble key={part.id} align="start" variant="destructive">
                 <BubbleContent className="whitespace-pre-wrap">{part.data.text}</BubbleContent>
@@ -184,6 +201,13 @@ export function AgentChatMessage({
           if (part.type === 'dynamic-tool') return <ToolPart key={part.id} part={part} />
           return null
         })}
+        {showInsufficientCredits && (
+          <Bubble align="start" variant="destructive">
+            <BubbleContent className="whitespace-pre-wrap">
+              <InsufficientCreditsMessage billingHref={insufficientCredits.billingHref} />
+            </BubbleContent>
+          </Bubble>
+        )}
       </MessageContent>
     </Message>
   )

--- a/frontend/apps/web/src/components/agents/AgentChatMessage.tsx
+++ b/frontend/apps/web/src/components/agents/AgentChatMessage.tsx
@@ -13,6 +13,7 @@ import {
   isInsufficientCreditsModelError,
   isInsufficientCreditsToolError,
 } from '@/lib/insufficient-credits'
+import { useWebConfig } from '@/lib/web-config'
 
 function ActorLabel({
   actorID,
@@ -115,20 +116,19 @@ export function AgentChatMessage({
   currentActorId,
   orgID,
   projectID,
-  insufficientCredits,
 }: {
   message: OmnaraUIMessage
   currentActorId?: string
   orgID: string
   projectID: string
-  insufficientCredits?: { billingHref?: string }
 }) {
+  const { data: webConfig } = useWebConfig()
   const metadata = message.metadata
   const mine =
     message.role === 'user' &&
     (metadata == null || (metadata.actorId != null && metadata.actorId === currentActorId))
   const showInsufficientCredits =
-    insufficientCredits != null &&
+    Boolean(webConfig?.billingURL) &&
     message.parts.some(
       (part) =>
         (part.type === 'data-model-error' && isInsufficientCreditsModelError(part.data.text)) ||
@@ -204,7 +204,7 @@ export function AgentChatMessage({
         {showInsufficientCredits && (
           <Bubble align="start" variant="destructive">
             <BubbleContent className="whitespace-pre-wrap">
-              <InsufficientCreditsMessage billingHref={insufficientCredits.billingHref} />
+              <InsufficientCreditsMessage billingHref={webConfig?.billingHref} />
             </BubbleContent>
           </Bubble>
         )}

--- a/frontend/apps/web/src/components/agents/AgentConversation.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConversation.tsx
@@ -12,6 +12,7 @@ import {
   MessageScrollerViewport,
 } from '@/components/ui/message-scroller'
 import { Skeleton } from '@/components/ui/skeleton'
+import { useWebConfig } from '@/lib/web-config'
 
 export function AgentConversation({
   chat,
@@ -24,6 +25,11 @@ export function AgentConversation({
   orgID: string
   projectID: string
 }) {
+  const { data: webConfig } = useWebConfig()
+  const insufficientCredits = webConfig?.billingURL
+    ? { billingHref: webConfig.billingHref }
+    : undefined
+
   return (
     <MessageScrollerProvider>
       <MessageScroller>
@@ -78,6 +84,7 @@ export function AgentConversation({
                       currentActorId={currentActorId}
                       orgID={orgID}
                       projectID={projectID}
+                      insufficientCredits={insufficientCredits}
                     />
                   </MessageScrollerItem>
                 ))}

--- a/frontend/apps/web/src/components/agents/AgentConversation.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConversation.tsx
@@ -12,7 +12,6 @@ import {
   MessageScrollerViewport,
 } from '@/components/ui/message-scroller'
 import { Skeleton } from '@/components/ui/skeleton'
-import { useWebConfig } from '@/lib/web-config'
 
 export function AgentConversation({
   chat,
@@ -25,11 +24,6 @@ export function AgentConversation({
   orgID: string
   projectID: string
 }) {
-  const { data: webConfig } = useWebConfig()
-  const insufficientCredits = webConfig?.billingURL
-    ? { billingHref: webConfig.billingHref }
-    : undefined
-
   return (
     <MessageScrollerProvider>
       <MessageScroller>
@@ -84,7 +78,6 @@ export function AgentConversation({
                       currentActorId={currentActorId}
                       orgID={orgID}
                       projectID={projectID}
-                      insufficientCredits={insufficientCredits}
                     />
                   </MessageScrollerItem>
                 ))}

--- a/frontend/apps/web/src/components/agents/AgentProfilesSection.tsx
+++ b/frontend/apps/web/src/components/agents/AgentProfilesSection.tsx
@@ -3,12 +3,16 @@ import { type AgentProfile, ApiError } from '@omnara/sdk'
 import { Link, useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 
+import { InsufficientCreditsMessage } from '@/components/agents/InsufficientCreditsMessage'
 import { SlackOAuthOutcomeDialog } from '@/components/agents/SlackOAuthOutcomeDialog'
 import { DataTable } from '@/components/data-table/DataTable'
 import { ResourceListToolbar } from '@/components/data-table/ResourceListToolbar'
+import { TriangleAlert } from '@/components/icons'
 import { Button } from '@/components/ui/button'
 import { usePagedQuery } from '@/hooks/use-paged-query'
 import { resourceSortOptions, useResourceList } from '@/hooks/use-resource-list'
+import { isInsufficientCreditsError } from '@/lib/insufficient-credits'
+import { useWebConfig } from '@/lib/web-config'
 
 export function AgentProfilesSection({
   orgId,
@@ -29,10 +33,13 @@ export function AgentProfilesSection({
   const paged = usePagedQuery(query, list.queryKey)
   const showToolbar = list.isFiltering || paged.pagination.page > 0 || paged.pagination.canNext
   const createAgent = useCreateAgent(orgId, projectId)
+  const { data: webConfig } = useWebConfig()
   const navigate = useNavigate()
   const [launchingId, setLaunchingId] = useState<string | null>(null)
+  const [launchError, setLaunchError] = useState<ApiError>()
 
   async function launch(profile: AgentProfile) {
+    setLaunchError(undefined)
     setLaunchingId(profile.id)
     try {
       const launched = await createAgent.mutateAsync({
@@ -44,7 +51,11 @@ export function AgentProfilesSection({
         params: { projectId, agentId: launched.agent.id },
       })
     } catch (error) {
-      window.alert(error instanceof ApiError ? error.message : 'Could not launch agent')
+      if (isInsufficientCreditsError(error)) {
+        setLaunchError(error)
+      } else {
+        window.alert(error instanceof ApiError ? error.message : 'Could not launch agent')
+      }
     }
     setLaunchingId(null)
   }
@@ -52,6 +63,19 @@ export function AgentProfilesSection({
   return (
     <>
       <div className="flex flex-col gap-3">
+        {launchError && (
+          <div
+            className="border-destructive/30 bg-destructive/5 text-destructive flex items-start gap-2 rounded-md border px-3 py-2 text-sm"
+            role="alert"
+          >
+            <TriangleAlert className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+            {webConfig?.billingURL ? (
+              <InsufficientCreditsMessage billingHref={webConfig.billingHref} />
+            ) : (
+              launchError.message
+            )}
+          </div>
+        )}
         <div className="flex flex-wrap items-center justify-between gap-2">
           <h2 className="text-2xl font-bold tracking-tight">Agent profiles</h2>
           {canManage && (

--- a/frontend/apps/web/src/components/agents/CreateAgentFormView.tsx
+++ b/frontend/apps/web/src/components/agents/CreateAgentFormView.tsx
@@ -4,7 +4,8 @@ import {
   useCreateAgentProfile,
   useUpdateAgentProfile,
 } from '@omnara/react'
-import type { ConfiguredModelSummary, MachinePoolSummary, ToolCatalog } from '@omnara/sdk'
+import type { ApiError } from '@omnara/sdk'
+import { type ConfiguredModelSummary, type MachinePoolSummary, type ToolCatalog } from '@omnara/sdk'
 import { useNavigate } from '@tanstack/react-router'
 import { type SyntheticEvent, useReducer, useRef, useState } from 'react'
 
@@ -25,6 +26,7 @@ import {
   defaultAgentTools,
 } from '@/components/agents/agentTemplates'
 import { ConfirmDiscardYamlDialog } from '@/components/agents/ConfirmDiscardYamlDialog'
+import { InsufficientCreditsMessage } from '@/components/agents/InsufficientCreditsMessage'
 import { takeMcpBuilderOAuthRestore } from '@/components/agents/pendingMcpBuilderOAuth'
 import { PillTabs } from '@/components/agents/PillTabs'
 import {
@@ -38,11 +40,13 @@ import { Button } from '@/components/ui/button'
 import { Field, FieldGroup, RequiredFieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import { ResourceNameFieldError } from '@/components/ui/resource-name-error'
+import { isInsufficientCreditsError } from '@/lib/insufficient-credits'
 import { resourceNameValid } from '@/lib/resource-name'
 import type { SubmitStatus } from '@/lib/submit-status'
 import { idle, settleSubmission, statusError, submitError, submitting } from '@/lib/submit-status'
 import { useProjectPage } from '@/lib/use-project-page'
 import { cn } from '@/lib/utils'
+import { useWebConfig } from '@/lib/web-config'
 
 type SubmitAction = 'profile' | 'launch'
 
@@ -76,6 +80,7 @@ export function CreateAgentFormView({
   const createAgentProfile = useCreateAgentProfile(activeOrg.id, projectId)
   const updateAgentProfile = useUpdateAgentProfile(activeOrg.id, projectId)
   const createAgent = useCreateAgent(activeOrg.id, projectId)
+  const { data: webConfig } = useWebConfig()
   const navigate = useNavigate()
   const [mode, dispatchMode] = useReducer(
     agentConfigModeReducer,
@@ -87,6 +92,7 @@ export function CreateAgentFormView({
     status: idle,
   }))
   const [pendingAction, setPendingAction] = useState<SubmitAction | null>(null)
+  const [launchError, setLaunchError] = useState<ApiError>()
   const savedProfile = useRef<SavedProfile | null>(null)
   const [session, setSession] = useState(() => createBasicConfigSession(''))
   const form = useAgentBuilderForm(
@@ -142,6 +148,7 @@ export function CreateAgentFormView({
 
   async function submit(action: SubmitAction) {
     if (!canSubmit) return
+    setLaunchError(undefined)
     setDraft((prev) => ({ ...prev, status: submitting }))
     setPendingAction(action)
     const name = draft.name
@@ -184,6 +191,9 @@ export function CreateAgentFormView({
     if (result.ok) {
       setDraft((prev) => ({ ...prev, status: idle }))
     } else {
+      if (action === 'launch' && isInsufficientCreditsError(result.error)) {
+        setLaunchError(result.error)
+      }
       const status = submitError(
         result.error,
         action === 'launch' ? 'Could not create agent' : 'Could not create profile',
@@ -301,9 +311,13 @@ export function CreateAgentFormView({
           Cancel
         </Button>
         <div className="flex items-center gap-4">
-          {errorMessage && (
+          {launchError && webConfig?.billingURL ? (
+            <p className="text-destructive whitespace-pre-wrap text-sm" role="alert">
+              <InsufficientCreditsMessage billingHref={webConfig.billingHref} />
+            </p>
+          ) : errorMessage ? (
             <p className="text-destructive whitespace-pre-wrap text-sm">{errorMessage}</p>
-          )}
+          ) : null}
           <Button
             type="button"
             variant="outline"

--- a/frontend/apps/web/src/components/agents/InsufficientCreditsMessage.tsx
+++ b/frontend/apps/web/src/components/agents/InsufficientCreditsMessage.tsx
@@ -1,0 +1,14 @@
+export function InsufficientCreditsMessage({ billingHref }: { billingHref?: string }) {
+  return (
+    <>
+      Insufficient Omnara credits.{' '}
+      {billingHref ? (
+        <a className="font-medium underline underline-offset-2" href={billingHref}>
+          Add credits
+        </a>
+      ) : (
+        'Ask an organization admin to add credits.'
+      )}
+    </>
+  )
+}

--- a/frontend/apps/web/src/components/app-shell/OrganizationNav.tsx
+++ b/frontend/apps/web/src/components/app-shell/OrganizationNav.tsx
@@ -1,5 +1,3 @@
-import { fetchWebConfig } from '@omnara/sdk/browser'
-import { useQuery } from '@tanstack/react-query'
 import { Link, useRouterState } from '@tanstack/react-router'
 
 import {
@@ -19,8 +17,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from '@/components/ui/sidebar'
-import { canManageOrg } from '@/lib/permissions'
-import { useActiveOrg } from '@/lib/use-active-org'
+import { useWebConfig } from '@/lib/web-config'
 
 const resources = [
   { to: '/' as const, label: 'Overview', icon: House },
@@ -34,9 +31,7 @@ const resources = [
 
 export function OrganizationNav() {
   const pathname = useRouterState({ select: (state) => state.location.pathname })
-  const { activeOrg } = useActiveOrg()
-  const webConfigQuery = useQuery({ queryKey: ['web-config'], queryFn: fetchWebConfig })
-  const billingURL = webConfigQuery.data?.billingURL
+  const { data: webConfig } = useWebConfig()
 
   return (
     <SidebarGroup>
@@ -52,10 +47,10 @@ export function OrganizationNav() {
               </SidebarMenuButton>
             </SidebarMenuItem>
           ))}
-          {billingURL && canManageOrg(activeOrg.role) && (
+          {webConfig?.billingHref && (
             <SidebarMenuItem>
               <SidebarMenuButton asChild>
-                <a href={`${billingURL}?org=${activeOrg.id}`}>
+                <a href={webConfig.billingHref}>
                   <CreditCard />
                   <span>Credits</span>
                 </a>

--- a/frontend/apps/web/src/lib/insufficient-credits.test.tsx
+++ b/frontend/apps/web/src/lib/insufficient-credits.test.tsx
@@ -1,0 +1,43 @@
+import { ApiError } from '@omnara/sdk'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import { InsufficientCreditsMessage } from '@/components/agents/InsufficientCreditsMessage'
+import {
+  isInsufficientCreditsError,
+  isInsufficientCreditsModelError,
+  isInsufficientCreditsToolError,
+} from '@/lib/insufficient-credits'
+
+describe('insufficient credits', () => {
+  it('recognizes only the managed-work API code', () => {
+    expect(
+      isInsufficientCreditsError(
+        new ApiError(409, 'Insufficient Omnara credits.', 'managed_work_admission_denied'),
+      ),
+    ).toBe(true)
+    expect(isInsufficientCreditsError(new ApiError(409, 'same message', 'conflict'))).toBe(false)
+  })
+
+  it('recognizes only the managed-model error text', () => {
+    expect(isInsufficientCreditsModelError('Insufficient Omnara credits.')).toBe(true)
+    expect(isInsufficientCreditsModelError('The model provider request failed.')).toBe(false)
+  })
+
+  it('recognizes only the managed-work tool error code', () => {
+    expect(isInsufficientCreditsToolError('managed_work_admission_denied')).toBe(true)
+    expect(isInsufficientCreditsToolError('tool_work_no_progress')).toBe(false)
+  })
+
+  it('links admins to billing and directs members to an admin', () => {
+    const admin = renderToStaticMarkup(
+      <InsufficientCreditsMessage billingHref="https://billing.test?org=org_123" />,
+    )
+    const member = renderToStaticMarkup(<InsufficientCreditsMessage />)
+
+    expect(admin).toContain('href="https://billing.test?org=org_123"')
+    expect(admin).toContain('Add credits')
+    expect(member).toContain('Ask an organization admin to add credits.')
+    expect(member).not.toContain('<a')
+  })
+})

--- a/frontend/apps/web/src/lib/insufficient-credits.ts
+++ b/frontend/apps/web/src/lib/insufficient-credits.ts
@@ -1,0 +1,16 @@
+import { ApiError } from '@omnara/sdk'
+
+const managedWorkAdmissionDeniedCode = 'managed_work_admission_denied'
+const insufficientOmnaraCreditsMessage = 'Insufficient Omnara credits.'
+
+export function isInsufficientCreditsError(error: unknown): error is ApiError {
+  return error instanceof ApiError && error.code === managedWorkAdmissionDeniedCode
+}
+
+export function isInsufficientCreditsModelError(text: string): boolean {
+  return text === insufficientOmnaraCreditsMessage
+}
+
+export function isInsufficientCreditsToolError(errorCode: string | undefined): boolean {
+  return errorCode === managedWorkAdmissionDeniedCode
+}

--- a/frontend/apps/web/src/lib/web-config.ts
+++ b/frontend/apps/web/src/lib/web-config.ts
@@ -1,0 +1,27 @@
+import { fetchWebConfig } from '@omnara/sdk/browser'
+import { useQuery } from '@tanstack/react-query'
+
+import { canManageOrg } from '@/lib/permissions'
+import { useActiveOrg } from '@/lib/use-active-org'
+
+const webConfigQuery = { queryKey: ['web-config'] as const, queryFn: fetchWebConfig }
+
+export function useWebConfig() {
+  const { activeOrg } = useActiveOrg()
+  const query = useQuery(webConfigQuery)
+  const billingURL = query.data?.billingURL
+
+  return {
+    ...query,
+    data:
+      query.data == null
+        ? undefined
+        : {
+            ...query.data,
+            billingHref:
+              billingURL && canManageOrg(activeOrg.role)
+                ? `${billingURL}?org=${activeOrg.id}`
+                : undefined,
+          },
+  }
+}

--- a/frontend/apps/web/src/routes/AgentProfileView.tsx
+++ b/frontend/apps/web/src/routes/AgentProfileView.tsx
@@ -11,14 +11,18 @@ import { AgentsTable } from '@/components/agents/AgentsSection'
 import { CreateCronTriggerDialog } from '@/components/agents/CronTriggerDialog'
 import { CronTriggersList } from '@/components/agents/CronTriggersSection'
 import { DeployAgentProfileDialog } from '@/components/agents/DeployAgentProfileDialog'
+import { InsufficientCreditsMessage } from '@/components/agents/InsufficientCreditsMessage'
 import { PillTabs } from '@/components/agents/PillTabs'
 import { SlackOAuthOutcomeDialog } from '@/components/agents/SlackOAuthOutcomeDialog'
 import { DetailList } from '@/components/data-table/DetailList'
+import { TriangleAlert } from '@/components/icons'
 import { PageBreadcrumb } from '@/components/layout/PageBreadcrumb'
 import { Button } from '@/components/ui/button'
 import { formatDateTime } from '@/lib/format'
+import { isInsufficientCreditsError } from '@/lib/insufficient-credits'
 import { useActiveOrg } from '@/lib/use-active-org'
 import { useProjectPage } from '@/lib/use-project-page'
+import { useWebConfig } from '@/lib/web-config'
 
 type ProfileTab = 'configuration' | 'integrations' | 'schedules' | 'agents'
 
@@ -42,8 +46,10 @@ function ProfileView({ profile, projectId }: { profile: AgentProfile; projectId:
   const [deployOpen, setDeployOpen] = useState(false)
   const [addCronOpen, setAddCronOpen] = useState(false)
   const [configDirty, setConfigDirty] = useState(false)
+  const [launchError, setLaunchError] = useState<ApiError>()
 
   const createAgent = useCreateAgent(activeOrg.id, projectId)
+  const { data: webConfig } = useWebConfig()
   const deleteProfile = useDeleteAgentProfile(activeOrg.id, projectId)
   const navigate = useNavigate()
 
@@ -56,6 +62,7 @@ function ProfileView({ profile, projectId }: { profile: AgentProfile; projectId:
     ) {
       return
     }
+    setLaunchError(undefined)
     try {
       const launched = await createAgent.mutateAsync({
         profile: profile.id,
@@ -66,7 +73,11 @@ function ProfileView({ profile, projectId }: { profile: AgentProfile; projectId:
         params: { projectId, agentId: launched.agent.id },
       })
     } catch (error) {
-      window.alert(error instanceof ApiError ? error.message : 'Could not launch agent')
+      if (isInsufficientCreditsError(error)) {
+        setLaunchError(error)
+      } else {
+        window.alert(error instanceof ApiError ? error.message : 'Could not launch agent')
+      }
     }
   }
 
@@ -98,6 +109,19 @@ function ProfileView({ profile, projectId }: { profile: AgentProfile; projectId:
             { id: 'profile', label: profile.name },
           ]}
         />
+        {launchError && (
+          <div
+            className="border-destructive/30 bg-destructive/5 text-destructive flex items-start gap-2 rounded-md border px-3 py-2 text-sm"
+            role="alert"
+          >
+            <TriangleAlert className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+            {webConfig?.billingURL ? (
+              <InsufficientCreditsMessage billingHref={webConfig.billingHref} />
+            ) : (
+              launchError.message
+            )}
+          </div>
+        )}
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="flex min-w-0 flex-col gap-1">
             <AgentProfileNameHeading

--- a/frontend/packages/react/src/domains/agent-chat-messages.test.ts
+++ b/frontend/packages/react/src/domains/agent-chat-messages.test.ts
@@ -218,6 +218,34 @@ describe('agentEventsToMessages', () => {
     ])
   })
 
+  it('exposes failed built-in tool error codes without trusting external tools', () => {
+    const result = toolResultEvent({
+      outcome: 'failed',
+      content_blocks: [
+        {
+          type: 'structured_data',
+          value: { error_code: 'managed_work_admission_denied' },
+        },
+      ],
+    })
+    const builtIn = agentEventsToMessages([event({ content_blocks: [toolCallBlock()] }), result])
+    expect(builtIn[0]?.parts[0]).toMatchObject({
+      type: 'dynamic-tool',
+      toolType: 'built_in',
+      toolErrorCode: 'managed_work_admission_denied',
+    })
+    for (const toolType of ['custom', 'mcp'] as const) {
+      const external = agentEventsToMessages([
+        event({
+          content_blocks: [{ ...toolCallBlock(), tool_type: toolType }],
+        }),
+        result,
+      ])
+      expect(external[0]?.parts[0]).toMatchObject({ type: 'dynamic-tool', toolType })
+      expect(external[0]?.parts[0]).not.toHaveProperty('toolErrorCode')
+    }
+  })
+
   it('hides content blocks explicitly marked omnara_hidden', () => {
     const messages = agentEventsToMessages([
       userInputEvent({

--- a/frontend/packages/react/src/domains/agent-chat-messages.ts
+++ b/frontend/packages/react/src/domains/agent-chat-messages.ts
@@ -7,6 +7,8 @@ import type {
   MediaRefContentBlock,
   ModelOutputDelta,
   ModelOutputEvent,
+  ToolCallType,
+  ToolResultContentBlock,
 } from '@omnara/sdk'
 import type { UIMessage } from 'ai'
 
@@ -33,7 +35,11 @@ export type OmnaraUIData = {
 }
 
 type BaseOmnaraUIMessage = UIMessage<OmnaraMessageMetadata, OmnaraUIData>
-type OmnaraUIMessagePart = BaseOmnaraUIMessage['parts'][number] & { id: string }
+type OmnaraUIMessagePart = BaseOmnaraUIMessage['parts'][number] & {
+  id: string
+  toolType?: ToolCallType
+  toolErrorCode?: string
+}
 export type OmnaraUIMessage = Omit<BaseOmnaraUIMessage, 'parts'> & {
   parts: OmnaraUIMessagePart[]
 }
@@ -81,6 +87,22 @@ function isHiddenContentBlock(block: { metadata?: Record<string, unknown> }): bo
   return block.metadata?.omnara_hidden === 'true'
 }
 
+function structuredToolErrorCode(blocks: ToolResultContentBlock[]): string | undefined {
+  for (const block of blocks) {
+    if (
+      block.type !== 'structured_data' ||
+      block.value == null ||
+      typeof block.value !== 'object'
+    ) {
+      continue
+    }
+    if (!('error_code' in block.value)) continue
+    const errorCode = block.value.error_code
+    if (typeof errorCode === 'string') return errorCode
+  }
+  return undefined
+}
+
 function agentInputParts(event: AgentInputEvent): OmnaraUIMessage['parts'] {
   const parts: OmnaraUIMessage['parts'] = []
   for (const [blockIndex, block] of event.content_blocks.entries()) {
@@ -122,6 +144,7 @@ function modelOutputParts(event: ModelOutputEvent): OmnaraUIMessage['parts'] {
         id,
         toolCallId: block.tool_call_id,
         toolName: block.name,
+        toolType: block.tool_type,
         state: 'input-available',
         input: block.input,
       })
@@ -209,16 +232,23 @@ export function agentEventsToMessages(
     if (index < 0) continue
     const part = message.parts[index]
     if (part?.type !== 'dynamic-tool') continue
+    const contentBlocks = event.content_blocks.filter((block) => !isHiddenContentBlock(block))
+    const toolErrorCode =
+      event.outcome === 'failed' && part.toolType === 'built_in'
+        ? structuredToolErrorCode(contentBlocks)
+        : undefined
     message.parts[index] = {
       type: 'dynamic-tool',
       id: part.id,
       toolCallId: part.toolCallId,
       toolName: part.toolName,
+      toolType: part.toolType,
+      ...(toolErrorCode == null ? {} : { toolErrorCode }),
       state: 'output-available',
       input: part.input,
       output: {
         outcome: event.outcome,
-        contentBlocks: event.content_blocks.filter((block) => !isHiddenContentBlock(block)),
+        contentBlocks,
       },
     }
     message.metadata = eventMetadata(event)

--- a/internal/harness/kernel/agent_executor_model_request_integration_test.go
+++ b/internal/harness/kernel/agent_executor_model_request_integration_test.go
@@ -115,13 +115,14 @@ func TestAgentExecutorAppliesManagedWorkAdmissionAtModelClaim(t *testing.T) {
 		string(modelprotocol.ErrorKindRuntime),
 		storeerr.ManagedWorkAdmissionDeniedCode,
 	)
-	var state, recoveryKind, errorKind, errorCode, apiFormat, requestID, responseID string
+	var state, recoveryKind, errorKind, errorCode, errorMessage, apiFormat, requestID, responseID string
 	var retryAbsent bool
 	if err := fixture.Pool.QueryRow(ctx, `
 SELECT context.state,
        coalesce(context.recovery_kind, ''),
        context.error_kind,
        context.error_code,
+       context.error_message,
        context.api_format,
        context.provider_request_id,
        context.provider_response_id,
@@ -135,6 +136,7 @@ WHERE context.project_id = $1
 		&recoveryKind,
 		&errorKind,
 		&errorCode,
+		&errorMessage,
 		&apiFormat,
 		&requestID,
 		&responseID,
@@ -144,14 +146,16 @@ WHERE context.project_id = $1
 	}
 	if state != string(executionstore.ModelCallContextFailed) || recoveryKind != "" ||
 		errorKind != string(modelprotocol.ErrorKindRuntime) ||
-		errorCode != storeerr.ManagedWorkAdmissionDeniedCode || apiFormat != "" ||
+		errorCode != storeerr.ManagedWorkAdmissionDeniedCode ||
+		errorMessage != "Insufficient Omnara credits." || apiFormat != "" ||
 		requestID != "" || responseID != "" || !retryAbsent {
 		t.Fatalf(
-			"denied context = %q/%q/%q/%q api=%q request=%q response=%q retry_absent=%v",
+			"denied context = %q/%q/%q/%q message=%q api=%q request=%q response=%q retry_absent=%v",
 			state,
 			recoveryKind,
 			errorKind,
 			errorCode,
+			errorMessage,
 			apiFormat,
 			requestID,
 			responseID,

--- a/internal/harness/tools/errors.go
+++ b/internal/harness/tools/errors.go
@@ -2,6 +2,4 @@ package tools
 
 import "errors"
 
-const managedWorkAdmissionDeniedMessage = "new work using this deployment-managed resource is temporarily unavailable"
-
 var ErrActionRequired = errors.New("tool call requires permission")

--- a/internal/harness/tools/machine_execution_target_integration_test.go
+++ b/internal/harness/tools/machine_execution_target_integration_test.go
@@ -1241,8 +1241,8 @@ func assertManagedWorkAdmissionToolFailure(
 	}
 	body := toolResultMapFromTestParts(t, result.ContentParts)
 	if body["error_code"] != storeerr.ManagedWorkAdmissionDeniedCode ||
-		body["error"] != managedWorkAdmissionDeniedMessage ||
-		body["message"] != managedWorkAdmissionDeniedMessage ||
+		body["error"] != "Insufficient Omnara credits." ||
+		body["message"] != "Insufficient Omnara credits." ||
 		body["retryable"] != false {
 		t.Fatalf("denied tool result = %+v", body)
 	}

--- a/internal/harness/tools/machine_tools.go
+++ b/internal/harness/tools/machine_tools.go
@@ -614,7 +614,7 @@ func failMachineTransactionForStorageError(
 	if errors.Is(cause, storeerr.ErrManagedWorkAdmissionDenied) {
 		return failMachineTransactionWithMessage(
 			storeerr.ManagedWorkAdmissionDeniedCode,
-			managedWorkAdmissionDeniedMessage,
+			storeerr.InsufficientOmnaraCreditsMessage,
 			cause,
 			false,
 		)

--- a/internal/harness/tools/process_tools.go
+++ b/internal/harness/tools/process_tools.go
@@ -112,7 +112,7 @@ func startCommand(
 				return failProcessTransaction(
 					err,
 					processToolErrorManagedWorkAdmissionDenied,
-					managedWorkAdmissionDeniedMessage,
+					storeerr.InsufficientOmnaraCreditsMessage,
 					false,
 					"",
 					"",

--- a/internal/httpapi/apierror/errors.go
+++ b/internal/httpapi/apierror/errors.go
@@ -35,7 +35,7 @@ var definitions = map[openapi.ErrorCode]definition{
 	openapi.ErrorCodeStateTransitionConflict: {http.StatusConflict, "state transition conflict"},
 	openapi.ErrorCodeManagedWorkAdmissionDenied: {
 		http.StatusConflict,
-		"new managed work is temporarily unavailable",
+		storeerr.InsufficientOmnaraCreditsMessage,
 	},
 	openapi.ErrorCodeDaemonRuntimeUnregistered: {
 		http.StatusGone,

--- a/internal/httpapi/apierror/errors_test.go
+++ b/internal/httpapi/apierror/errors_test.go
@@ -126,7 +126,7 @@ func TestFromErrorHidesOpaqueSentinelDetail(t *testing.T) {
 		"operator policy detail: %w",
 		storeerr.ErrManagedWorkAdmissionDenied,
 	))
-	if admission.Message != "new managed work is temporarily unavailable" {
+	if admission.Message != "Insufficient Omnara credits." {
 		t.Fatalf("managed admission message = %q, want opaque base message", admission.Message)
 	}
 }

--- a/internal/storage/executionstore/model_contexts_claims.go
+++ b/internal/storage/executionstore/model_contexts_claims.go
@@ -147,7 +147,7 @@ func managedWorkAdmissionModelFailure(
 		ModelCallContextID: contextRow.ID,
 		ErrorKind:          modelprotocol.ErrorKindRuntime,
 		ErrorCode:          storeerr.ManagedWorkAdmissionDeniedCode,
-		ErrorMessage:       "new work using this deployment-managed model is temporarily unavailable",
+		ErrorMessage:       storeerr.InsufficientOmnaraCreditsMessage,
 	}
 }
 

--- a/internal/storage/storeerr/errors.go
+++ b/internal/storage/storeerr/errors.go
@@ -6,7 +6,10 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-const ManagedWorkAdmissionDeniedCode = "managed_work_admission_denied"
+const (
+	ManagedWorkAdmissionDeniedCode   = "managed_work_admission_denied"
+	InsufficientOmnaraCreditsMessage = "Insufficient Omnara credits."
+)
 
 var (
 	ErrInvalidRequest                = errors.New("invalid request")


### PR DESCRIPTION
- return the categorical “Insufficient Omnara credits.” message for managed-work admission failures across agent launch, managed model requests, and managed machine/process tools
- show organization admins a direct billing link and direct members to an admin across launch and conversation failures, while preserving generic fallbacks when billing is unavailable
- use the existing managed_work_admission_denied code for API and trusted built-in tool failures, and the categorical error text for durable model failures, without reclassifying provider, custom, or MCP errors