### PR TITLE
fix: harden Blaxel sandbox pagination

### DIFF
--- a/internal/machinepool/providers/blaxel/client.go
+++ b/internal/machinepool/providers/blaxel/client.go
@@ -151,7 +151,6 @@ func (c *restClient) ListSandboxes(
 	query := requestURL.Query()
 	query.Set("limit", strconv.Itoa(limit))
 	query.Set("q", "omnara-mch-")
-	query.Set("sort", "name:asc")
 	if cursor != "" {
 		query.Set("cursor", cursor)
 	}

--- a/internal/machinepool/providers/blaxel/client_test.go
+++ b/internal/machinepool/providers/blaxel/client_test.go
@@ -275,7 +275,7 @@ func TestBlaxelRESTClientListsSandboxesWithVersionedCursor(t *testing.T) {
 			query.Get("limit") != "200" ||
 			query.Get("q") != "omnara-mch-" ||
 			query.Has("showTerminated") ||
-			query.Get("sort") != "name:asc" {
+			query.Has("sort") {
 			t.Errorf("unexpected list query: %s", r.URL.RawQuery)
 			return
 		}

--- a/internal/machinepool/providers/blaxel/runtime_observer.go
+++ b/internal/machinepool/providers/blaxel/runtime_observer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/omnara-ai/omnara/internal/machinepool/providers"
 	"github.com/omnara-ai/omnara/internal/storage"
@@ -84,19 +85,21 @@ func (p *provider) ObserveRuntimeStates(
 	for _, index := range validIndexes {
 		target := targets[index]
 		matches := listed[target.ProviderResourceID]
-		if len(matches) != 1 {
+		if len(matches) == 0 {
 			continue
 		}
-		expectedName, _ := expectedSandboxName(target)
-		if !sandboxOwnedBy(
-			matches[0], expectedName, target.InstallationID, target.MachineID,
-		) {
-			continue
-		}
-		state := normalizedSandboxRuntimeState(matches[0])
-		if state != providers.RuntimeStateUnknown {
-			observations[index].State = state
-			continue
+		if len(matches) == 1 {
+			expectedName, _ := expectedSandboxName(target)
+			if !sandboxOwnedBy(
+				matches[0], expectedName, target.InstallationID, target.MachineID,
+			) {
+				continue
+			}
+			state := normalizedSandboxRuntimeState(matches[0])
+			if state != providers.RuntimeStateUnknown {
+				observations[index].State = state
+				continue
+			}
 		}
 
 		observation, err := observeRuntimeState(ctx, api, target)
@@ -161,9 +164,11 @@ func listTargetSandboxes(
 		}
 		for _, candidate := range page.Sandboxes {
 			if _, wanted := targetNames[candidate.Metadata.Name]; wanted {
-				if len(matches[candidate.Metadata.Name]) < 2 {
+				matched := matches[candidate.Metadata.Name]
+				if len(matched) == 0 ||
+					(len(matched) == 1 && !sameRuntimeSandbox(matched[0], candidate)) {
 					matches[candidate.Metadata.Name] = append(
-						matches[candidate.Metadata.Name], candidate,
+						matched, candidate,
 					)
 				}
 			}
@@ -180,6 +185,13 @@ func listTargetSandboxes(
 		seenCursors[page.NextCursor] = struct{}{}
 		cursor = page.NextCursor
 	}
+}
+
+func sameRuntimeSandbox(left, right sandbox) bool {
+	return left.Metadata.Name == right.Metadata.Name &&
+		maps.Equal(left.Metadata.Labels, right.Metadata.Labels) &&
+		left.State == right.State &&
+		left.Status == right.Status
 }
 
 func expectedSandboxName(target providers.RuntimeTarget) (string, bool) {

--- a/internal/machinepool/providers/blaxel/runtime_observer_test.go
+++ b/internal/machinepool/providers/blaxel/runtime_observer_test.go
@@ -145,12 +145,16 @@ func TestBlaxelObserveRuntimeStatesPaginatesAndIntersectsTargets(t *testing.T) {
 		HasMore: true, NextCursor: "next+/=",
 	}
 	api.listPages["next+/="] = sandboxListPage{Sandboxes: []sandbox{
+		api.listPages[""].Sandboxes[0],
 		ownedRuntimeSandbox(t, targets[2], "STANDBY", "DEPLOYED"),
 		ownedRuntimeSandbox(t, targets[5], "RUNNING", "DELETING"),
 	}}
 	api.listPages[""].Sandboxes[4].Metadata.Labels[installationLabel] = uuid.NewString()
 	api.sandboxesByName[targets[3].ProviderResourceID] = ownedRuntimeSandbox(
 		t, targets[3], "RUNNING", "DEPLOYED",
+	)
+	api.sandboxesByName[targets[2].ProviderResourceID] = ownedRuntimeSandbox(
+		t, targets[2], "STANDBY", "DEPLOYED",
 	)
 
 	observations, err := newTestProvider(api).ObserveRuntimeStates(context.Background(), targets)
@@ -161,13 +165,16 @@ func TestBlaxelObserveRuntimeStatesPaginatesAndIntersectsTargets(t *testing.T) {
 		!slices.Equal(api.listLimits, []int{runtimeObservationListPageSize, runtimeObservationListPageSize}) {
 		t.Fatalf("list cursors=%v limits=%v", api.listCursors, api.listLimits)
 	}
-	if !slices.Equal(api.getCalls, []string{targets[3].ProviderResourceID}) {
+	if !slices.Equal(api.getCalls, []string{
+		targets[2].ProviderResourceID,
+		targets[3].ProviderResourceID,
+	}) {
 		t.Fatalf("fallback GET calls = %v", api.getCalls)
 	}
 	wantStates := map[int]providers.RuntimeState{
 		0: providers.RuntimeStateRunning,
 		1: providers.RuntimeStateInactive,
-		2: providers.RuntimeStateUnknown,
+		2: providers.RuntimeStateInactive,
 		3: providers.RuntimeStateRunning,
 		4: providers.RuntimeStateUnknown,
 		5: providers.RuntimeStateTerminated,


### PR DESCRIPTION
This was prompted by repeated failures in the live Blaxel provider smoke test that initially looked flaky. The exact sandbox lookup succeeded, but the bulk observation remained `unknown` until the test timed out.

Investigation showed that Omnara explicitly requested name sorting and Blaxel currently returns overlapping cursor pages for both name sort directions. Repeated copies of the target sandbox were then treated as ambiguous, so the same behavior could also affect production runtime reconciliation.

This removes the unnecessary name sort while retaining the Omnara sandbox filter and cursor pagination. The observer also now collapses identical repeated records defensively. If repeated records disagree, it resolves the ambiguity through Blaxel's exact single-sandbox endpoint.

The focused unit tests, full Go unit suite, broader machine-pool suite, and real Blaxel smoke journey pass. The live journey now completes in about four seconds instead of timing out while waiting for bulk observation.