### PR TITLE
feat: fence maintenance and worker database writes during migrations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -184,3 +184,6 @@ linters:
           - bodyclose
           - contextcheck
           - noctx
+      - path: internal/storage/dbconn/schema_guard\.go
+        linters:
+          - rowserrcheck

--- a/Makefile
+++ b/Makefile
@@ -187,15 +187,13 @@ migration-check:
 			grep_status=$$?; \
 			test "$$grep_status" -eq 1 || exit "$$grep_status"; \
 		fi; \
-		if test "$$dir" = "internal/machinedaemon/statedb/migrations"; then \
-			if no_transaction="$$(grep -niE '^[[:space:]]*--[[:space:]]*[+]goose[[:space:]]+no[[:space:]]+transaction[[:space:]]*$$' "$$dir"/*.sql)"; then \
-				printf '%s\n' "$$no_transaction"; \
-				printf '%s migrations must be transactional\n' "$$dir"; \
-				exit 1; \
-			else \
-				grep_status=$$?; \
-				test "$$grep_status" -eq 1 || exit "$$grep_status"; \
-			fi; \
+		if no_transaction="$$(grep -niE '^[[:space:]]*--[[:space:]]*[+]goose[[:space:]]+no[[:space:]]+transaction[[:space:]]*$$' "$$dir"/*.sql)"; then \
+			printf '%s\n' "$$no_transaction"; \
+			printf '%s migrations must be transactional\n' "$$dir"; \
+			exit 1; \
+		else \
+			grep_status=$$?; \
+			test "$$grep_status" -eq 1 || exit "$$grep_status"; \
 		fi; \
 	done
 	$(MIGRATION_CHECK) check

--- a/cmd/maintenance/main.go
+++ b/cmd/maintenance/main.go
@@ -128,6 +128,33 @@ func main() {
 		metricSet,
 		metrics.ReadyAll(schemaGuard.Ready, db.Ping, redisClient.Ping),
 	)
+	activated := make(chan bool, 1)
+	go func() {
+		activated <- schemaGuard.WaitForActivation(ctx)
+	}()
+	select {
+	case active := <-activated:
+		if !active {
+			if mismatch := schemaGuard.Mismatch(); mismatch != nil {
+				if handleSchemaVersionMismatch(signalCtx, healthErr, logger, mismatch) != 0 {
+					os.Exit(1)
+				}
+				return
+			}
+			if err := <-healthErr; err != nil {
+				logger.Error("maintenance health and metrics server failed", "error", err)
+				os.Exit(1)
+			}
+			return
+		}
+	case err := <-healthErr:
+		cancel()
+		if err != nil {
+			logger.Error("maintenance health and metrics server failed", "error", err)
+			os.Exit(1)
+		}
+		return
+	}
 	machinePoolManager := machinepool.NewManager(store.Execution(), store.Identity(), cfg.PublicURL)
 	runtimeRecorder := metrics.NewProviderRuntimeRecorder(metricSet)
 

--- a/cmd/maintenance/main.go
+++ b/cmd/maintenance/main.go
@@ -13,7 +13,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/omnara-ai/omnara/internal/config"
+	"github.com/omnara-ai/omnara/internal/dbmigrate"
 	"github.com/omnara-ai/omnara/internal/defaultprovider"
 	logpkg "github.com/omnara-ai/omnara/internal/log"
 	"github.com/omnara-ai/omnara/internal/log/logent"
@@ -23,8 +25,10 @@ import (
 	"github.com/omnara-ai/omnara/internal/notifications"
 	"github.com/omnara-ai/omnara/internal/redistore"
 	"github.com/omnara-ai/omnara/internal/storage"
+	"github.com/omnara-ai/omnara/internal/storage/dbconn"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
+	schemamigrations "github.com/omnara-ai/omnara/migrations"
 )
 
 const (
@@ -59,6 +63,18 @@ func main() {
 		os.Exit(1)
 	}
 	defer db.Close()
+	versionDB := stdlib.OpenDBFromPool(db)
+	defer func() { _ = versionDB.Close() }()
+	expectedVersion, err := dbmigrate.PostgresTargetVersion(
+		versionDB,
+		schemamigrations.Files,
+		schemamigrations.GoMigrations()...,
+	)
+	if err != nil {
+		logger.Error("read maintenance schema target version", "error", err)
+		os.Exit(1)
+	}
+	schemaGuard := dbconn.NewSchemaGuard(db, expectedVersion)
 
 	signalCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -104,17 +120,17 @@ func main() {
 		os.Exit(1)
 	}
 	store := storage.NewStore(
-		db,
+		schemaGuard,
 		storage.WithPostCommitPublisher(publisher),
 		storage.WithSecretKeyWrapper(secretKeyWrapper),
 		storage.WithMachinePoolProviders(machinepool.DefaultCatalog()),
 	)
 	healthErr := metrics.Serve(
-		ctx,
+		signalCtx,
 		logger,
 		cfg.MaintenanceMetricsAddr,
 		metricSet,
-		metrics.ReadyAll(db.Ping, redisClient.Ping),
+		metrics.ReadyAll(schemaGuard.Ready, db.Ping, redisClient.Ping),
 	)
 	machinePoolManager := machinepool.NewManager(store.Execution(), store.Identity(), cfg.PublicURL)
 	runtimeRecorder := metrics.NewProviderRuntimeRecorder(metricSet)
@@ -187,19 +203,27 @@ func main() {
 		}()
 	}
 
