### PR TITLE
fix: live test resource names

### DIFF
--- a/internal/e2e/service_e2e_daemon_process_tools_live_test.go
+++ b/internal/e2e/service_e2e_daemon_process_tools_live_test.go
@@ -19,7 +19,7 @@ func TestServiceE2ELiveOpenAIResponsesDockerDaemonProcessTools(t *testing.T) {
 	runLiveServiceProviderJourney(
 		t,
 		"openai-prod",
-		"docker-daemon-process-tools",
+		"daemon-tools",
 		8*time.Minute,
 		runLiveDockerDaemonProcessTools,
 	)
@@ -29,7 +29,7 @@ func TestServiceE2ELiveOpenAIChatCompletionsDockerDaemonProcessTools(t *testing.
 	runLiveServiceProviderJourney(
 		t,
 		"openai-chat-prod",
-		"docker-daemon-process-tools",
+		"daemon-tools",
 		8*time.Minute,
 		runLiveDockerDaemonProcessTools,
 	)
@@ -39,7 +39,7 @@ func TestServiceE2ELiveOpenRouterDockerDaemonProcessTools(t *testing.T) {
 	runLiveServiceProviderJourney(
 		t,
 		"openrouter-prod",
-		"docker-daemon-process-tools",
+		"daemon-tools",
 		8*time.Minute,
 		runLiveDockerDaemonProcessTools,
 	)
@@ -49,7 +49,7 @@ func TestServiceE2ELiveAnthropicDockerDaemonProcessTools(t *testing.T) {
 	runLiveServiceProviderJourney(
 		t,
 		"anthropic-prod",
-		"docker-daemon-process-tools",
+		"daemon-tools",
 		8*time.Minute,
 		runLiveDockerDaemonProcessTools,
 	)


### PR DESCRIPTION
Shortens the daemon process-tools journey seed used by live provider tests. This keeps the derived organization, machine, and daemon-token fixture names under the resource-name limit and fixes the main-only OpenAI Chat Completions failure.