### PR TITLE
build: adopt a bounded Dependabot maintenance policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,21 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 3
+    groups:
+      actions-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     cooldown:
       default-days: 7
+
   - package-ecosystem: gomod
     directories:
       - /
@@ -14,5 +27,81 @@ updates:
       - /tools/omnaralint
     schedule:
       interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 3
+    groups:
+      aws-sdk-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - github.com/aws/aws-sdk-go-v2*
+        update-types:
+          - minor
+          - patch
+      golang-x-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - golang.org/x/*
+        update-types:
+          - minor
+          - patch
+      shared-go-dependencies:
+        group-by: dependency-name
+    cooldown:
+      default-days: 7
+
+  # The main frontend uses pnpm 11, which Dependabot does not currently
+  # support. Keep the independent pnpm 10 CLI example updated here.
+  - package-ecosystem: npm
+    directory: /examples/cli-agent
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 3
+    groups:
+      production-minor-and-patch:
+        applies-to: version-updates
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      development-minor-and-patch:
+        applies-to: version-updates
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+
+  - package-ecosystem: docker
+    directories:
+      - /
+      - /examples/sharepoint-mount
+      - /examples/unikraft-machine
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 3
+    groups:
+      per-image:
+        group-by: dependency-name
+    ignore:
+      # Runtime and toolchain lines are upgraded deliberately; digest and
+      # patch updates within the adopted lines remain eligible.
+      - dependency-name: node
+        update-types:
+          - version-update:semver-major
+      - dependency-name: golang
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,10 +71,18 @@ updates:
       development-minor-and-patch:
         applies-to: version-updates
         dependency-type: development
+        exclude-patterns:
+          - typescript
         update-types:
           - minor
           - patch
-      shared-npm-dependencies:
+      shared-typescript:
+        applies-to: version-updates
+        patterns:
+          - typescript
+        update-types:
+          - minor
+          - patch
         group-by: dependency-name
     cooldown:
       semver-major-days: 30

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,10 +51,10 @@ updates:
     cooldown:
       default-days: 7
 
-  # The main frontend uses pnpm 11, which Dependabot does not currently
-  # support. Keep the independent pnpm 10 CLI example updated here.
   - package-ecosystem: npm
-    directory: /examples/cli-agent
+    directories:
+      - /frontend
+      - /examples/cli-agent
     schedule:
       interval: weekly
       day: monday
@@ -74,6 +74,8 @@ updates:
         update-types:
           - minor
           - patch
+      shared-npm-dependencies:
+        group-by: dependency-name
     cooldown:
       semver-major-days: 30
       semver-minor-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
       timezone: America/Los_Angeles
     open-pull-requests-limit: 3
     groups:
+      actions-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
       actions-minor-and-patch:
         applies-to: version-updates
         patterns:
@@ -32,6 +36,10 @@ updates:
       timezone: America/Los_Angeles
     open-pull-requests-limit: 3
     groups:
+      go-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
       aws-sdk-minor-and-patch:
         applies-to: version-updates
         patterns:
@@ -62,6 +70,16 @@ updates:
       timezone: America/Los_Angeles
     open-pull-requests-limit: 3
     groups:
+      production-security-updates:
+        applies-to: security-updates
+        dependency-type: production
+      development-security-updates:
+        applies-to: security-updates
+        dependency-type: development
+      other-npm-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
       production-minor-and-patch:
         applies-to: version-updates
         dependency-type: production


### PR DESCRIPTION
## Summary

- run Dependabot on a predictable Monday morning schedule with at most three open version-update PRs per ecosystem
- group routine GitHub Actions, related Go, and npm production/development minor/patch updates
- group security updates separately from the routine version-update queue
- cover both pnpm workspaces and keep TypeScript updates aligned across them
- add Docker coverage and group the same image across directories
- keep Node and Go toolchain line changes manual while allowing digest and patch refreshes

## Policy

Routine minor/patch work is grouped to reduce queue volume. Higher-risk major updates remain separate unless the repository has an explicit compatibility line: Node and Go container line changes are intentionally ignored until a human updates that line.

The frontend remains on pnpm 11.22. Dependabot core currently lists pnpm 11 as supported and includes pnpm-11-specific update logic, even though GitHub's published ecosystem table has not yet caught up.

This configuration also defines security-update grouping. Automatic Dependabot security-update PRs are a separate repository setting; GitHub's status endpoint confirms they are currently disabled, so enable them after this configuration lands.

## Validation

- `git diff --check`
- `uvx check-jsonschema --schemafile https://json.schemastore.org/dependabot-2.0.json .github/dependabot.yml`
- `make web-check`

## References

- [GitHub: optimizing Dependabot PR creation](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates)
- [GitHub: Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference)
- [GitHub: Dependabot comment commands](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-pull-request-comment-commands)
- [Dependabot's own configuration](https://github.com/dependabot/dependabot-core/blob/main/.github/dependabot.yml)
- [Dependabot core pnpm support](https://github.com/dependabot/dependabot-core/blob/main/npm_and_yarn/lib/dependabot/npm_and_yarn/pnpm_package_manager.rb)