-	exitCode := runCoreMaintenanceLoop(
+	exitCode, schemaMismatch := runCoreMaintenanceLoop(
 		ctx,
-		cancel,
 		logger,
 		store,
 		cfg.MaintenanceInterval,
 		healthErr,
+		schemaGuard.Done(),
 	)
 	cancel()
 	<-machineLoopDone
 	<-runtimeDiscoveryDone
 	<-runtimeRecheckDone
 	<-defaultModelProviderDone
+	if schemaMismatch {
+		exitCode = handleSchemaVersionMismatch(
+			signalCtx,
+			healthErr,
+			logger,
+			schemaGuard.Mismatch(),
+		)
+	}
 	if exitCode != 0 {
 		os.Exit(exitCode)
 	}
@@ -307,12 +331,12 @@ func jitteredMaintenanceDelay(interval time.Duration) time.Duration {
 
 func runCoreMaintenanceLoop(
 	ctx context.Context,
-	cancel context.CancelFunc,
 	log *slog.Logger,
 	store *storage.Store,
 	interval time.Duration,
 	healthErr <-chan error,
-) int {
+	schemaMismatch <-chan struct{},
+) (int, bool) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
@@ -322,18 +346,47 @@ func runCoreMaintenanceLoop(
 		event.Done(loopCtx)
 		select {
 		case <-ctx.Done():
-			<-healthErr
-			return 0
+			if err := <-healthErr; err != nil {
+				log.Error("maintenance health and metrics server failed", "error", err)
+				return 1, false
+			}
+			return 0, false
 		case err := <-healthErr:
-			cancel()
 			if err != nil {
 				log.Error("maintenance health and metrics server failed", "error", err)
-				return 1
+				return 1, false
 			}
-			return 0
+			return 0, false
+		case <-schemaMismatch:
+			return 0, true
 		case <-ticker.C:
 		}
 	}
+}
+
+func handleSchemaVersionMismatch(
+	signalCtx context.Context,
+	healthErr <-chan error,
+	log *slog.Logger,
+	mismatch *dbconn.SchemaVersionMismatchError,
+) int {
+	log.Warn(
+		"maintenance schema version mismatch",
+		"expected_version", mismatch.Expected,
+		"actual_version", mismatch.Actual,
+		"action", "quiesce",
+	)
+	var healthServerErr error
+	select {
+	case <-signalCtx.Done():
+		healthServerErr = <-healthErr
+	case healthServerErr = <-healthErr:
+	}
+	if healthServerErr != nil {
+		log.Error("maintenance health and metrics server failed", "error", healthServerErr)
+		return 1
+	}
+	return 0
 }
 
 func runCoreMaintenanceTick(

--- a/cmd/maintenance/main.go
+++ b/cmd/maintenance/main.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/omnara-ai/omnara/internal/config"
 	"github.com/omnara-ai/omnara/internal/dbmigrate"
 	"github.com/omnara-ai/omnara/internal/defaultprovider"
@@ -63,10 +62,7 @@ func main() {
 		os.Exit(1)
 	}
 	defer db.Close()
-	versionDB := stdlib.OpenDBFromPool(db)
-	defer func() { _ = versionDB.Close() }()
 	expectedVersion, err := dbmigrate.PostgresTargetVersion(
-		versionDB,
 		schemamigrations.Files,
 		schemamigrations.GoMigrations()...,
 	)

--- a/cmd/maintenance/main_test.go
+++ b/cmd/maintenance/main_test.go
@@ -11,7 +11,37 @@ import (
 
 	"github.com/omnara-ai/omnara/internal/machinepool"
 	"github.com/omnara-ai/omnara/internal/metrics"
+	"github.com/omnara-ai/omnara/internal/storage/dbconn"
 )
+
+func TestHandleSchemaVersionMismatchQuiesces(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	healthErr := make(chan error, 1)
+	done := make(chan int, 1)
+	go func() {
+		done <- handleSchemaVersionMismatch(
+			ctx,
+			healthErr,
+			slog.New(slog.NewTextHandler(io.Discard, nil)),
+			&dbconn.SchemaVersionMismatchError{Expected: 26, Actual: 25},
+		)
+	}()
+	select {
+	case code := <-done:
+		t.Fatalf("quiesced maintenance returned early with %d", code)
+	case <-time.After(20 * time.Millisecond):
+	}
+	cancel()
+	healthErr <- nil
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("quiesced maintenance did not stop after cancellation")
+	}
+}
 
 func TestJitteredMaintenanceDelayStaysWithinTenPercent(t *testing.T) {
 	interval := 10 * time.Second

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -141,6 +141,35 @@ func main() {
 		metricSet,
 		metrics.ReadyAll(schemaGuard.Ready, db.Ping, redisClient.Ping),
 	)
+	activated := make(chan bool, 1)
+	go func() {
+		activated <- schemaGuard.WaitForActivation(ctx)
+	}()
+	select {
+	case active := <-activated:
+		if !active {
+			if mismatch := schemaGuard.Mismatch(); mismatch != nil {
+				log.Warn(
+					"worker schema version mismatch",
+					"expected_version", mismatch.Expected,
+					"actual_version", mismatch.Actual,
+					"action", "quiesce",
+				)
+			}
+			if err := <-healthErr; err != nil {
+				log.Error("worker health and metrics server failed", "error", err)
+				os.Exit(1)
+			}
+			return
+		}
+	case err := <-healthErr:
+		cancel()
+		if err != nil {
+			log.Error("worker health and metrics server failed", "error", err)
+			os.Exit(1)
+		}
+		return
+	}
 	httpRecorder := metrics.NewHTTPClientRecorder(metricSet, metrics.SubsystemHTTPClient)
 	integrationHTTPClient := metrics.NewObservedHTTPClient(
 		outboundhttp.NewPublicClient(

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/omnara-ai/omnara/internal/blobstore"
 	"github.com/omnara-ai/omnara/internal/config"
 	"github.com/omnara-ai/omnara/internal/crontrigger"
@@ -69,10 +68,7 @@ func main() {
 		os.Exit(1)
 	}
 	defer db.Close()
-	versionDB := stdlib.OpenDBFromPool(db)
-	defer func() { _ = versionDB.Close() }()
 	expectedVersion, err := dbmigrate.PostgresTargetVersion(
-		versionDB,
 		schemamigrations.Files,
 		schemamigrations.GoMigrations()...,
 	)
@@ -250,7 +246,11 @@ func main() {
 		unexpectedWorkerErr := err != nil && signalCtx.Err() == nil
 		cancel()
 		stop()
-		<-healthErr
+		healthServerErr := <-healthErr
+		if healthServerErr != nil {
+			log.Error("worker health and metrics server failed", "error", healthServerErr)
+			exitCode = 1
+		}
 		if unexpectedWorkerErr {
 			log.Error("kernel worker failed", "error", err)
 			exitCode = 1
@@ -267,8 +267,12 @@ func main() {
 		}
 	case <-signalCtx.Done():
 		cancel()
-		<-healthErr
+		healthServerErr := <-healthErr
 		<-workerErr
+		if healthServerErr != nil {
+			log.Error("worker health and metrics server failed", "error", healthServerErr)
+			exitCode = 1
+		}
 	case <-schemaGuard.Done():
 		schemaMismatch = schemaGuard.Mismatch()
 		cancel()

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -11,9 +11,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/omnara-ai/omnara/internal/blobstore"
 	"github.com/omnara-ai/omnara/internal/config"
 	"github.com/omnara-ai/omnara/internal/crontrigger"
+	"github.com/omnara-ai/omnara/internal/dbmigrate"
 	"github.com/omnara-ai/omnara/internal/harness/kernel"
 	"github.com/omnara-ai/omnara/internal/harness/tools"
 	workerpkg "github.com/omnara-ai/omnara/internal/harness/worker"
@@ -28,7 +30,9 @@ import (
 	"github.com/omnara-ai/omnara/internal/redistore"
 	"github.com/omnara-ai/omnara/internal/skills"
 	"github.com/omnara-ai/omnara/internal/storage"
+	"github.com/omnara-ai/omnara/internal/storage/dbconn"
 	"github.com/omnara-ai/omnara/internal/webaccess"
+	schemamigrations "github.com/omnara-ai/omnara/migrations"
 )
 
 const (
@@ -65,6 +69,18 @@ func main() {
 		os.Exit(1)
 	}
 	defer db.Close()
+	versionDB := stdlib.OpenDBFromPool(db)
+	defer func() { _ = versionDB.Close() }()
+	expectedVersion, err := dbmigrate.PostgresTargetVersion(
+		versionDB,
+		schemamigrations.Files,
+		schemamigrations.GoMigrations()...,
+	)
+	if err != nil {
+		log.Error("read worker schema target version", "error", err)
+		os.Exit(1)
+	}
+	schemaGuard := dbconn.NewSchemaGuard(db, expectedVersion)
 
 	signalCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -121,13 +137,13 @@ func main() {
 		}
 		storeOpts = append(storeOpts, storage.WithBlobStore(blobs))
 	}
-	store := storage.NewStore(db, storeOpts...)
+	store := storage.NewStore(schemaGuard, storeOpts...)
 	healthErr := metrics.Serve(
-		ctx,
+		signalCtx,
 		log,
 		cfg.WorkerMetricsAddr,
 		metricSet,
-		metrics.ReadyAll(db.Ping, redisClient.Ping),
+		metrics.ReadyAll(schemaGuard.Ready, db.Ping, redisClient.Ping),
 	)
 	httpRecorder := metrics.NewHTTPClientRecorder(metricSet, metrics.SubsystemHTTPClient)
 	integrationHTTPClient := metrics.NewObservedHTTPClient(
@@ -228,11 +244,14 @@ func main() {
 	}()
 
 	exitCode := 0
+	var schemaMismatch *dbconn.SchemaVersionMismatchError
 	select {
 	case err := <-workerErr:
+		unexpectedWorkerErr := err != nil && signalCtx.Err() == nil
 		cancel()
+		stop()
 		<-healthErr
-		if err != nil && signalCtx.Err() == nil {
+		if unexpectedWorkerErr {
 			log.Error("kernel worker failed", "error", err)
 			exitCode = 1
 		}
@@ -250,9 +269,31 @@ func main() {
 		cancel()
 		<-healthErr
 		<-workerErr
+	case <-schemaGuard.Done():
+		schemaMismatch = schemaGuard.Mismatch()
+		cancel()
+		<-workerErr
 	}
 	<-cronTriggerDone
 	backgroundRunner.Shutdown()
+	if schemaMismatch != nil {
+		log.Warn(
+			"worker schema version mismatch",
+			"expected_version", schemaMismatch.Expected,
+			"actual_version", schemaMismatch.Actual,
+			"action", "quiesce",
+		)
+		var healthServerErr error
+		select {
+		case <-signalCtx.Done():
+			healthServerErr = <-healthErr
+		case healthServerErr = <-healthErr:
+		}
+		if healthServerErr != nil {
+			log.Error("worker health and metrics server failed", "error", healthServerErr)
+			exitCode = 1
+		}
+	}
 	if exitCode != 0 {
 		os.Exit(exitCode)
 	}

--- a/internal/dbmigrate/postgres.go
+++ b/internal/dbmigrate/postgres.go
@@ -98,13 +98,11 @@ func ApplyPostgres(
 		delegate: locker,
 		timeout:  migrationUnlockTimeout,
 	}
-	provider, err := goose.NewProvider(
-		goose.DialectPostgres,
+	provider, err := newPostgresProvider(
 		db,
 		migrations,
+		goMigrations,
 		goose.WithSessionLocker(boundedLocker),
-		goose.WithDisableGlobalRegistry(true),
-		goose.WithGoMigrations(goMigrations...),
 	)
 	if err != nil {
 		return fmt.Errorf("create PostgreSQL migration provider: %w", err)
@@ -134,6 +132,32 @@ func ApplyPostgres(
 		)
 	}
 	return nil
+}
+
+func PostgresTargetVersion(
+	db *sql.DB,
+	migrations fs.FS,
+	goMigrations ...*goose.Migration,
+) (int64, error) {
+	provider, err := newPostgresProvider(db, migrations, goMigrations)
+	if err != nil {
+		return 0, fmt.Errorf("create PostgreSQL migration provider: %w", err)
+	}
+	sources := provider.ListSources()
+	return sources[len(sources)-1].Version, nil
+}
+
+func newPostgresProvider(
+	db *sql.DB,
+	migrations fs.FS,
+	goMigrations []*goose.Migration,
+	opts ...goose.ProviderOption,
+) (*goose.Provider, error) {
+	opts = append(opts,
+		goose.WithDisableGlobalRegistry(true),
+		goose.WithGoMigrations(goMigrations...),
+	)
+	return goose.NewProvider(goose.DialectPostgres, db, migrations, opts...)
 }
 
 // Goose removes cancellation before SessionUnlock; restore a deadline so cleanup cannot hang.

--- a/internal/dbmigrate/postgres.go
+++ b/internal/dbmigrate/postgres.go
@@ -135,11 +135,10 @@ func ApplyPostgres(
 }
 
 func PostgresTargetVersion(
-	db *sql.DB,
 	migrations fs.FS,
 	goMigrations ...*goose.Migration,
 ) (int64, error) {
-	provider, err := newPostgresProvider(db, migrations, goMigrations)
+	provider, err := newPostgresProvider(new(sql.DB), migrations, goMigrations)
 	if err != nil {
 		return 0, fmt.Errorf("create PostgreSQL migration provider: %w", err)
 	}

--- a/internal/dbmigrate/postgres_test.go
+++ b/internal/dbmigrate/postgres_test.go
@@ -8,12 +8,28 @@ import (
 	"testing"
 	"testing/fstest"
 	"time"
+
+	"github.com/pressly/goose/v3"
 )
 
 func TestRunPostgresRequiresPositiveTimeout(t *testing.T) {
 	err := RunPostgres(context.Background(), "not-used", fstest.MapFS{}, 0)
 	if err == nil || !strings.Contains(err.Error(), "must be positive") {
 		t.Fatalf("migration timeout error = %v", err)
+	}
+}
+
+func TestPostgresTargetVersionUsesLatestMigrationSource(t *testing.T) {
+	target, err := PostgresTargetVersion(
+		new(sql.DB),
+		fstest.MapFS{"000001_initial.sql": {Data: []byte("-- +goose Up\nSELECT 1;")}},
+		goose.NewGoMigration(2, nil, nil),
+	)
+	if err != nil {
+		t.Fatalf("read PostgreSQL migration target version: %v", err)
+	}
+	if target != 2 {
+		t.Fatalf("PostgreSQL migration target version = %d, want 2", target)
 	}
 }
 

--- a/internal/dbmigrate/postgres_test.go
+++ b/internal/dbmigrate/postgres_test.go
@@ -21,7 +21,6 @@ func TestRunPostgresRequiresPositiveTimeout(t *testing.T) {
 
 func TestPostgresTargetVersionUsesLatestMigrationSource(t *testing.T) {
 	target, err := PostgresTargetVersion(
-		new(sql.DB),
 		fstest.MapFS{"000001_initial.sql": {Data: []byte("-- +goose Up\nSELECT 1;")}},
 		goose.NewGoMigration(2, nil, nil),
 	)

--- a/internal/harness/tools/dispatch.go
+++ b/internal/harness/tools/dispatch.go
@@ -9,6 +9,7 @@ import (
 	logpkg "github.com/omnara-ai/omnara/internal/log"
 	"github.com/omnara-ai/omnara/internal/model"
 	"github.com/omnara-ai/omnara/internal/storage"
+	"github.com/omnara-ai/omnara/internal/storage/dbconn"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
 )
@@ -365,9 +366,11 @@ func retryAsyncToolPersistence(
 }
 
 func retryableAsyncToolPersistenceError(ctx context.Context, err error) bool {
+	var schemaMismatch *dbconn.SchemaVersionMismatchError
 	return ctx.Err() == nil &&
 		!errors.Is(err, context.Canceled) &&
 		!errors.Is(err, context.DeadlineExceeded) &&
+		!errors.As(err, &schemaMismatch) &&
 		!errors.Is(err, storeerr.ErrRuntimeLockInactive) &&
 		!errors.Is(err, storeerr.ErrStateTransitionConflict) &&
 		!errors.Is(err, storeerr.ErrIdempotencyConflict) &&

--- a/internal/harness/tools/dispatch_test.go
+++ b/internal/harness/tools/dispatch_test.go
@@ -1,6 +1,12 @@
 package tools
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/omnara-ai/omnara/internal/storage/dbconn"
+)
 
 func TestToolCompletionRejectsUnsetContent(t *testing.T) {
 	transactional := completeInTransaction(toolResultContent{})
@@ -19,5 +25,15 @@ func TestToolCompletionRejectsUnsetContent(t *testing.T) {
 	}
 	if _, ok := completeAsynchronously(empty).(completeAsync); !ok {
 		t.Fatal("explicitly empty async result was not accepted")
+	}
+}
+
+func TestSchemaVersionMismatchIsNotRetryableForAsyncPersistence(t *testing.T) {
+	err := fmt.Errorf("persist tool result: %w", &dbconn.SchemaVersionMismatchError{
+		Expected: 26,
+		Actual:   27,
+	})
+	if retryableAsyncToolPersistenceError(context.Background(), err) {
+		t.Fatal("schema version mismatch is retryable")
 	}
 }

--- a/internal/storage/accountsecurity/service.go
+++ b/internal/storage/accountsecurity/service.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/omnara-ai/omnara/internal/storage/dbconn"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
 )
 
 type Service struct {
-	pool     *pgxpool.Pool
+	db       dbconn.DB
 	identity *identitystore.Store
 }
 
@@ -20,11 +20,11 @@ func isNilID(id identitystore.ID) bool {
 }
 
 func New(
-	pool *pgxpool.Pool,
+	db dbconn.DB,
 	identity *identitystore.Store,
 ) *Service {
 	return &Service{
-		pool:     pool,
+		db:       db,
 		identity: identity,
 	}
 }
@@ -37,7 +37,7 @@ func (s *Service) RevokeUserTokensForCompromiseWithPasswordIfPresent(
 	if isNilID(userID) {
 		return storeerr.ErrUnauthorized
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin compromise revocation: %w", err)
 	}

--- a/internal/storage/artifactstore/artifacts_store.go
+++ b/internal/storage/artifactstore/artifacts_store.go
@@ -75,7 +75,7 @@ func (s *Store) CreateArtifact(
 		return ArtifactRecord{}, fmt.Errorf("upload artifact content: %w", err)
 	}
 	cleanupUploadedBlob := func(cause error) error {
-		if err := s.blobs.DeleteBlob(ctx, artifactKey); err != nil {
+		if err := s.blobs.DeleteBlob(context.WithoutCancel(ctx), artifactKey); err != nil {
 			return errors.Join(cause, fmt.Errorf("cleanup uploaded artifact content: %w", err))
 		}
 		return cause
@@ -83,7 +83,7 @@ func (s *Store) CreateArtifact(
 	input.Digest = metadata.Digest
 	input.SizeBytes = &metadata.SizeBytes
 
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ArtifactRecord{}, cleanupUploadedBlob(fmt.Errorf("begin create artifact: %w", err))
 	}

--- a/internal/storage/artifactstore/artifacts_store_test.go
+++ b/internal/storage/artifactstore/artifacts_store_test.go
@@ -1,6 +1,45 @@
 package artifactstore
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/omnara-ai/omnara/internal/blobstore"
+	"github.com/omnara-ai/omnara/internal/storage/dbconn"
+)
+
+type artifactBeginFailureDB struct {
+	dbconn.DB
+	err error
+}
+
+func (db artifactBeginFailureDB) BeginTx(context.Context, pgx.TxOptions) (pgx.Tx, error) {
+	return nil, db.err
+}
+
+type cancelingArtifactBlobStore struct {
+	blobstore.Store
+	cancel       context.CancelFunc
+	deleteCalled bool
+	deleteCtxErr error
+}
+
+func (store *cancelingArtifactBlobStore) PutBlob(
+	context.Context,
+	string,
+	[]byte,
+) (blobstore.Metadata, error) {
+	store.cancel()
+	return blobstore.Metadata{Digest: "sha256:test", SizeBytes: 4}, nil
+}
+
+func (store *cancelingArtifactBlobStore) DeleteBlob(ctx context.Context, _ string) error {
+	store.deleteCalled = true
+	store.deleteCtxErr = ctx.Err()
+	return store.deleteCtxErr
+}
 
 func TestArtifactObjectKeyUsesAgentAndArtifactID(t *testing.T) {
 	agentID := parseUUIDText("018ffc6b-7f1a-7828-8687-93aa210f5f4a")
@@ -11,5 +50,28 @@ func TestArtifactObjectKeyUsesAgentAndArtifactID(t *testing.T) {
 		artifactID,
 	), "artifacts/018ffc6b-7f1a-7828-8687-93aa210f5f4a/018ffc6b-7f1a-7c16-8a7a-973be2463b7d"; got != want {
 		t.Fatalf("artifact object key = %q, want %q", got, want)
+	}
+}
+
+func TestCreateArtifactCleanupSurvivesCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	beginErr := errors.New("begin transaction")
+	blobs := &cancelingArtifactBlobStore{cancel: cancel}
+	store := New(artifactBeginFailureDB{err: beginErr}, blobs)
+
+	_, err := store.CreateArtifact(ctx, CreateArtifactInput{
+		ProjectID:   parseUUIDText("018ffc6b-7f1a-7828-8687-93aa210f5f4a"),
+		AgentID:     parseUUIDText("018ffc6b-7f1a-7c16-8a7a-973be2463b7d"),
+		ContentType: "text/plain",
+		Content:     []byte("test"),
+	})
+	if !errors.Is(err, beginErr) {
+		t.Fatalf("create artifact error = %v, want %v", err, beginErr)
+	}
+	if !blobs.deleteCalled {
+		t.Fatal("uploaded blob was not cleaned up")
+	}
+	if blobs.deleteCtxErr != nil {
+		t.Fatalf("cleanup context error = %v, want nil", blobs.deleteCtxErr)
 	}
 }

--- a/internal/storage/artifactstore/store.go
+++ b/internal/storage/artifactstore/store.go
@@ -2,8 +2,8 @@ package artifactstore
 
 import (
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/omnara-ai/omnara/internal/blobstore"
+	"github.com/omnara-ai/omnara/internal/storage/dbconn"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
 	"github.com/omnara-ai/omnara/internal/storage/internal/storeutil"
 )
@@ -13,13 +13,13 @@ type ID = uuid.UUID
 var NilID = uuid.Nil
 
 type Store struct {
-	pool  *pgxpool.Pool
+	db    dbconn.DB
 	q     *dbsqlc.Queries
 	blobs blobstore.Store
 }
 
-func New(pool *pgxpool.Pool, blobs blobstore.Store) *Store {
-	return &Store{pool: pool, q: dbsqlc.New(pool), blobs: blobs}
+func New(db dbconn.DB, blobs blobstore.Store) *Store {
+	return &Store{db: db, q: dbsqlc.New(db), blobs: blobs}
 }
 
 func isNilID(id ID) bool {

--- a/internal/storage/dbconn/db.go
+++ b/internal/storage/dbconn/db.go
@@ -1,0 +1,15 @@
+package dbconn
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type DB interface {
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
+	BeginTx(context.Context, pgx.TxOptions) (pgx.Tx, error)
+}

--- a/internal/storage/dbconn/schema_guard.go
+++ b/internal/storage/dbconn/schema_guard.go
@@ -2,13 +2,19 @@ package dbconn
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+var errSchemaVersionInactive = errors.New("database schema version is not active")
+
+const schemaActivationPollInterval = time.Second
 
 type SchemaVersionMismatchError struct {
 	Expected int64
@@ -23,6 +29,7 @@ type SchemaGuard struct {
 	pool     *pgxpool.Pool
 	expected int64
 	done     chan struct{}
+	active   atomic.Bool
 	mismatch atomic.Pointer[SchemaVersionMismatchError]
 }
 
@@ -42,7 +49,39 @@ func (guard *SchemaGuard) Ready(context.Context) error {
 	if mismatch := guard.Mismatch(); mismatch != nil {
 		return mismatch
 	}
-	return nil
+	if guard.active.Load() {
+		return nil
+	}
+	return errSchemaVersionInactive
+}
+
+func (guard *SchemaGuard) WaitForActivation(ctx context.Context) bool {
+	if guard.Mismatch() != nil {
+		return false
+	}
+	if guard.active.Load() {
+		return true
+	}
+	ticker := time.NewTicker(schemaActivationPollInterval)
+	defer ticker.Stop()
+	for {
+		actual, err := readSchemaVersion(ctx, guard.pool)
+		if err == nil {
+			switch {
+			case actual == guard.expected:
+				guard.active.Store(true)
+				return true
+			case actual > guard.expected:
+				_ = guard.observe(actual)
+				return false
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ticker.C:
+		}
+	}
 }
 
 func (guard *SchemaGuard) Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error) {
@@ -98,6 +137,9 @@ func (guard *SchemaGuard) begin(ctx context.Context, opts pgx.TxOptions) (*guard
 	}
 	if opts != (pgx.TxOptions{}) {
 		return nil, fmt.Errorf("schema guard requires default transaction options")
+	}
+	if !guard.active.Load() {
+		return nil, errSchemaVersionInactive
 	}
 	opts.IsoLevel = pgx.ReadCommitted
 	tx, err := guard.pool.BeginTx(ctx, opts)

--- a/internal/storage/dbconn/schema_guard.go
+++ b/internal/storage/dbconn/schema_guard.go
@@ -1,0 +1,231 @@
+package dbconn
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type SchemaVersionMismatchError struct {
+	Expected int64
+	Actual   int64
+}
+
+func (err *SchemaVersionMismatchError) Error() string {
+	return fmt.Sprintf("database schema version %d does not match binary version %d", err.Actual, err.Expected)
+}
+
+type SchemaGuard struct {
+	pool     *pgxpool.Pool
+	expected int64
+	done     chan struct{}
+	mismatch atomic.Pointer[SchemaVersionMismatchError]
+}
+
+func NewSchemaGuard(pool *pgxpool.Pool, expected int64) *SchemaGuard {
+	return &SchemaGuard{pool: pool, expected: expected, done: make(chan struct{})}
+}
+
+func (guard *SchemaGuard) Done() <-chan struct{} {
+	return guard.done
+}
+
+func (guard *SchemaGuard) Mismatch() *SchemaVersionMismatchError {
+	return guard.mismatch.Load()
+}
+
+func (guard *SchemaGuard) Ready(context.Context) error {
+	if mismatch := guard.Mismatch(); mismatch != nil {
+		return mismatch
+	}
+	return nil
+}
+
+func (guard *SchemaGuard) Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error) {
+	tx, err := guard.begin(ctx, pgx.TxOptions{})
+	if err != nil {
+		return pgconn.CommandTag{}, err
+	}
+	tag, err := tx.Exec(ctx, sql, arguments...)
+	if err != nil {
+		return pgconn.CommandTag{}, tx.abort(ctx, err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return pgconn.CommandTag{}, err
+	}
+	return tag, nil
+}
+
+func (guard *SchemaGuard) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	tx, err := guard.begin(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, err
+	}
+	rows, err := tx.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, tx.abort(ctx, err)
+	}
+	return &guardedRows{
+		Rows:   rows,
+		commit: func() error { return tx.Commit(ctx) },
+		abort:  func(cause error) error { return tx.abort(ctx, cause) },
+	}, nil
+}
+
+func (guard *SchemaGuard) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
+	tx, err := guard.begin(ctx, pgx.TxOptions{})
+	if err != nil {
+		return &guardedRow{err: err}
+	}
+	return &guardedRow{
+		row:    tx.QueryRow(ctx, sql, args...),
+		commit: func() error { return tx.Commit(ctx) },
+		abort:  func(cause error) error { return tx.abort(ctx, cause) },
+	}
+}
+
+func (guard *SchemaGuard) BeginTx(ctx context.Context, opts pgx.TxOptions) (pgx.Tx, error) {
+	return guard.begin(ctx, opts)
+}
+
+func (guard *SchemaGuard) begin(ctx context.Context, opts pgx.TxOptions) (*guardedTx, error) {
+	if mismatch := guard.Mismatch(); mismatch != nil {
+		return nil, mismatch
+	}
+	if opts != (pgx.TxOptions{}) {
+		return nil, fmt.Errorf("schema guard requires default transaction options")
+	}
+	opts.IsoLevel = pgx.ReadCommitted
+	tx, err := guard.pool.BeginTx(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &guardedTx{Tx: tx, guard: guard}, nil
+}
+
+func (guard *SchemaGuard) observe(actual int64) *SchemaVersionMismatchError {
+	if actual != guard.expected {
+		mismatch := &SchemaVersionMismatchError{Expected: guard.expected, Actual: actual}
+		if guard.mismatch.CompareAndSwap(nil, mismatch) {
+			close(guard.done)
+		}
+	}
+	return guard.Mismatch()
+}
+
+func readSchemaVersion(ctx context.Context, db interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+}) (int64, error) {
+	var version int64
+	if err := db.QueryRow(ctx, `SELECT COALESCE(MAX(version_id), 0) FROM goose_db_version`).Scan(&version); err != nil {
+		return 0, fmt.Errorf("read database schema version: %w", err)
+	}
+	return version, nil
+}
+
+type guardedTx struct {
+	pgx.Tx
+	guard *SchemaGuard
+}
+
+func (tx *guardedTx) Commit(ctx context.Context) error {
+	if mismatch := tx.guard.Mismatch(); mismatch != nil {
+		return tx.abort(ctx, mismatch)
+	}
+	if _, err := tx.Exec(ctx, `LOCK TABLE goose_db_version IN SHARE MODE`); err != nil {
+		return tx.abort(ctx, err)
+	}
+	actual, err := readSchemaVersion(ctx, tx.Tx)
+	if err != nil {
+		return tx.abort(ctx, err)
+	}
+	if mismatch := tx.guard.observe(actual); mismatch != nil {
+		return tx.abort(ctx, mismatch)
+	}
+	return tx.Tx.Commit(ctx)
+}
+
+func (tx *guardedTx) Rollback(ctx context.Context) error {
+	if err := tx.Tx.Rollback(ctx); err != nil {
+		return err
+	}
+	if tx.guard.Mismatch() == nil {
+		actual, err := readSchemaVersion(ctx, tx.guard.pool)
+		if err == nil {
+			_ = tx.guard.observe(actual)
+		}
+	}
+	return nil
+}
+
+func (tx *guardedTx) abort(ctx context.Context, cause error) error {
+	_ = tx.Rollback(ctx)
+	if mismatch := tx.guard.Mismatch(); mismatch != nil {
+		return mismatch
+	}
+	return cause
+}
+
+type guardedRow struct {
+	row    pgx.Row
+	err    error
+	commit func() error
+	abort  func(error) error
+}
+
+func (row *guardedRow) Scan(dest ...any) error {
+	if row.err != nil {
+		return row.err
+	}
+	if err := row.row.Scan(dest...); err != nil {
+		return row.abort(err)
+	}
+	return row.commit()
+}
+
+type guardedRows struct {
+	pgx.Rows
+	commit   func() error
+	abort    func(error) error
+	err      error
+	finished bool
+}
+
+func (rows *guardedRows) Close() {
+	rows.Rows.Close()
+	rows.finish()
+}
+
+func (rows *guardedRows) finish() {
+	if rows.finished {
+		return
+	}
+	rows.finished = true
+	if err := rows.Rows.Err(); err != nil {
+		rows.err = rows.abort(err)
+		return
+	}
+	rows.err = rows.commit()
+}
+
+func (rows *guardedRows) Next() bool {
+	if rows.finished {
+		return false
+	}
+	if rows.Rows.Next() {
+		return true
+	}
+	rows.finish()
+	return false
+}
+
+func (rows *guardedRows) Err() error {
+	if rows.Rows.Err() != nil {
+		rows.finish()
+	}
+	return rows.err
+}

--- a/internal/storage/dbconn/schema_guard_test.go
+++ b/internal/storage/dbconn/schema_guard_test.go
@@ -1,0 +1,74 @@
+package dbconn
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type recordingRollbackTx struct {
+	pgx.Tx
+	rolledBack bool
+}
+
+func (tx *recordingRollbackTx) Rollback(context.Context) error {
+	tx.rolledBack = true
+	return nil
+}
+
+func TestSchemaGuardRejectsNonDefaultTransactionOptions(t *testing.T) {
+	guard := NewSchemaGuard(nil, 1)
+	if _, err := guard.BeginTx(
+		context.Background(),
+		pgx.TxOptions{IsoLevel: pgx.ReadCommitted},
+	); err == nil {
+		t.Fatal("expected non-default transaction options error")
+	}
+}
+
+func TestSchemaGuardLatchesFirstMismatch(t *testing.T) {
+	guard := NewSchemaGuard(nil, 26)
+	if err := guard.observe(26); err != nil {
+		t.Fatalf("matching version: %v", err)
+	}
+	if err := guard.Ready(context.Background()); err != nil {
+		t.Fatalf("ready before mismatch: %v", err)
+	}
+	if err := guard.observe(27); err == nil {
+		t.Fatal("expected schema version mismatch")
+	}
+	if err := guard.observe(28); err == nil {
+		t.Fatal("expected latched schema version mismatch")
+	}
+	if err := guard.observe(26); err == nil {
+		t.Fatal("expected matching observation to preserve latched mismatch")
+	}
+	mismatch := guard.Mismatch()
+	if mismatch == nil || mismatch.Expected != 26 || mismatch.Actual != 27 {
+		t.Fatalf("latched mismatch = %+v", mismatch)
+	}
+	select {
+	case <-guard.Done():
+	default:
+		t.Fatal("mismatch channel is open")
+	}
+	if err := guard.Ready(context.Background()); !errors.Is(err, mismatch) {
+		t.Fatalf("readiness error = %v, want %v", err, mismatch)
+	}
+}
+
+func TestRollbackSkipsVersionReadAfterMismatch(t *testing.T) {
+	guard := NewSchemaGuard(nil, 26)
+	_ = guard.observe(27)
+	rawTx := &recordingRollbackTx{}
+	tx := &guardedTx{Tx: rawTx, guard: guard}
+
+	if err := tx.Rollback(context.Background()); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if !rawTx.rolledBack {
+		t.Fatal("underlying transaction was not rolled back")
+	}
+}

--- a/internal/storage/dbconn/schema_guard_test.go
+++ b/internal/storage/dbconn/schema_guard_test.go
@@ -28,8 +28,19 @@ func TestSchemaGuardRejectsNonDefaultTransactionOptions(t *testing.T) {
 	}
 }
 
+func TestSchemaGuardStartsInactive(t *testing.T) {
+	guard := NewSchemaGuard(nil, 1)
+	if err := guard.Ready(context.Background()); !errors.Is(err, errSchemaVersionInactive) {
+		t.Fatalf("readiness error = %v, want %v", err, errSchemaVersionInactive)
+	}
+	if _, err := guard.BeginTx(context.Background(), pgx.TxOptions{}); !errors.Is(err, errSchemaVersionInactive) {
+		t.Fatalf("begin transaction error = %v, want %v", err, errSchemaVersionInactive)
+	}
+}
+
 func TestSchemaGuardLatchesFirstMismatch(t *testing.T) {
 	guard := NewSchemaGuard(nil, 26)
+	guard.active.Store(true)
 	if err := guard.observe(26); err != nil {
 		t.Fatalf("matching version: %v", err)
 	}
@@ -56,6 +67,9 @@ func TestSchemaGuardLatchesFirstMismatch(t *testing.T) {
 	}
 	if err := guard.Ready(context.Background()); !errors.Is(err, mismatch) {
 		t.Fatalf("readiness error = %v, want %v", err, mismatch)
+	}
+	if guard.WaitForActivation(context.Background()) {
+		t.Fatal("mismatched active guard activated")
 	}
 }
 

--- a/internal/storage/executionstore/agent_config_changes_store.go
+++ b/internal/storage/executionstore/agent_config_changes_store.go
@@ -52,7 +52,7 @@ func (s *Store) ChangeAgentConfig(ctx context.Context, input ChangeAgentConfigIn
 		return ChangeAgentConfigResult{}, errors.New("project and agent are required")
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ChangeAgentConfigResult{}, fmt.Errorf("begin change agent config: %w", err)
 	}

--- a/internal/storage/executionstore/agent_configs_store.go
+++ b/internal/storage/executionstore/agent_configs_store.go
@@ -25,7 +25,7 @@ func (s *Store) CreateAgentConfig(ctx context.Context, input CreateAgentConfigIn
 	input.Definition = normalizedJSON(input.Definition)
 	input = withDefaultAgentConfigCompilation(input)
 
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return AgentConfigRecord{}, fmt.Errorf("begin create agent config: %w", err)
 	}
@@ -89,7 +89,7 @@ func (s *Store) CaptureAgentConfigForModelContext(
 		return AgentConfigSnapshotRecord{}, errors.New("project and agent are required")
 	}
 
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return AgentConfigSnapshotRecord{}, fmt.Errorf(
 			"begin capture agent config for model context: %w",

--- a/internal/storage/executionstore/agent_content_inputs_store.go
+++ b/internal/storage/executionstore/agent_content_inputs_store.go
@@ -52,7 +52,7 @@ func (s *Store) CreateAgentContentInput(
 		return AgentInputRecord{}, nil, false, err
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return AgentInputRecord{}, nil, false, fmt.Errorf(
 			"begin create agent content input: %w",

--- a/internal/storage/executionstore/agent_fixture_integration.go
+++ b/internal/storage/executionstore/agent_fixture_integration.go
@@ -26,7 +26,7 @@ func (s *Store) CreateAgentFixture(ctx context.Context, input AgentFixtureInput)
 		return AgentRecord{}, errors.New("current config id is required")
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return AgentRecord{}, fmt.Errorf("begin create agent fixture: %w", err)
 	}

--- a/internal/storage/executionstore/agent_inputs_backlog_store.go
+++ b/internal/storage/executionstore/agent_inputs_backlog_store.go
@@ -82,7 +82,7 @@ func (s *Store) changeAgentInputDeliveryMode(
 		return errors.New("project id, agent id, and input id are required")
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin change agent input delivery mode: %w", err)
 	}

--- a/internal/storage/executionstore/agent_inputs_store.go
+++ b/internal/storage/executionstore/agent_inputs_store.go
@@ -105,7 +105,7 @@ func (s *Store) ClaimNextAgentWork(ctx context.Context, input ClaimNextAgentWork
 		return ClaimedAgentWork{}, false, err
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ClaimedAgentWork{}, false, fmt.Errorf("begin claim agent work: %w", err)
 	}
@@ -627,7 +627,7 @@ func (s *Store) CancelQueuedBacklogInput(
 	if isNilID(input.ProjectID) || isNilID(input.AgentID) || isNilID(input.InputID) {
 		return errors.New("project id, agent id, and input id are required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin cancel queued backlog input: %w", err)
 	}
@@ -688,7 +688,7 @@ func (s *Store) MoveQueuedBacklogInput(
 	default:
 		return errors.New("position must be front, back, before, or after")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin move queued backlog input: %w", err)
 	}

--- a/internal/storage/executionstore/agent_interactions_store.go
+++ b/internal/storage/executionstore/agent_interactions_store.go
@@ -92,7 +92,7 @@ func (s *Store) CreatePermissionInteraction(
 		return AgentInteractionRecord{}, fmt.Errorf("marshal permission request: %w", err)
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return AgentInteractionRecord{}, fmt.Errorf("begin create agent interaction: %w", err)
 	}
@@ -259,7 +259,7 @@ func (s *Store) ResolveAgentInteraction(
 		return AgentInteractionRecord{}, errors.New("project, agent, and interaction are required")
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return AgentInteractionRecord{}, fmt.Errorf("begin resolve agent interaction: %w", err)
 	}

--- a/internal/storage/executionstore/agent_launch_store.go
+++ b/internal/storage/executionstore/agent_launch_store.go
@@ -58,7 +58,7 @@ func (s *Store) LaunchAgent(
 		input.Name = &name
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return LaunchAgentResult{}, fmt.Errorf("begin launch agent: %w", err)
 	}

--- a/internal/storage/executionstore/agent_mcp_connections_store.go
+++ b/internal/storage/executionstore/agent_mcp_connections_store.go
@@ -82,7 +82,7 @@ func (s *Store) ReconcileAgentMCPConnections(
 	if reconciled && len(connections) == len(servers) && len(current) > 0 {
 		return connections, nil
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("begin reconcile agent mcp connections: %w", err)
 	}

--- a/internal/storage/executionstore/agent_profiles_store.go
+++ b/internal/storage/executionstore/agent_profiles_store.go
@@ -34,7 +34,7 @@ func (s *Store) CreateAgentProfile(
 	}
 	input.IdempotencyKey = agentProfileCreateIdempotencyKey(input.IdempotencyKey)
 
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return AgentProfileRecord{}, fmt.Errorf("begin create agent profile: %w", err)
 	}
@@ -121,7 +121,7 @@ func (s *Store) RetargetAgentProfile(
 	}
 	input.IdempotencyKey = agentProfileRetargetIdempotencyKey(input.IdempotencyKey)
 
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return AgentProfileRecord{}, fmt.Errorf("begin retarget agent profile: %w", err)
 	}
@@ -237,7 +237,7 @@ func (s *Store) RenameAgentProfile(
 		return AgentProfileRecord{}, storeerr.InvalidRequest(err)
 	}
 	input.Name = normalizedName
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return AgentProfileRecord{}, fmt.Errorf("begin rename agent profile: %w", err)
 	}
@@ -286,7 +286,7 @@ func (s *Store) GetAgentProfile(ctx context.Context, projectID, id ID) (AgentPro
 	if isNilID(projectID) {
 		return AgentProfileRecord{}, errors.New("project id is required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return AgentProfileRecord{}, fmt.Errorf("begin get agent: %w", err)
 	}
@@ -411,7 +411,7 @@ func (s *Store) DeleteAgentProfile(ctx context.Context, projectID, id ID) error 
 	if isNilID(projectID) || isNilID(id) {
 		return errors.New("project and agent profile are required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin delete agent profile: %w", err)
 	}

--- a/internal/storage/executionstore/agent_runtime_cancellation_store.go
+++ b/internal/storage/executionstore/agent_runtime_cancellation_store.go
@@ -34,7 +34,7 @@ func (s *Store) CancelAgent(
 		return CancelAgentResult{}, errors.New("project and agent are required")
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return CancelAgentResult{}, fmt.Errorf("begin cancel agent: %w", err)
 	}

--- a/internal/storage/executionstore/agent_runtime_lock_reaping_store.go
+++ b/internal/storage/executionstore/agent_runtime_lock_reaping_store.go
@@ -71,7 +71,7 @@ func (s *Store) reapExpiredAgentRuntimeLock(
 	projectID, agentID, runtimeLockID ID,
 ) (bool, error) {
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return false, fmt.Errorf("begin reap expired agent runtime lock: %w", err)
 	}

--- a/internal/storage/executionstore/agent_runtime_locks_store.go
+++ b/internal/storage/executionstore/agent_runtime_locks_store.go
@@ -87,7 +87,7 @@ func (s *Store) EnsureRuntimeLockActive(
 	if isNilID(projectID) || isNilID(agentID) || isNilID(runtimeID) {
 		return errors.New("project, agent, and runtime lock ids are required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin runtime lock check: %w", err)
 	}
@@ -135,7 +135,7 @@ func (s *Store) beginAgentRuntimeOwnedMutation(
 	ctx context.Context,
 	projectID, agentID, runtimeID ID,
 ) (pgx.Tx, *dbsqlc.Queries, error) {
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("begin runtime-owned mutation: %w", err)
 	}
@@ -316,7 +316,7 @@ func (s *Store) RenewAgentRuntimeLock(
 	if err := validateAgentRuntimeLockLeaseDuration(leaseDuration); err != nil {
 		return AgentRuntimeLockRenewal{}, err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return AgentRuntimeLockRenewal{}, fmt.Errorf("begin renew agent runtime lock: %w", err)
 	}
@@ -384,7 +384,7 @@ func (s *Store) ReleaseAgentRuntimeLock(
 	projectID, agentID, runtimeLockID ID,
 ) error {
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin release agent runtime lock: %w", err)
 	}

--- a/internal/storage/executionstore/agent_runtime_store.go
+++ b/internal/storage/executionstore/agent_runtime_store.go
@@ -348,7 +348,7 @@ func (s *Store) ArchiveAgent(
 	}
 	if err := validateProjectPrincipalActionTx(
 		ctx,
-		dbsqlc.New(s.pool),
+		s.q,
 		projectID,
 		archivedBy,
 		identitystore.AgentActionOperate,
@@ -364,7 +364,7 @@ func (s *Store) ArchiveAgent(
 		return AgentRecord{}, nil, err
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return AgentRecord{}, nil, fmt.Errorf("begin archive agent: %w", err)
 	}

--- a/internal/storage/executionstore/agent_wakeups_store.go
+++ b/internal/storage/executionstore/agent_wakeups_store.go
@@ -22,7 +22,7 @@ func (s *Store) RebuildMissingAgentWakeups(
 	var total int64
 	var afterAgentID *ID
 	for {
-		tx, beginErr := s.pool.BeginTx(ctx, pgx.TxOptions{})
+		tx, beginErr := s.db.BeginTx(ctx, pgx.TxOptions{})
 		if beginErr != nil {
 			return total, fmt.Errorf("begin missing agent wakeup rebuild batch: %w", beginErr)
 		}

--- a/internal/storage/executionstore/context_checkpoints_store.go
+++ b/internal/storage/executionstore/context_checkpoints_store.go
@@ -38,7 +38,7 @@ func (s *Store) PublishContextCheckpoint(
 	}
 	input.Usage = modelUsageForStorage(input.Usage)
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ContextCheckpointRecord{}, fmt.Errorf("begin publish context checkpoint: %w", err)
 	}

--- a/internal/storage/executionstore/context_checkpoints_terminal_failure.go
+++ b/internal/storage/executionstore/context_checkpoints_terminal_failure.go
@@ -46,7 +46,7 @@ func (s *Store) RecordTerminalCompactionFailure(
 		return err
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin terminal compaction failure: %w", err)
 	}

--- a/internal/storage/executionstore/cron_triggers_store.go
+++ b/internal/storage/executionstore/cron_triggers_store.go
@@ -110,7 +110,7 @@ func (s *Store) CreateCronTrigger(
 	}
 	input.IdempotencyKey = cronTriggerCreateIdempotencyKey(input.IdempotencyKey)
 
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return CronTriggerRecord{}, fmt.Errorf("begin create cron trigger: %w", err)
 	}
@@ -268,7 +268,7 @@ func (s *Store) UpdateCronTrigger(
 	if isNilID(input.ProjectID) || isNilID(input.TriggerID) {
 		return CronTriggerRecord{}, errors.New("project and cron trigger are required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return CronTriggerRecord{}, fmt.Errorf("begin update cron trigger: %w", err)
 	}
@@ -512,7 +512,7 @@ func (s *Store) ClaimDueCronTriggers(
 	if limit <= 0 {
 		return ClaimDueCronTriggersResult{}, errors.New("limit must be positive")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ClaimDueCronTriggersResult{}, fmt.Errorf("begin claim due cron triggers: %w", err)
 	}
@@ -587,7 +587,7 @@ func (s *Store) CompleteCronTriggerFiring(
 	if isNilID(input.ProjectID) || isNilID(input.TriggerID) || isNilID(input.ClaimToken) {
 		return errors.New("project, cron trigger, and claim token are required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin complete cron trigger firing: %w", err)
 	}

--- a/internal/storage/executionstore/integration_inputs_store.go
+++ b/internal/storage/executionstore/integration_inputs_store.go
@@ -30,7 +30,7 @@ func (s *Store) CreateIntegrationTargetContentInput(
 		return AgentInputRecord{}, nil, err
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return AgentInputRecord{}, nil, fmt.Errorf("begin create integration target input: %w", err)
 	}

--- a/internal/storage/executionstore/machine_connection_store.go
+++ b/internal/storage/executionstore/machine_connection_store.go
@@ -61,7 +61,7 @@ func (s *Store) ConnectBYOMachine(
 	if err != nil {
 		return ConnectBYOMachineResult{}, storeerr.InvalidRequest(err)
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ConnectBYOMachineResult{}, fmt.Errorf("begin connect BYO machine: %w", err)
 	}

--- a/internal/storage/executionstore/machine_daemon_bootstrap_store.go
+++ b/internal/storage/executionstore/machine_daemon_bootstrap_store.go
@@ -28,7 +28,7 @@ func (s *Store) CreateBYOMachineDaemonToken(
 	if err != nil {
 		return CreatedMachineDaemonToken{}, err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return CreatedMachineDaemonToken{}, fmt.Errorf("begin create machine daemon token: %w", err)
 	}
@@ -161,7 +161,7 @@ func (s *Store) BeginPoolMachineProviderProvisioning(
 	if err != nil {
 		return PoolMachineProviderProvisioningStart{}, err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return PoolMachineProviderProvisioningStart{}, fmt.Errorf(
 			"begin pool machine provider provisioning: %w",
@@ -315,7 +315,7 @@ func (s *Store) RevokeBYOMachineDaemonToken(
 	orgID, machineID, tokenID ID,
 	reason string,
 ) (MachineDaemonTokenRecord, error) {
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return MachineDaemonTokenRecord{}, fmt.Errorf("begin revoke machine daemon token: %w", err)
 	}
@@ -528,7 +528,7 @@ func (s *Store) RecordMachineFailureReport(
 		MachineID:       input.MachineID,
 		DaemonTokenID:   input.DaemonTokenID,
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin machine failure report: %w", err)
 	}

--- a/internal/storage/executionstore/machine_daemon_runtime_expiry_store.go
+++ b/internal/storage/executionstore/machine_daemon_runtime_expiry_store.go
@@ -41,7 +41,7 @@ func (s *Store) endExpiredDaemonRuntime(
 	ctx context.Context,
 	candidate dbsqlc.ListExpiredDaemonRuntimeCandidatesRow,
 ) (DaemonRuntimeRecord, bool, error) {
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return DaemonRuntimeRecord{}, false, fmt.Errorf("begin end expired daemon runtime: %w", err)
 	}

--- a/internal/storage/executionstore/machine_daemon_runtime_store.go
+++ b/internal/storage/executionstore/machine_daemon_runtime_store.go
@@ -54,7 +54,7 @@ func (s *Store) RegisterDaemonRuntimeWithReconciliation(
 	}
 	input.Capacity = normalizedJSON(input.Capacity)
 	input.ObservedPlatform = normalizedJSON(input.ObservedPlatform)
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return DaemonRuntimeRegistrationRecord{}, fmt.Errorf("begin register daemon runtime: %w", err)
 	}
@@ -271,7 +271,7 @@ func (s *Store) HeartbeatDaemonRuntime(
 	}
 	input.ObservedPlatform = normalizedJSON(input.ObservedPlatform)
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return DaemonRuntimeRecord{}, fmt.Errorf("begin heartbeat daemon runtime: %w", err)
 	}
@@ -329,7 +329,7 @@ func (s *Store) EndDaemonRuntime(
 		return DaemonRuntimeRecord{}, err
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return DaemonRuntimeRecord{}, fmt.Errorf("begin end daemon runtime: %w", err)
 	}
@@ -380,7 +380,7 @@ func (s *Store) SleepDaemonRuntime(
 		return DaemonRuntimeRecord{}, err
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return DaemonRuntimeRecord{}, fmt.Errorf("begin sleep daemon runtime: %w", err)
 	}

--- a/internal/storage/executionstore/machine_daemon_store.go
+++ b/internal/storage/executionstore/machine_daemon_store.go
@@ -228,7 +228,7 @@ func (s *Store) CreateDaemonMachine(ctx context.Context, input CreateDaemonMachi
 	if err != nil {
 		return MachineRecord{}, err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return MachineRecord{}, fmt.Errorf("begin create machine: %w", err)
 	}
@@ -344,7 +344,7 @@ func (s *Store) UpdateMachine(ctx context.Context, input UpdateMachineInput) (Ma
 	if isNilID(input.OrgID) || isNilID(input.MachineID) {
 		return MachineRecord{}, errors.New("org and machine are required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return MachineRecord{}, fmt.Errorf("begin update machine: %w", err)
 	}
@@ -526,7 +526,7 @@ func (s *Store) DeleteMachine(
 	if isNilID(input.OrgID) || isNilID(input.MachineID) {
 		return MachineRecord{}, errors.New("org and machine are required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return MachineRecord{}, fmt.Errorf("begin delete machine: %w", err)
 	}
@@ -648,7 +648,7 @@ func (s *Store) CreateProjectMachineGrant(
 	if err != nil {
 		return ProjectMachineGrantRecord{}, MachineRecord{}, err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ProjectMachineGrantRecord{}, MachineRecord{}, fmt.Errorf(
 			"begin create project machine grant: %w",
@@ -955,7 +955,7 @@ func (s *Store) DeleteProjectMachineGrant(
 	orgID, projectID, id ID,
 ) (ProjectMachineGrantRecord, error) {
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ProjectMachineGrantRecord{}, fmt.Errorf(
 			"begin delete project machine grant: %w",

--- a/internal/storage/executionstore/machine_lifecycle_store.go
+++ b/internal/storage/executionstore/machine_lifecycle_store.go
@@ -111,7 +111,7 @@ func (s *Store) ClaimPoolMachineForProvisioning(
 	if isNilID(orgID) || isNilID(machineID) {
 		return PoolMachineProvisioningClaim{}, false, errors.New("org and machine are required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return PoolMachineProvisioningClaim{}, false, fmt.Errorf("begin claim pool machine for provisioning: %w", err)
 	}
@@ -177,7 +177,7 @@ func (s *Store) AdmitPoolMachineProvisioning(
 	if err != nil {
 		return PoolMachineProvisioningAdmission{}, err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return PoolMachineProvisioningAdmission{}, fmt.Errorf(
 			"begin admit pool machine provisioning: %w",
@@ -432,7 +432,7 @@ func (s *Store) CompletePoolMachineProvisioning(
 	if provisionAttempt <= 0 {
 		return errors.New("provision attempt is required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin complete pool machine provisioning: %w", err)
 	}
@@ -482,7 +482,7 @@ func (s *Store) MarkPoolMachineProvisionFailed(
 	if input.RetryDelay < time.Millisecond {
 		return errors.New("retry delay must be at least one millisecond")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin mark pool machine provision failed: %w", err)
 	}
@@ -530,7 +530,7 @@ func (s *Store) MarkPoolMachineDeleting(ctx context.Context, input MachineDeleti
 	if input.ExpectedLifecycleVersion <= 0 {
 		return MachineRecord{}, false, errors.New("expected lifecycle version is required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return MachineRecord{}, false, fmt.Errorf("begin mark pool machine deleting: %w", err)
 	}
@@ -643,7 +643,7 @@ func (s *Store) ClaimExpiredIdlePoolMachineDeletion(
 	if isNilID(orgID) || isNilID(machineID) {
 		return PoolMachineDeletionClaim{}, false, errors.New("org and machine are required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return PoolMachineDeletionClaim{}, false, fmt.Errorf("begin claim expired idle pool machine deletion: %w", err)
 	}
@@ -701,7 +701,7 @@ func (s *Store) ClaimPoolMachineDeletion(
 	if input.ExpectedLifecycleVersion <= 0 {
 		return PoolMachineDeletionClaim{}, false, errors.New("expected lifecycle version is required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return PoolMachineDeletionClaim{}, false, fmt.Errorf("begin claim pool machine deletion: %w", err)
 	}
@@ -877,7 +877,7 @@ func (s *Store) MarkMachineDeleteFailed(ctx context.Context, input MachineDelete
 	if input.RetryDelay < time.Millisecond {
 		return errors.New("retry delay must be at least one millisecond")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin mark machine delete failed: %w", err)
 	}
@@ -930,7 +930,7 @@ func (s *Store) CompletePoolMachineDeletion(
 	if deleteAttempt <= 0 {
 		return errors.New("delete attempt is required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin complete pool machine deletion: %w", err)
 	}

--- a/internal/storage/executionstore/machine_pools_store.go
+++ b/internal/storage/executionstore/machine_pools_store.go
@@ -324,7 +324,7 @@ func (s *Store) CreateMachinePool(
 	if err := s.validatePoolDefaultsTx(ctx, s.q, input, poolDefaults); err != nil {
 		return MachinePoolRecord{}, err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return MachinePoolRecord{}, fmt.Errorf("begin create machine pool: %w", err)
 	}
@@ -640,7 +640,7 @@ func (s *Store) UpdateMachinePool(
 	if isNilID(input.OrgID) || isNilID(input.ID) {
 		return MachinePoolRecord{}, errors.New("org and machine pool are required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return MachinePoolRecord{}, fmt.Errorf("begin update machine pool: %w", err)
 	}
@@ -945,7 +945,7 @@ func (s *Store) DeleteMachinePool(ctx context.Context, orgID, id ID) ([]MachineR
 	if pool.ManagementKind == management.Cluster {
 		return nil, fmt.Errorf("cluster-managed machine pools cannot be deleted: %w", storeerr.ErrStateTransitionConflict)
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("begin delete machine pool: %w", err)
 	}

--- a/internal/storage/executionstore/machine_wake_store.go
+++ b/internal/storage/executionstore/machine_wake_store.go
@@ -32,7 +32,7 @@ func (s *Store) BeginMachineWake(
 		return MachineWakeUnavailable, errors.New("machine wake timeout must be at least one millisecond")
 	}
 
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return MachineWakeUnavailable, fmt.Errorf("begin machine wake: %w", err)
 	}

--- a/internal/storage/executionstore/model_contexts_claims.go
+++ b/internal/storage/executionstore/model_contexts_claims.go
@@ -55,7 +55,7 @@ type claimModelCallInput struct {
 func (s *Store) claimModelCall(ctx context.Context, input claimModelCallInput) (ModelCallClaim, error) {
 	projectID, agentID, runtimeLockID := claimIdentity(input)
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ModelCallClaim{}, fmt.Errorf("begin claim model call: %w", err)
 	}
@@ -403,7 +403,7 @@ func (s *Store) ClaimNextModelCallContext(
 		return ModelCallClaim{}, errors.New("project, agent, predecessor context, and runtime are required")
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ModelCallClaim{}, fmt.Errorf("begin claim next model call context: %w", err)
 	}

--- a/internal/storage/executionstore/model_contexts_compaction.go
+++ b/internal/storage/executionstore/model_contexts_compaction.go
@@ -46,7 +46,7 @@ func (s *Store) RecordModelCallFailureAndClaimCompaction(
 	}
 
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return TriggeredCompactionHandoff{}, fmt.Errorf("begin triggered compaction handoff: %w", err)
 	}
@@ -234,7 +234,7 @@ func (s *Store) ReplaceCompactionSource(
 	}
 
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ReplaceCompactionSourceResult{}, fmt.Errorf("begin compaction source replacement: %w", err)
 	}

--- a/internal/storage/executionstore/model_contexts_lifecycle.go
+++ b/internal/storage/executionstore/model_contexts_lifecycle.go
@@ -47,7 +47,7 @@ func (s *Store) RecordRetryableModelCallFailure(
 	); err != nil {
 		return ModelCallContextRecord{}, err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ModelCallContextRecord{}, fmt.Errorf("begin retryable model call failure: %w", err)
 	}

--- a/internal/storage/executionstore/model_outputs_terminal_error.go
+++ b/internal/storage/executionstore/model_outputs_terminal_error.go
@@ -50,7 +50,7 @@ func (s *Store) RecordModelCallErrorAndCompleteContext(
 		return events.Event{}, err
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return events.Event{}, fmt.Errorf("begin record model call error: %w", err)
 	}

--- a/internal/storage/executionstore/model_outputs_workflow.go
+++ b/internal/storage/executionstore/model_outputs_workflow.go
@@ -145,7 +145,7 @@ func (s *Store) RecordToolCallSourceAndCompleteContext(
 		return events.Event{}, nil, err
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return events.Event{}, nil, fmt.Errorf("begin record tool call source: %w", err)
 	}
@@ -402,7 +402,7 @@ func (s *Store) RecordModelOutputAndCompleteContext(
 		return events.Event{}, err
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return events.Event{}, fmt.Errorf("begin record model output: %w", err)
 	}

--- a/internal/storage/executionstore/process_action_completion_store.go
+++ b/internal/storage/executionstore/process_action_completion_store.go
@@ -222,7 +222,7 @@ func (s *Store) completeDaemonProcessAction(
 		return DaemonProcessActionReportApplication{}, errors.New("project, agent, process, and action are required")
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return DaemonProcessActionReportApplication{}, fmt.Errorf("begin complete process action: %w", err)
 	}

--- a/internal/storage/executionstore/process_actions_store.go
+++ b/internal/storage/executionstore/process_actions_store.go
@@ -209,7 +209,7 @@ func (s *Store) AcceptDaemonProcess(
 	if isNilID(input.ProcessID) {
 		return DaemonProcessOffer{}, false, errors.New("process is required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return DaemonProcessOffer{}, false, fmt.Errorf("begin accept daemon process: %w", err)
 	}
@@ -345,7 +345,7 @@ func (s *Store) AcceptDaemonProcessAction(
 	if isNilID(input.ProcessID) || isNilID(input.ID) {
 		return DaemonProcessActionGrant{}, false, errors.New("process and action are required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return DaemonProcessActionGrant{}, false, fmt.Errorf("begin accept daemon process action: %w", err)
 	}

--- a/internal/storage/executionstore/process_daemon_completion_store.go
+++ b/internal/storage/executionstore/process_daemon_completion_store.go
@@ -30,7 +30,7 @@ func (s *Store) MarkProcessStarted(
 	}
 	input.SourceStartedAt = canonicalSourceTime(input.SourceStartedAt)
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return DaemonProcessReportApplication{}, fmt.Errorf("begin mark process started: %w", err)
 	}
@@ -220,7 +220,7 @@ func (s *Store) CompleteDaemonProcess(
 		input.SourceEndedAt = canonicalSourceTime(input.SourceEndedAt)
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return DaemonProcessReportApplication{}, fmt.Errorf("begin complete daemon process: %w", err)
 	}
@@ -499,7 +499,7 @@ func (s *Store) GetProcessByToolCall(
 	if isNilID(projectID) || isNilID(agentID) || isNilID(toolCallID) {
 		return ProcessRecord{}, false, errors.New("project, agent, and tool call are required")
 	}
-	return getProcessByToolCallTx(ctx, s.pool, projectID, agentID, toolCallID)
+	return getProcessByToolCallTx(ctx, s.db, projectID, agentID, toolCallID)
 }
 
 func (r *ToolCallReader) ListActiveProcesses(

--- a/internal/storage/executionstore/process_tool_unreachable_store.go
+++ b/internal/storage/executionstore/process_tool_unreachable_store.go
@@ -179,7 +179,7 @@ func (s *Store) failMachineUnreachableQueuedProcess(
 	graceSeconds int32,
 ) (bool, error) {
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return false, fmt.Errorf("begin machine-unreachable queued process expiry: %w", err)
 	}
@@ -301,7 +301,7 @@ func (s *Store) failMachineUnreachableQueuedProcessActions(
 	graceSeconds int32,
 ) (int64, error) {
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return 0, fmt.Errorf("begin machine-unreachable queued action expiry: %w", err)
 	}
@@ -417,7 +417,7 @@ func (s *Store) completeMachineUnreachableProcessActionToolCall(
 		return false, err
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return false, fmt.Errorf(
 			"begin machine-unreachable process action completion: %w",
@@ -508,7 +508,7 @@ func (s *Store) completeMachineUnreachableToolCall(
 		return false, err
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return false, err
 	}

--- a/internal/storage/executionstore/processes_store.go
+++ b/internal/storage/executionstore/processes_store.go
@@ -268,7 +268,7 @@ func (s *Store) CompleteProcess(ctx context.Context, input CompleteProcessInput)
 	}
 	input.SourceEndedAt = canonicalSourceTime(input.SourceEndedAt)
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ProcessRecord{}, fmt.Errorf("begin complete process: %w", err)
 	}

--- a/internal/storage/executionstore/project_machine_pool_grants_store.go
+++ b/internal/storage/executionstore/project_machine_pool_grants_store.go
@@ -404,7 +404,7 @@ func (s *Store) CreateProjectMachinePoolGrant(
 	if err != nil {
 		return ProjectMachinePoolGrantRecord{}, storeerr.InvalidRequest(err)
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ProjectMachinePoolGrantRecord{}, fmt.Errorf("begin create project machine pool grant: %w", err)
 	}
@@ -556,7 +556,7 @@ func (s *Store) UpdateProjectMachinePoolGrant(
 			"pool grant org, project, and id are required",
 		))
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ProjectMachinePoolGrantRecord{}, fmt.Errorf("begin update project machine pool grant: %w", err)
 	}
@@ -752,7 +752,7 @@ func (s *Store) DeleteProjectMachinePoolGrant(
 		return DeleteProjectMachinePoolGrantResult{}, errors.New("pool grant org, project, and id are required")
 	}
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return DeleteProjectMachinePoolGrantResult{}, fmt.Errorf("begin revoke project machine pool grant: %w", err)
 	}

--- a/internal/storage/executionstore/provider_runtime_reconciliation_store.go
+++ b/internal/storage/executionstore/provider_runtime_reconciliation_store.go
@@ -234,7 +234,7 @@ func (s *Store) MarkProviderRuntimeMismatch(
 	if candidate.ProviderRuntimeMismatchSince != nil {
 		return false, nil
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return false, fmt.Errorf("begin provider runtime mismatch mark: %w", err)
 	}
@@ -343,7 +343,7 @@ func (s *Store) ClaimProviderRuntimeMismatchDeletion(
 	if !providerRuntimeWakeAllowsDeletion(candidate) {
 		return PoolMachineDeletionClaim{}, false, nil
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return PoolMachineDeletionClaim{}, false, fmt.Errorf(
 			"begin provider runtime mismatch deletion claim: %w",
@@ -415,7 +415,7 @@ func (s *Store) ClaimProviderRuntimeTerminatedDeletion(
 	if !providerRuntimeWakeAllowsDeletion(candidate) {
 		return PoolMachineDeletionClaim{}, false, nil
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return PoolMachineDeletionClaim{}, false, fmt.Errorf(
 			"begin provider runtime terminated deletion claim: %w",

--- a/internal/storage/executionstore/store.go
+++ b/internal/storage/executionstore/store.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/omnara-ai/omnara/internal/notifications"
+	"github.com/omnara-ai/omnara/internal/storage/dbconn"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
 	"github.com/omnara-ai/omnara/internal/storage/integrationstore"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
@@ -25,6 +26,7 @@ type Config struct {
 
 type Store struct {
 	pool                  *pgxpool.Pool
+	db                    dbconn.DB
 	q                     *dbsqlc.Queries
 	postCommitPublisher   notifications.PostCommitPublisher
 	modelCallRetryBackoff func(int, string) time.Duration
@@ -34,10 +36,12 @@ type Store struct {
 	secrets               *secretstore.Store
 }
 
-func New(pool *pgxpool.Pool, config Config) *Store {
+func New(db dbconn.DB, config Config) *Store {
+	pool, _ := db.(*pgxpool.Pool)
 	return &Store{
 		pool:                  pool,
-		q:                     dbsqlc.New(pool),
+		db:                    db,
+		q:                     dbsqlc.New(db),
 		postCommitPublisher:   config.PostCommitPublisher,
 		modelCallRetryBackoff: config.ModelCallRetryBackoff,
 		integrations:          config.Integrations,

--- a/internal/storage/executionstore/tool_call_execution.go
+++ b/internal/storage/executionstore/tool_call_execution.go
@@ -93,7 +93,7 @@ func (s *Store) executeToolCallOnce(
 	input ExecuteToolCallInput,
 	plan ToolCallPlan,
 ) (ExecuteToolCallResult, error) {
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ExecuteToolCallResult{}, fmt.Errorf("begin tool call execution: %w", err)
 	}

--- a/internal/storage/executionstore/tool_calls_store.go
+++ b/internal/storage/executionstore/tool_calls_store.go
@@ -149,7 +149,7 @@ func (s *Store) CompleteToolCall(
 	input CompleteToolCallInput,
 ) (ToolCallRecord, error) {
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ToolCallRecord{}, fmt.Errorf("begin complete tool call: %w", err)
 	}
@@ -495,7 +495,7 @@ func (s *Store) CompleteRuntimeToolCall(
 	input CompleteRuntimeToolCallInput,
 ) (ToolCallRecord, error) {
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ToolCallRecord{}, err
 	}
@@ -669,7 +669,7 @@ func (s *Store) CompleteCustomToolCall(
 	input CompleteCustomToolCallInput,
 ) (CompleteCustomToolCallResult, error) {
 	txNotifications := s.newTxNotifications()
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return CompleteCustomToolCallResult{}, err
 	}

--- a/internal/storage/identitystore/auth_connectors_store.go
+++ b/internal/storage/identitystore/auth_connectors_store.go
@@ -33,7 +33,7 @@ func (s *Store) UpsertAuthConnector(ctx context.Context, input CreateAuthConnect
 	if err != nil {
 		return AuthConnectorRecord{}, err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return AuthConnectorRecord{}, fmt.Errorf("begin upsert auth connector: %w", err)
 	}

--- a/internal/storage/identitystore/device_auth_store.go
+++ b/internal/storage/identitystore/device_auth_store.go
@@ -105,7 +105,7 @@ func (s *Store) ApproveDeviceAuthFlow(ctx context.Context, input ApproveDeviceAu
 	if input.UserCode == "" || isNilID(input.UserID) || isNilID(input.ApprovedBrowserSessionID) {
 		return storeerr.ErrUnauthorized
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin device auth approval: %w", err)
 	}
@@ -163,7 +163,7 @@ func (s *Store) DenyDeviceAuthFlow(ctx context.Context, input DenyDeviceAuthFlow
 	if input.UserCode == "" {
 		return storeerr.ErrUnauthorized
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin device auth denial: %w", err)
 	}
@@ -205,7 +205,7 @@ func (s *Store) PollDeviceAuthFlow(
 	if input.DeviceCode == "" {
 		return DeviceAuthFlowPollRecord{}, storeerr.ErrUnauthorized
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return DeviceAuthFlowPollRecord{}, fmt.Errorf("begin device auth poll: %w", err)
 	}

--- a/internal/storage/identitystore/org_api_keys_store.go
+++ b/internal/storage/identitystore/org_api_keys_store.go
@@ -40,7 +40,7 @@ func (s *Store) CreateOrgAPIKeyWithPlaintext(
 	if err != nil {
 		return CreatedOrgAPIKey{}, err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return CreatedOrgAPIKey{}, fmt.Errorf("begin create org api key: %w", err)
 	}
@@ -253,7 +253,7 @@ func (s *Store) UpdateOrgAPIKey(
 	if input.OrgRole != "" && !orgAPIKeyRoleAllowed(input.OrgRole) {
 		return OrgAPIKeyRecord{}, fmt.Errorf("org api key role must be %q or %q", authz.OrgRoleAdmin, authz.OrgRoleMember)
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return OrgAPIKeyRecord{}, fmt.Errorf("begin update org api key: %w", err)
 	}
@@ -334,7 +334,7 @@ func (s *Store) RevokeOrgAPIKey(
 	if isNilID(orgID) || isNilID(keyID) {
 		return OrgAPIKeyRecord{}, errors.New("org id and key id are required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return OrgAPIKeyRecord{}, fmt.Errorf("begin revoke org api key: %w", err)
 	}
@@ -391,7 +391,7 @@ func (s *Store) SetOrgAPIKeyProjectRole(
 	if !isValidProjectRole(input.Role) {
 		return ProjectMembershipRecord{}, errors.New("role must be admin, developer, operator, or viewer")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ProjectMembershipRecord{}, fmt.Errorf("begin set org api key project role: %w", err)
 	}
@@ -466,7 +466,7 @@ func (s *Store) RemoveOrgAPIKeyProjectRole(
 	if isNilID(input.OrgID) || isNilID(input.KeyID) || isNilID(input.ProjectID) {
 		return errors.New("org id, key id, and project id are required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin remove org api key project role: %w", err)
 	}

--- a/internal/storage/identitystore/org_invitations_store.go
+++ b/internal/storage/identitystore/org_invitations_store.go
@@ -31,7 +31,7 @@ func (s *Store) CreateOrgInvitation(
 		return OrgInvitationRecord{}, storeerr.InvalidRequest(errors.New("role must be admin or member"))
 	}
 	normalizedEmail := NormalizeEmail(input.Email)
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return OrgInvitationRecord{}, fmt.Errorf("begin create org invitation: %w", err)
 	}
@@ -291,7 +291,7 @@ func (s *Store) answerOrgInvitation(
 	if len(emailRows) == 0 {
 		return OrgInvitationWithOrgNameRecord{}, storeerr.ErrUnauthorized
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return OrgInvitationWithOrgNameRecord{}, fmt.Errorf("begin answer org invitation: %w", err)
 	}

--- a/internal/storage/identitystore/orgs_projects_store.go
+++ b/internal/storage/identitystore/orgs_projects_store.go
@@ -221,7 +221,7 @@ func (s *Store) CreateProjectForPrincipal(
 		return ProjectRecord{}, storeerr.InvalidRequest(err)
 	}
 	input.Name = normalizedName
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ProjectRecord{}, fmt.Errorf("begin create project: %w", err)
 	}

--- a/internal/storage/identitystore/password_auth_store.go
+++ b/internal/storage/identitystore/password_auth_store.go
@@ -54,7 +54,7 @@ func (s *Store) StartPasswordSignup(
 	if err != nil {
 		return PasswordSignupStartRecord{}, fmt.Errorf("generate email verification token: %w", err)
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return PasswordSignupStartRecord{}, fmt.Errorf("begin password signup: %w", err)
 	}
@@ -170,7 +170,7 @@ func (s *Store) CompletePasswordSignup(
 	if input.Token == "" || input.PasswordHash == "" {
 		return CompletePasswordSignupRecord{}, storeerr.ErrUnauthorized
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return CompletePasswordSignupRecord{}, fmt.Errorf("begin complete password signup: %w", err)
 	}
@@ -305,7 +305,7 @@ func (s *Store) AuthenticatePasswordAndCreateSession(
 	if err != nil {
 		return UserRecord{}, fmt.Errorf("load password credential: %w", err)
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return UserRecord{}, fmt.Errorf("begin password login: %w", err)
 	}
@@ -405,7 +405,7 @@ func (s *Store) StartPasswordReset(
 	if err != nil {
 		return PasswordResetStartRecord{}, fmt.Errorf("generate password reset token: %w", err)
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return PasswordResetStartRecord{}, fmt.Errorf("begin password reset request: %w", err)
 	}
@@ -444,7 +444,7 @@ func (s *Store) CompletePasswordReset(ctx context.Context, input CompletePasswor
 	if input.Token == "" || input.PasswordHash == "" {
 		return UserRecord{}, storeerr.ErrUnauthorized
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return UserRecord{}, fmt.Errorf("begin complete password reset: %w", err)
 	}
@@ -546,7 +546,7 @@ func (s *Store) ChangePassword(ctx context.Context, input ChangePasswordInput) (
 	if input.PasswordHash == "" {
 		return UserRecord{}, errors.New("password hash is required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return UserRecord{}, fmt.Errorf("begin change password: %w", err)
 	}

--- a/internal/storage/identitystore/personal_access_tokens_store.go
+++ b/internal/storage/identitystore/personal_access_tokens_store.go
@@ -29,7 +29,7 @@ func (s *Store) CreatePersonalAccessTokenWithPlaintext(
 	if err != nil {
 		return CreatedPersonalAccessToken{}, err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return CreatedPersonalAccessToken{}, fmt.Errorf("begin create personal access token: %w", err)
 	}

--- a/internal/storage/identitystore/support.go
+++ b/internal/storage/identitystore/support.go
@@ -6,23 +6,23 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/omnara-ai/omnara/internal/blobstore"
 	"github.com/omnara-ai/omnara/internal/secrets"
+	"github.com/omnara-ai/omnara/internal/storage/dbconn"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
 	"github.com/omnara-ai/omnara/internal/storage/internal/skillops"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
 )
 
 type Store struct {
-	pool             *pgxpool.Pool
+	db               dbconn.DB
 	q                *dbsqlc.Queries
 	secretKeyWrapper secrets.KeyWrapper
 	blobs            blobstore.Store
 }
 
-func New(pool *pgxpool.Pool, keyWrapper secrets.KeyWrapper, blobs blobstore.Store) *Store {
-	return &Store{pool: pool, q: dbsqlc.New(pool), secretKeyWrapper: keyWrapper, blobs: blobs}
+func New(db dbconn.DB, keyWrapper secrets.KeyWrapper, blobs blobstore.Store) *Store {
+	return &Store{db: db, q: dbsqlc.New(db), secretKeyWrapper: keyWrapper, blobs: blobs}
 }
 
 func (s *Store) GetInstallationID(ctx context.Context) (ID, error) {

--- a/internal/storage/identitystore/users_memberships_store.go
+++ b/internal/storage/identitystore/users_memberships_store.go
@@ -160,7 +160,7 @@ func (s *Store) resolveAuthIdentityUser(
 		return UserRecord{}, storeerr.ErrUnauthorized
 	}
 	email := strings.TrimSpace(input.Email)
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return UserRecord{}, fmt.Errorf("begin resolve auth identity user: %w", err)
 	}
@@ -304,7 +304,7 @@ func (s *Store) createAuthIdentitySession(
 	sessionToken, csrfToken string,
 	ttl time.Duration,
 ) (UserRecord, error) {
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return UserRecord{}, fmt.Errorf("begin auth identity session: %w", err)
 	}
@@ -366,7 +366,7 @@ func (s *Store) AddProjectMembership(
 			errors.New("role must be admin, developer, operator, or viewer"),
 		)
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ProjectMembershipRecord{}, fmt.Errorf("begin add project membership: %w", err)
 	}
@@ -415,7 +415,7 @@ func (s *Store) AddOrgMembership(
 	if input.Role == "" {
 		return OrgMembershipRecord{}, errors.New("role is required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return OrgMembershipRecord{}, fmt.Errorf("begin add org membership: %w", err)
 	}
@@ -500,7 +500,7 @@ func (s *Store) UpdateOrgMemberRole(
 	if input.Role != authz.OrgRoleAdmin && input.Role != authz.OrgRoleMember {
 		return OrgMembershipRecord{}, storeerr.InvalidRequest(errors.New("role must be admin or member"))
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return OrgMembershipRecord{}, fmt.Errorf("begin update org member role: %w", err)
 	}
@@ -549,7 +549,7 @@ func (s *Store) RemoveOrgMember(ctx context.Context, input RemoveOrgMemberInput)
 	if isNilID(input.UserID) {
 		return errors.New("user id is required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin remove org member: %w", err)
 	}
@@ -823,7 +823,7 @@ func (s *Store) DeleteUserAccount(ctx context.Context, userID ID) error {
 	if isNilID(userID) {
 		return errors.New("user is required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin delete user account: %w", err)
 	}

--- a/internal/storage/integration_fixture_test.go
+++ b/internal/storage/integration_fixture_test.go
@@ -908,6 +908,60 @@ func changeInputFromRecord(record executionstore.AgentConfigRecord) executionsto
 	}
 }
 
+func TestSchemaGuardWaitsForExpectedVersion(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pool := openIntegrationDB(t, ctx)
+
+	var current int64
+	if err := pool.QueryRow(ctx, `SELECT COALESCE(MAX(version_id), 0) FROM goose_db_version`).Scan(&current); err != nil {
+		t.Fatal(err)
+	}
+	guard := dbconn.NewSchemaGuard(pool, current+1)
+	activated := make(chan bool, 1)
+	go func() {
+		activated <- guard.WaitForActivation(ctx)
+	}()
+	if err := guard.Ready(ctx); err == nil {
+		t.Fatal("behind-version guard is ready")
+	}
+	select {
+	case <-guard.Done():
+		t.Fatal("behind-version guard latched a mismatch")
+	default:
+	}
+
+	migrationTx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = migrationTx.Rollback(ctx) }()
+	if _, err := migrationTx.Exec(
+		ctx,
+		`INSERT INTO goose_db_version (version_id, is_applied) VALUES ($1, true)`,
+		current+1,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := guard.BeginTx(ctx, pgx.TxOptions{}); err == nil {
+		t.Fatal("uncommitted-version guard began a transaction")
+	}
+	if err := migrationTx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case active := <-activated:
+		if !active {
+			t.Fatal("expected schema guard activation")
+		}
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	if err := guard.Ready(ctx); err != nil {
+		t.Fatalf("activated schema guard readiness: %v", err)
+	}
+}
+
 func TestSchemaGuardAllowsWorkUntilMigrationVersionCommits(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -928,6 +982,13 @@ func TestSchemaGuardAllowsWorkUntilMigrationVersionCommits(t *testing.T) {
 		t.Fatal(err)
 	}
 	guard := dbconn.NewSchemaGuard(guardPool, expected)
+	if !guard.WaitForActivation(ctx) {
+		t.Fatal("schema guard did not activate")
+	}
+	rollbackGuard := dbconn.NewSchemaGuard(guardPool, expected)
+	if !rollbackGuard.WaitForActivation(ctx) {
+		t.Fatal("rollback schema guard did not activate")
+	}
 	var value int
 	if err := guard.QueryRow(ctx, `SELECT 7`).Scan(&value); err != nil || value != 7 {
 		t.Fatalf("guarded row = (%d, %v), want (7, nil)", value, err)
@@ -1006,7 +1067,6 @@ func TestSchemaGuardAllowsWorkUntilMigrationVersionCommits(t *testing.T) {
 		t.Fatalf("schema mismatch = %+v", mismatch)
 	}
 
-	rollbackGuard := dbconn.NewSchemaGuard(guardPool, expected)
 	rollbackTx, err := rollbackGuard.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		t.Fatalf("begin guarded work before rollback: %v", err)
@@ -1028,6 +1088,23 @@ func TestSchemaGuardAllowsWorkUntilMigrationVersionCommits(t *testing.T) {
 	}
 
 	postCutoverGuard := dbconn.NewSchemaGuard(guardPool, expected)
+	postCutoverActivation := make(chan bool, 1)
+	go func() {
+		postCutoverActivation <- postCutoverGuard.WaitForActivation(ctx)
+	}()
+	select {
+	case <-postCutoverGuard.Done():
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	select {
+	case active := <-postCutoverActivation:
+		if active {
+			t.Fatal("post-cutover guard activated")
+		}
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
 	err = postCutoverGuard.QueryRow(
 		ctx,
 		`INSERT INTO schema_guard_writes (id) VALUES (3) RETURNING id`,

--- a/internal/storage/integration_fixture_test.go
+++ b/internal/storage/integration_fixture_test.go
@@ -5,15 +5,18 @@ package storage
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/omnara-ai/omnara/internal/agentconfig"
 	"github.com/omnara-ai/omnara/internal/publicid"
 	"github.com/omnara-ai/omnara/internal/secrets"
+	"github.com/omnara-ai/omnara/internal/storage/dbconn"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
@@ -902,5 +905,160 @@ func changeInputFromRecord(record executionstore.AgentConfigRecord) executionsto
 		CompiledDefinition:      record.CompiledDefinition,
 		CompilerVersion:         record.CompilerVersion,
 		EffectiveDefinitionHash: record.EffectiveDefinitionHash,
+	}
+}
+
+func TestSchemaGuardAllowsWorkUntilMigrationVersionCommits(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pool := openIntegrationDB(t, ctx)
+	guardConfig := pool.Config()
+	guardConfig.ConnConfig.RuntimeParams["default_transaction_isolation"] = "repeatable read"
+	guardPool, err := pgxpool.NewWithConfig(ctx, guardConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer guardPool.Close()
+	if _, err := pool.Exec(ctx, `CREATE TABLE schema_guard_writes (id integer PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+
+	var expected int64
+	if err := pool.QueryRow(ctx, `SELECT COALESCE(MAX(version_id), 0) FROM goose_db_version`).Scan(&expected); err != nil {
+		t.Fatal(err)
+	}
+	guard := dbconn.NewSchemaGuard(guardPool, expected)
+	var value int
+	if err := guard.QueryRow(ctx, `SELECT 7`).Scan(&value); err != nil || value != 7 {
+		t.Fatalf("guarded row = (%d, %v), want (7, nil)", value, err)
+	}
+	rows, err := guard.Query(ctx, `SELECT value FROM generate_series(1, 2) AS values(value)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	values, err := pgx.CollectRows(rows, pgx.RowTo[int])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(values) != 2 || values[0] != 1 || values[1] != 2 {
+		t.Fatalf("guarded rows = %v, want [1 2]", values)
+	}
+	rows, err = guard.Query(ctx, `INSERT INTO schema_guard_writes (id) VALUES (4) RETURNING id`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	insertedID, err := pgx.CollectOneRow(rows, pgx.RowTo[int])
+	if err != nil || insertedID != 4 {
+		t.Fatalf("guarded returning row = (%d, %v), want (4, nil)", insertedID, err)
+	}
+
+	migrationTx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = migrationTx.Rollback(ctx) }()
+	var migrationPID int32
+	if err := migrationTx.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&migrationPID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := migrationTx.Exec(ctx, `CREATE TABLE schema_guard_migration_work (id integer)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := guard.Exec(ctx, `INSERT INTO schema_guard_writes (id) VALUES (1)`); err != nil {
+		t.Fatalf("guarded work before migration version change: %v", err)
+	}
+	if _, err := migrationTx.Exec(
+		ctx,
+		`INSERT INTO goose_db_version (version_id, is_applied) VALUES ($1, true)`,
+		expected+1,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	writeTx, err := guard.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = writeTx.Rollback(ctx) }()
+	if _, err := writeTx.Exec(ctx, `INSERT INTO schema_guard_writes (id) VALUES (2)`); err != nil {
+		t.Fatal(err)
+	}
+	writeErr := make(chan error, 1)
+	go func() {
+		writeErr <- writeTx.Commit(ctx)
+	}()
+	integrationdb.WaitForLockWaitBlockedBy(
+		t,
+		ctx,
+		pool,
+		`LOCK TABLE goose_db_version IN SHARE MODE`,
+		migrationPID,
+	)
+	if err := migrationTx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	err = <-writeErr
+	var mismatch *dbconn.SchemaVersionMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("guarded write error = %v, want schema version mismatch", err)
+	}
+	if mismatch.Expected != expected || mismatch.Actual != expected+1 {
+		t.Fatalf("schema mismatch = %+v", mismatch)
+	}
+
+	rollbackGuard := dbconn.NewSchemaGuard(guardPool, expected)
+	rollbackTx, err := rollbackGuard.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("begin guarded work before rollback: %v", err)
+	}
+	if _, err := rollbackTx.Exec(ctx, `SELECT missing_schema_guard_column`); err == nil {
+		t.Fatal("expected guarded transaction statement error")
+	}
+	if err := rollbackTx.Rollback(ctx); err != nil {
+		t.Fatalf("roll back guarded work: %v", err)
+	}
+	rollbackMismatch := rollbackGuard.Mismatch()
+	if rollbackMismatch == nil || rollbackMismatch.Expected != expected || rollbackMismatch.Actual != expected+1 {
+		t.Fatalf("rollback schema mismatch = %+v", rollbackMismatch)
+	}
+	select {
+	case <-rollbackGuard.Done():
+	default:
+		t.Fatal("rolled-back schema guard did not latch mismatch")
+	}
+
+	postCutoverGuard := dbconn.NewSchemaGuard(guardPool, expected)
+	err = postCutoverGuard.QueryRow(
+		ctx,
+		`INSERT INTO schema_guard_writes (id) VALUES (3) RETURNING id`,
+	).Scan(new(int))
+	var postCutoverMismatch *dbconn.SchemaVersionMismatchError
+	if !errors.As(err, &postCutoverMismatch) {
+		t.Fatalf("post-cutover guarded write error = %v, want schema version mismatch", err)
+	}
+
+	rows, err = pool.Query(ctx, `SELECT id FROM schema_guard_writes ORDER BY id`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids, err := pgx.CollectRows(rows, pgx.RowTo[int])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 4 {
+		t.Fatalf("guarded writes = %v, want [1 4]", ids)
+	}
+	select {
+	case <-guard.Done():
+	default:
+		t.Fatal("schema guard did not latch mismatch")
+	}
+	select {
+	case <-postCutoverGuard.Done():
+	default:
+		t.Fatal("post-cutover schema guard did not latch mismatch")
+	}
+	if err := guard.QueryRow(ctx, `SELECT 1`).Scan(new(int)); !errors.As(err, &mismatch) {
+		t.Fatalf("query after mismatch = %v, want latched mismatch", err)
 	}
 }

--- a/internal/storage/integrationstore/integration_installs_store.go
+++ b/internal/storage/integrationstore/integration_installs_store.go
@@ -25,7 +25,7 @@ func (s *Store) UpsertIntegrationInstall(
 	if err != nil {
 		return IntegrationInstallRecord{}, err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return IntegrationInstallRecord{}, fmt.Errorf("begin upsert integration install: %w", err)
 	}
@@ -277,7 +277,7 @@ func (s *Store) DisableIntegrationInstall(
 		return false, errors.New("project, integration install, and expected OAuth flow are required")
 	}
 	expectedOAuthFlowID := *input.ExpectedOAuthFlowID
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return false, fmt.Errorf("begin disable integration install: %w", err)
 	}
@@ -324,7 +324,7 @@ func (s *Store) DeleteIntegrationInstall(ctx context.Context, projectID, id ID) 
 	if isNilID(projectID) || isNilID(id) {
 		return errors.New("project and integration install are required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin delete integration install: %w", err)
 	}

--- a/internal/storage/integrationstore/store.go
+++ b/internal/storage/integrationstore/store.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/omnara-ai/omnara/internal/storage/dbconn"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
 	"github.com/omnara-ai/omnara/internal/storage/internal/storeutil"
 )
@@ -29,13 +29,13 @@ type Access interface {
 }
 
 type Store struct {
-	pool   *pgxpool.Pool
+	db     dbconn.DB
 	q      *dbsqlc.Queries
 	access Access
 }
 
-func New(pool *pgxpool.Pool, access Access) *Store {
-	return &Store{pool: pool, q: dbsqlc.New(pool), access: access}
+func New(db dbconn.DB, access Access) *Store {
+	return &Store{db: db, q: dbsqlc.New(db), access: access}
 }
 
 func isNilID(id ID) bool {

--- a/internal/storage/modelstore/configured_models_store.go
+++ b/internal/storage/modelstore/configured_models_store.go
@@ -22,7 +22,7 @@ func (s *Store) CreateConfiguredModel(
 	ctx context.Context,
 	input CreateConfiguredModelInput,
 ) (ConfiguredModelRecord, error) {
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ConfiguredModelRecord{}, fmt.Errorf("begin create configured model: %w", err)
 	}
@@ -184,7 +184,7 @@ func (s *Store) PatchConfiguredModel(
 	if isNilID(input.OrgID) || isNilID(input.ModelProviderConfigID) || isNilID(input.ID) {
 		return ConfiguredModelRecord{}, errors.New("org, provider config, and configured model are required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ConfiguredModelRecord{}, err
 	}
@@ -615,7 +615,7 @@ func (s *Store) DeleteConfiguredModel(
 	ctx context.Context,
 	orgID, id ID,
 ) (ConfiguredModelRecord, error) {
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ConfiguredModelRecord{}, fmt.Errorf("begin delete configured model: %w", err)
 	}

--- a/internal/storage/modelstore/model_provider_configs_store.go
+++ b/internal/storage/modelstore/model_provider_configs_store.go
@@ -24,7 +24,7 @@ func (s *Store) CreateModelProviderConfig(
 	input CreateModelProviderConfigInput,
 ) (ModelProviderConfigRecord, error) {
 	input.managementKind = management.Tenant
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ModelProviderConfigRecord{}, fmt.Errorf("begin create model provider config: %w", err)
 	}
@@ -295,7 +295,7 @@ func (s *Store) PatchModelProviderConfig(
 	if isNilID(input.OrgID) || isNilID(input.ID) {
 		return ModelProviderConfigRecord{}, errors.New("org and provider config are required")
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ModelProviderConfigRecord{}, err
 	}
@@ -459,7 +459,7 @@ func (s *Store) DeleteModelProviderConfig(
 	ctx context.Context,
 	orgID, id ID,
 ) (ModelProviderConfigRecord, error) {
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ModelProviderConfigRecord{}, fmt.Errorf("begin delete model provider config: %w", err)
 	}

--- a/internal/storage/modelstore/project_model_grants_store.go
+++ b/internal/storage/modelstore/project_model_grants_store.go
@@ -21,7 +21,7 @@ func (s *Store) CreateProjectModelGrant(
 		return ProjectModelGrantRecord{}, errors.New("org, project, and configured model are required")
 	}
 	input = normalizeProjectModelGrantInput(input)
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ProjectModelGrantRecord{}, fmt.Errorf("begin create project model grant: %w", err)
 	}
@@ -92,7 +92,7 @@ func (s *Store) UpdateProjectModelGrant(
 	if isNilID(input.OrgID) || isNilID(input.ProjectID) || isNilID(input.ID) {
 		return ProjectModelGrantRecord{}, storeerr.InvalidRequest(errors.New("org, project, and grant are required"))
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return ProjectModelGrantRecord{}, fmt.Errorf("begin update project model grant: %w", err)
 	}

--- a/internal/storage/modelstore/support.go
+++ b/internal/storage/modelstore/support.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/omnara-ai/omnara/internal/storage/dbconn"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
 )
@@ -19,12 +19,12 @@ const (
 )
 
 type Store struct {
-	pool *pgxpool.Pool
-	q    *dbsqlc.Queries
+	db dbconn.DB
+	q  *dbsqlc.Queries
 }
 
-func New(pool *pgxpool.Pool) *Store {
-	return &Store{pool: pool, q: dbsqlc.New(pool)}
+func New(db dbconn.DB) *Store {
+	return &Store{db: db, q: dbsqlc.New(db)}
 }
 
 func isNilID(id ID) bool {

--- a/internal/storage/orglifecycle/default_model_provider.go
+++ b/internal/storage/orglifecycle/default_model_provider.go
@@ -137,7 +137,7 @@ func (s *Service) CompleteDefaultModelProviderProvisioning(
 		return errors.New("default model provider credential is required")
 	}
 
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin default model provider provisioning completion: %w", err)
 	}

--- a/internal/storage/orglifecycle/default_reconciliation.go
+++ b/internal/storage/orglifecycle/default_reconciliation.go
@@ -110,7 +110,7 @@ func (s *Service) reconcileOrgDefaults(
 	if !input.Apply {
 		txOptions.AccessMode = pgx.ReadOnly
 	}
-	tx, err := s.pool.BeginTx(ctx, txOptions)
+	tx, err := s.db.BeginTx(ctx, txOptions)
 	if err != nil {
 		return ReconcileDefaultsResult{}, fmt.Errorf("begin default reconciliation: %w", err)
 	}

--- a/internal/storage/orglifecycle/orgs_projects.go
+++ b/internal/storage/orglifecycle/orgs_projects.go
@@ -50,7 +50,7 @@ func (s *Service) CreateOrgForUser(
 		}
 		input.OrgID = orgID
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return identitystore.CreateOrgForUserRecord{}, fmt.Errorf("begin create org for user: %w", err)
 	}
@@ -241,7 +241,7 @@ func (s *Service) DeleteProject(
 	if err != nil {
 		return nil, err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("begin delete project: %w", err)
 	}
@@ -335,7 +335,7 @@ func (s *Service) deleteOrganizationAttempt(
 	actor *executionstore.ActorParams,
 	lockProjectIDs []ID,
 ) ([]executionstore.MachineRecord, []ID, error) {
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("begin delete organization: %w", err)
 	}

--- a/internal/storage/orglifecycle/service.go
+++ b/internal/storage/orglifecycle/service.go
@@ -2,9 +2,9 @@ package orglifecycle
 
 import (
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/omnara-ai/omnara/internal/blobstore"
 	"github.com/omnara-ai/omnara/internal/notifications"
+	"github.com/omnara-ai/omnara/internal/storage/dbconn"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
@@ -26,7 +26,7 @@ type Config struct {
 }
 
 type Service struct {
-	pool                *pgxpool.Pool
+	db                  dbconn.DB
 	q                   *dbsqlc.Queries
 	blobs               blobstore.Store
 	postCommitPublisher notifications.PostCommitPublisher
@@ -36,10 +36,10 @@ type Service struct {
 	secrets             *secretstore.Store
 }
 
-func New(pool *pgxpool.Pool, config Config) *Service {
+func New(db dbconn.DB, config Config) *Service {
 	return &Service{
-		pool:                pool,
-		q:                   dbsqlc.New(pool),
+		db:                  db,
+		q:                   dbsqlc.New(db),
 		blobs:               config.Blobs,
 		postCommitPublisher: config.PostCommitPublisher,
 		identity:            config.Identity,

--- a/internal/storage/secretstore/secret_oauth_store.go
+++ b/internal/storage/secretstore/secret_oauth_store.go
@@ -38,7 +38,7 @@ func (s *Store) RotateProjectAvailableOAuthSecret(
 	); err != nil {
 		return SecretRecord{}, err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return SecretRecord{}, fmt.Errorf("begin rotate project oauth secret: %w", err)
 	}
@@ -161,7 +161,7 @@ func (s *Store) AcquireProjectOAuthRefreshLease(
 	if err != nil {
 		return OAuthRefreshLeaseRecord{}, false, err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return OAuthRefreshLeaseRecord{}, false, fmt.Errorf("begin acquire oauth refresh lease: %w", err)
 	}

--- a/internal/storage/secretstore/secret_writes_store.go
+++ b/internal/storage/secretstore/secret_writes_store.go
@@ -35,7 +35,7 @@ func (s *Store) CreateSecret(
 	if err := s.validateCreateSecretInput(ctx, &input); err != nil {
 		return SecretRecord{}, SecretVersionRecord{}, err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return SecretRecord{}, SecretVersionRecord{}, fmt.Errorf("begin create secret: %w", err)
 	}
@@ -234,7 +234,7 @@ func (s *Store) UpdateSecretMetadata(
 	if err != nil {
 		return SecretRecord{}, invalidSecretRequest("%v", err)
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return SecretRecord{}, fmt.Errorf("begin update secret metadata: %w", err)
 	}
@@ -302,7 +302,7 @@ func (s *Store) CreateSecretVersion(
 	if err != nil {
 		return SecretRecord{}, SecretVersionRecord{}, invalidSecretRequest("%v", err)
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return SecretRecord{}, SecretVersionRecord{}, fmt.Errorf(
 			"begin create secret version: %w",
@@ -433,7 +433,7 @@ func (s *Store) DeleteSecret(ctx context.Context, input DeleteSecretInput) (Secr
 	if err := s.authorizeSecretManage(ctx, record, input.Actor); err != nil {
 		return SecretRecord{}, err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return SecretRecord{}, fmt.Errorf("begin delete secret: %w", err)
 	}

--- a/internal/storage/secretstore/support.go
+++ b/internal/storage/secretstore/support.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/omnara-ai/omnara/internal/authz"
 	"github.com/omnara-ai/omnara/internal/secrets"
+	"github.com/omnara-ai/omnara/internal/storage/dbconn"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
@@ -22,14 +22,14 @@ type Access interface {
 }
 
 type Store struct {
-	pool             *pgxpool.Pool
+	db               dbconn.DB
 	q                *dbsqlc.Queries
 	secretKeyWrapper secrets.KeyWrapper
 	access           Access
 }
 
-func New(pool *pgxpool.Pool, keyWrapper secrets.KeyWrapper, access Access) *Store {
-	return &Store{pool: pool, q: dbsqlc.New(pool), secretKeyWrapper: keyWrapper, access: access}
+func New(db dbconn.DB, keyWrapper secrets.KeyWrapper, access Access) *Store {
+	return &Store{db: db, q: dbsqlc.New(db), secretKeyWrapper: keyWrapper, access: access}
 }
 
 type ID = uuid.UUID

--- a/internal/storage/skillstore/skill_deletion_store.go
+++ b/internal/storage/skillstore/skill_deletion_store.go
@@ -46,7 +46,7 @@ func (s *Store) DeleteSkill(ctx context.Context, input DeleteSkillInput) error {
 		}
 		return err
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return fmt.Errorf("begin delete skill: %w", err)
 	}

--- a/internal/storage/skillstore/skill_grants_store.go
+++ b/internal/storage/skillstore/skill_grants_store.go
@@ -44,7 +44,7 @@ func (s *Store) CreateSkillGrant(
 	if err != nil {
 		return SkillGrantRecord{}, fmt.Errorf("generate skill grant id: %w", err)
 	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return SkillGrantRecord{}, fmt.Errorf("begin create skill grant: %w", err)
 	}

--- a/internal/storage/skillstore/skill_revisions_store.go
+++ b/internal/storage/skillstore/skill_revisions_store.go
@@ -90,7 +90,7 @@ func (s *Store) insertSkillRevision(
 	input CreateSkillInput,
 	archiveDigest string,
 ) (skillRevisionInsertResult, error) {
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return skillRevisionInsertResult{}, fmt.Errorf("begin create skill revision: %w", err)
 	}

--- a/internal/storage/skillstore/store.go
+++ b/internal/storage/skillstore/store.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/omnara-ai/omnara/internal/blobstore"
+	"github.com/omnara-ai/omnara/internal/storage/dbconn"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
@@ -30,14 +30,14 @@ type Access interface {
 }
 
 type Store struct {
-	pool   *pgxpool.Pool
+	db     dbconn.DB
 	q      *dbsqlc.Queries
 	blobs  blobstore.Store
 	access Access
 }
 
-func New(pool *pgxpool.Pool, blobs blobstore.Store, access Access) *Store {
-	return &Store{pool: pool, q: dbsqlc.New(pool), blobs: blobs, access: access}
+func New(db dbconn.DB, blobs blobstore.Store, access Access) *Store {
+	return &Store{db: db, q: dbsqlc.New(db), blobs: blobs, access: access}
 }
 
 type SkillRecord struct {

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/omnara-ai/omnara/internal/secrets"
 	"github.com/omnara-ai/omnara/internal/storage/accountsecurity"
 	"github.com/omnara-ai/omnara/internal/storage/artifactstore"
+	"github.com/omnara-ai/omnara/internal/storage/dbconn"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
 	"github.com/omnara-ai/omnara/internal/storage/integrationstore"
@@ -72,22 +73,23 @@ func WithModelCallRetryBackoff(backoff func(int, string) time.Duration) Option {
 	}
 }
 
-func NewStore(pool *pgxpool.Pool, opts ...Option) *Store {
+func NewStore(db dbconn.DB, opts ...Option) *Store {
 	config := storeConfig{}
 	for _, opt := range opts {
 		opt(&config)
 	}
+	pool, _ := db.(*pgxpool.Pool)
 	store := &Store{
 		pool:  pool,
 		blobs: config.blobs,
 	}
-	store.identity = identitystore.New(pool, config.secretKeyWrapper, config.blobs)
-	store.models = modelstore.New(pool)
-	store.secrets = secretstore.New(pool, config.secretKeyWrapper, store.identity)
-	store.skills = skillstore.New(pool, config.blobs, store.identity)
-	store.artifacts = artifactstore.New(pool, config.blobs)
-	store.integrations = integrationstore.New(pool, executionstore.IntegrationInstallAccess{})
-	store.execution = executionstore.New(pool, executionstore.Config{
+	store.identity = identitystore.New(db, config.secretKeyWrapper, config.blobs)
+	store.models = modelstore.New(db)
+	store.secrets = secretstore.New(db, config.secretKeyWrapper, store.identity)
+	store.skills = skillstore.New(db, config.blobs, store.identity)
+	store.artifacts = artifactstore.New(db, config.blobs)
+	store.integrations = integrationstore.New(db, executionstore.IntegrationInstallAccess{})
+	store.execution = executionstore.New(db, executionstore.Config{
 		PostCommitPublisher:   config.postCommitPublisher,
 		ModelCallRetryBackoff: config.modelCallRetryBackoff,
 		Integrations:          store.integrations,
@@ -95,7 +97,7 @@ func NewStore(pool *pgxpool.Pool, opts ...Option) *Store {
 		Identity:              store.identity,
 		Secrets:               store.secrets,
 	})
-	store.organizations = orglifecycle.New(pool, orglifecycle.Config{
+	store.organizations = orglifecycle.New(db, orglifecycle.Config{
 		Blobs:               config.blobs,
 		PostCommitPublisher: config.postCommitPublisher,
 		Identity:            store.identity,
@@ -104,7 +106,7 @@ func NewStore(pool *pgxpool.Pool, opts ...Option) *Store {
 		Secrets:             store.secrets,
 	})
 	store.accountSecurity = accountsecurity.New(
-		pool,
+		db,
 		store.identity,
 	)
 	return store

--- a/migrations/go_migrations.go
+++ b/migrations/go_migrations.go
@@ -1,6 +1,13 @@
 package migrations
 
-import "github.com/pressly/goose/v3"
+import (
+	"embed"
+
+	"github.com/pressly/goose/v3"
+)
+
+//go:embed *.sql
+var Files embed.FS
 
 func GoMigrations() []*goose.Migration {
 	return []*goose.Migration{

--- a/migrations/go_migrations_test.go
+++ b/migrations/go_migrations_test.go
@@ -10,7 +10,12 @@ import (
 	"github.com/pressly/goose/v3"
 )
 
-func TestGoMigrationsMatchDirectory(t *testing.T) {
+func TestMigrations(t *testing.T) {
+	for _, migration := range schemamigrations.GoMigrations() {
+		if !migration.UseTx {
+			t.Fatalf("Go migration %d must be transactional", migration.Version)
+		}
+	}
 	config, err := pgx.ParseConfig("postgres://unused@localhost/unused?sslmode=disable")
 	if err != nil {
 		t.Fatal(err)
@@ -18,13 +23,35 @@ func TestGoMigrationsMatchDirectory(t *testing.T) {
 	db := stdlib.OpenDB(*config)
 	t.Cleanup(func() { _ = db.Close() })
 
-	if _, err := goose.NewProvider(
+	embeddedProvider, err := goose.NewProvider(
+		goose.DialectPostgres,
+		db,
+		schemamigrations.Files,
+		goose.WithDisableGlobalRegistry(true),
+		goose.WithGoMigrations(schemamigrations.GoMigrations()...),
+	)
+	if err != nil {
+		t.Fatalf("construct embedded migration provider: %v", err)
+	}
+	filesystemProvider, err := goose.NewProvider(
 		goose.DialectPostgres,
 		db,
 		os.DirFS("."),
 		goose.WithDisableGlobalRegistry(true),
 		goose.WithGoMigrations(schemamigrations.GoMigrations()...),
-	); err != nil {
-		t.Fatalf("construct scoped migration provider: %v", err)
+	)
+	if err != nil {
+		t.Fatalf("construct filesystem migration provider: %v", err)
+	}
+	embeddedSources := embeddedProvider.ListSources()
+	filesystemSources := filesystemProvider.ListSources()
+	if len(embeddedSources) != len(filesystemSources) {
+		t.Fatalf("embedded migrations = %d, filesystem migrations = %d", len(embeddedSources), len(filesystemSources))
+	}
+	for index, embedded := range embeddedSources {
+		filesystem := filesystemSources[index]
+		if embedded.Version != filesystem.Version || embedded.Type != filesystem.Type {
+			t.Fatalf("embedded migration = %+v, filesystem migration = %+v", embedded, filesystem)
+		}
 	}
 }


### PR DESCRIPTION
- derive the expected Goose schema version from the migration inventory embedded in each runtime binary
- fence maintenance and worker database commits against the committed Goose version so stale processes cannot mutate a newer schema
- latch schema mismatches, fail readiness, cancel owned work, and keep the service quiesced until replacement