### PR TITLE
fix: reject database-unsafe content before storage

### DIFF
--- a/docs/tools/custom.mdx
+++ b/docs/tools/custom.mdx
@@ -119,6 +119,8 @@ curl "$OMNARA_API/orgs/$ORG/projects/$PROJ/agents/$AGENT/tool-calls/tcl_wz3jehcy
 
 The agent wakes and continues its turn with your result in context. If your system failed, submit `outcome: "failed"` with a text block explaining why — a failed tool call is information the model can act on, not an error you should swallow.
 
+Result text, structured-data string keys and values, and metadata must not contain U+0000. Decode text output before submitting it, and send binary output as a supported media block or a safe failed result. An invalid result returns `400` and leaves the call `ready`; correct the payload instead of retrying the same payload.
+
 **The first result wins.** Only `ready` custom calls accept results; a second submission for the same call, or a result for a built-in or MCP call, returns `409`:
 
 ```json

--- a/docs/tools/custom.mdx
+++ b/docs/tools/custom.mdx
@@ -119,7 +119,7 @@ curl "$OMNARA_API/orgs/$ORG/projects/$PROJ/agents/$AGENT/tool-calls/tcl_wz3jehcy
 
 The agent wakes and continues its turn with your result in context. If your system failed, submit `outcome: "failed"` with a text block explaining why — a failed tool call is information the model can act on, not an error you should swallow.
 
-Result text, structured-data string keys and values, and metadata must not contain U+0000. Decode text output before submitting it, and send binary output as a supported media block or a safe failed result. An invalid result returns `400` and leaves the call `ready`; correct the payload instead of retrying the same payload.
+Result text, structured-data string keys and values, and metadata must not contain U+0000.
 
 **The first result wins.** Only `ready` custom calls accept results; a second submission for the same call, or a result for a built-in or MCP call, returns `409`:
 

--- a/internal/dbsafe/dbsafe.go
+++ b/internal/dbsafe/dbsafe.go
@@ -1,0 +1,40 @@
+package dbsafe
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"unicode/utf8"
+)
+
+func Text(value string) error {
+	if !utf8.ValidString(value) {
+		return errors.New("contains invalid UTF-8")
+	}
+	if strings.IndexByte(value, 0) >= 0 {
+		return errors.New("contains U+0000")
+	}
+	return nil
+}
+
+func JSONStrings(raw []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("decode JSON: %w", err)
+		}
+		if value, ok := token.(string); ok {
+			if err := Text(value); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/internal/dbsafe/dbsafe_test.go
+++ b/internal/dbsafe/dbsafe_test.go
@@ -1,0 +1,46 @@
+package dbsafe
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestText(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "valid", value: "hello"},
+		{name: "NUL", value: "before\x00after", wantErr: true},
+		{name: "invalid UTF-8", value: string([]byte{0xff}), wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := Text(test.value)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("Text(%q) error = %v, wantErr %v", test.value, err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestJSONStrings(t *testing.T) {
+	largeNumber := strings.Repeat("9", 400)
+	for _, test := range []struct {
+		name    string
+		value   []byte
+		wantErr bool
+	}{
+		{name: "large number", value: []byte(`{"value":` + largeNumber + `}`)},
+		{name: "invalid UTF-8 is decoded", value: []byte{'{', '"', 'x', '"', ':', '"', 0xff, '"', '}'}},
+		{name: "NUL value", value: []byte(`{"value":"before\u0000after"}`), wantErr: true},
+		{name: "NUL key", value: []byte(`{"before\u0000after":true}`), wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := JSONStrings(test.value)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("JSONStrings(%s) error = %v, wantErr %v", test.value, err, test.wantErr)
+			}
+		})
+	}
+}

--- a/internal/httpapi/agent_tool_calls_integration_test.go
+++ b/internal/httpapi/agent_tool_calls_integration_test.go
@@ -524,7 +524,8 @@ func TestPublicCustomToolCallLifecycle(t *testing.T) {
 			name:       "metadata NUL",
 			toolCallID: mediaToolCallID,
 			body: `{"outcome":"succeeded","content_blocks":[` +
-				`{"type":"text","text":"safe","metadata":{"source":"before\u0000after"}}]}`,
+				`{"type":"media","media_type":"image/png","data":"` + pngBase64 + `",` +
+				`"metadata":{"source":"before\u0000after"}}]}`,
 		},
 		{
 			name:       "media filename NUL",
@@ -549,6 +550,17 @@ func TestPublicCustomToolCallLifecycle(t *testing.T) {
 				t.Fatalf("database-unsafe result response = %+v, want invalid_request", response)
 			}
 		})
+	}
+	var artifactCount int
+	if err := pool.QueryRow(
+		ctx,
+		`SELECT count(*) FROM artifacts WHERE agent_id = $1`,
+		agent.ID,
+	).Scan(&artifactCount); err != nil {
+		t.Fatalf("count artifacts after rejected results: %v", err)
+	}
+	if artifactCount != 0 {
+		t.Fatalf("rejected results left %d artifact rows", artifactCount)
 	}
 	readyAfterRejectedResults := requestJSONWithHeaders(
 		t,

--- a/internal/httpapi/agent_tool_calls_integration_test.go
+++ b/internal/httpapi/agent_tool_calls_integration_test.go
@@ -474,6 +474,7 @@ func TestPublicCustomToolCallLifecycle(t *testing.T) {
 	secondToolCallID := publicToolCallIDs[1]
 	mediaToolCallID := publicToolCallIDs[2]
 	emptyToolCallID := publicToolCallIDs[4]
+	pngBase64 := base64.StdEncoding.EncodeToString(testPNGBytes)
 	resultPath := toolCallsPath + "/" + toolCallID + "/result"
 	for _, test := range []struct {
 		name string
@@ -501,6 +502,80 @@ func TestPublicCustomToolCallLifecycle(t *testing.T) {
 				authHeaders(project.AdminToken),
 			)
 		})
+	}
+	for _, test := range []struct {
+		name       string
+		toolCallID string
+		body       string
+	}{
+		{
+			name:       "text NUL",
+			toolCallID: toolCallID,
+			body: `{"outcome":"succeeded","content_blocks":[` +
+				`{"type":"text","text":"before\u0000after"}]}`,
+		},
+		{
+			name:       "structured data NUL",
+			toolCallID: secondToolCallID,
+			body: `{"outcome":"succeeded","content_blocks":[` +
+				`{"type":"structured_data","value":{"nested":["before\u0000after"]}}]}`,
+		},
+		{
+			name:       "metadata NUL",
+			toolCallID: mediaToolCallID,
+			body: `{"outcome":"succeeded","content_blocks":[` +
+				`{"type":"text","text":"safe","metadata":{"source":"before\u0000after"}}]}`,
+		},
+		{
+			name:       "media filename NUL",
+			toolCallID: mediaToolCallID,
+			body: `{"outcome":"succeeded","content_blocks":[` +
+				`{"type":"media","media_type":"image/png","filename":"before\u0000after.png","data":"` +
+				pngBase64 + `"}]}`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			response := requestJSONWithHeaders(
+				t,
+				handler,
+				http.MethodPost,
+				toolCallsPath+"/"+test.toolCallID+"/result",
+				test.body,
+				"",
+				http.StatusBadRequest,
+				authHeaders(project.AdminToken),
+			)
+			if response["code"] != "invalid_request" {
+				t.Fatalf("database-unsafe result response = %+v, want invalid_request", response)
+			}
+		})
+	}
+	readyAfterRejectedResults := requestJSONWithHeaders(
+		t,
+		handler,
+		http.MethodGet,
+		toolCallsPath+"?state=ready&type=custom",
+		"",
+		"",
+		http.StatusOK,
+		authHeaders(project.AdminToken),
+	)
+	readyAfterRejectedResultsByProviderID := publicToolCallsByProviderID(
+		t,
+		readyAfterRejectedResults,
+	)
+	for _, providerCallID := range []string{
+		"call_lookup_customer",
+		"call_lookup_customer_2",
+		"call_lookup_customer_3",
+	} {
+		if readyAfterRejectedResultsByProviderID[providerCallID]["state"] != "ready" {
+			t.Fatalf(
+				"tool call %s after rejected result = %+v, want ready",
+				providerCallID,
+				readyAfterRejectedResultsByProviderID[providerCallID],
+			)
+		}
 	}
 	submitted := requestJSONWithHeaders(
 		t,
@@ -555,7 +630,7 @@ func TestPublicCustomToolCallLifecycle(t *testing.T) {
 		handler,
 		http.MethodPost,
 		toolCallsPath+"/"+secondToolCallID+"/result",
-		`{"outcome":"failed","content_blocks":[{"type":"text","text":"Customer lookup failed."}]}`,
+		`{"outcome":"failed","content_blocks":[{"type":"structured_data","value":{"message":"before\ud800after"}}]}`,
 		"",
 		http.StatusCreated,
 		authHeaders(project.AdminToken),
@@ -564,8 +639,16 @@ func TestPublicCustomToolCallLifecycle(t *testing.T) {
 	if failedCall["state"] != "completed" || failedCall["outcome"] != "failed" {
 		t.Fatalf("failed tool call = %+v", failedCall)
 	}
-	if failedSubmitted["tool_result"].(map[string]any)["outcome"] != "failed" {
-		t.Fatalf("failed tool result = %+v", failedSubmitted["tool_result"])
+	failedToolResult := failedSubmitted["tool_result"].(map[string]any)
+	expectedFailedContentBlocks := []any{map[string]any{
+		"type": "structured_data",
+		"value": map[string]any{
+			"message": "before\uFFFDafter",
+		},
+	}}
+	if failedToolResult["outcome"] != "failed" ||
+		!reflect.DeepEqual(failedToolResult["content_blocks"], expectedFailedContentBlocks) {
+		t.Fatalf("failed tool result = %+v", failedToolResult)
 	}
 	completedCalls, err := storagetest.ListCompletedToolCallsForTurn(
 		ctx,
@@ -592,14 +675,10 @@ func TestPublicCustomToolCallLifecycle(t *testing.T) {
 	}
 	if failedRecord == nil ||
 		failedRecord.Outcome != executionstore.ToolResultOutcomeFailed ||
-		!publicEventTextEquals(
-			map[string]any{"content_blocks": failedContentBlocks},
-			"Customer lookup failed.",
-		) {
+		!reflect.DeepEqual(failedContentBlocks, expectedFailedContentBlocks) {
 		t.Fatalf("failed custom tool call = %+v", failedRecord)
 	}
 
-	pngBase64 := base64.StdEncoding.EncodeToString(testPNGBytes)
 	mediaSubmitted := requestJSONWithHeaders(
 		t,
 		handler,

--- a/internal/httpapi/media_ingest.go
+++ b/internal/httpapi/media_ingest.go
@@ -5,8 +5,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"strings"
 
+	"github.com/omnara-ai/omnara/internal/dbsafe"
 	"github.com/omnara-ai/omnara/internal/modelcontext"
 	"github.com/omnara-ai/omnara/internal/storage"
 	"github.com/omnara-ai/omnara/internal/storage/artifactstore"
@@ -141,9 +141,9 @@ func (s *Server) extractInlineMedia(
 				),
 			}
 		}
-		if strings.IndexByte(block.Filename, 0) >= 0 {
+		if err := dbsafe.Text(block.Filename); err != nil {
 			return nil, mediaIngestError{
-				fmt.Sprintf("content block %d: filename must not contain U+0000", ordinal),
+				fmt.Sprintf("content block %d: filename %s", ordinal, err),
 			}
 		}
 		totalBytes += len(content)
@@ -170,6 +170,19 @@ func (s *Server) extractInlineMedia(
 	}
 	if len(pending) == 0 {
 		return contentBlocks, nil
+	}
+	for ordinal, raw := range rawBlocks {
+		if attachment, ok := pending[ordinal]; ok {
+			raw = attachment.metadata
+		}
+		if len(raw) == 0 {
+			continue
+		}
+		if err := dbsafe.JSONStrings(raw); err != nil {
+			return nil, mediaIngestError{
+				fmt.Sprintf("content block %d: %s", ordinal, err),
+			}
+		}
 	}
 	out := make([]json.RawMessage, 0, len(rawBlocks))
 	for ordinal, raw := range rawBlocks {

--- a/internal/httpapi/media_ingest.go
+++ b/internal/httpapi/media_ingest.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/omnara-ai/omnara/internal/modelcontext"
 	"github.com/omnara-ai/omnara/internal/storage"
@@ -138,6 +139,11 @@ func (s *Server) extractInlineMedia(
 					ordinal,
 					maxAttachmentFilenameBytes,
 				),
+			}
+		}
+		if strings.IndexByte(block.Filename, 0) >= 0 {
+			return nil, mediaIngestError{
+				fmt.Sprintf("content block %d: filename must not contain U+0000", ordinal),
 			}
 		}
 		totalBytes += len(content)

--- a/internal/httpapi/public_api_agent_launch_integration_test.go
+++ b/internal/httpapi/public_api_agent_launch_integration_test.go
@@ -160,6 +160,19 @@ func TestPublicAgentLaunchFlow(t *testing.T) {
 		http.StatusConflict,
 		authHeaders(project.AdminToken),
 	)
+	invalidMessage := requestJSONWithHeaders(
+		t,
+		handler,
+		http.MethodPost,
+		project.ProjectPath+"/agents",
+		`{"config":"`+configID+`","message":"before\u0000after"}`,
+		"idem-agent-launch-invalid-message",
+		http.StatusBadRequest,
+		authHeaders(project.AdminToken),
+	)
+	if invalidMessage["code"] != "invalid_request" {
+		t.Fatalf("invalid launch message response = %+v, want invalid_request", invalidMessage)
+	}
 
 	explicitConfig := requestJSONWithHeaders(
 		t,
@@ -193,7 +206,7 @@ func TestPublicAgentLaunchFlow(t *testing.T) {
 		handler,
 		http.MethodPost,
 		project.ProjectPath+"/agents",
-		`{"profile":"`+profileID+`","config":"`+retargetedConfigID+`","message":"ignored retry body"}`,
+		`{"profile":"`+profileID+`","config":"`+retargetedConfigID+`","message":"ignored\u0000retry body"}`,
 		"idem-agent-launch-first",
 		http.StatusOK,
 		authHeaders(project.AdminToken),

--- a/internal/httpapi/session_input_media_integration_test.go
+++ b/internal/httpapi/session_input_media_integration_test.go
@@ -172,6 +172,54 @@ func TestSessionInputInlineMediaUploadAndDownload(t *testing.T) {
 	}
 }
 
+func TestSessionInputInlineMediaMatchesJSONUTF8Decoding(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	handler, _ := newMediaIntegrationHandler(t, ctx)
+	project := bootstrapPublicHTTPProject(t, handler, "media-invalid-utf8")
+	launch := launchPublicHTTPAgent(
+		t,
+		handler,
+		project,
+		"media-invalid-utf8",
+		project.AdminToken,
+		http.StatusCreated,
+	)
+	agentPublicID := launch["agent"].(map[string]any)["id"].(string)
+	inputsPath := project.ProjectPath + "/agents/" + agentPublicID + "/inputs"
+	invalidText := `{"type":"text","text":"before` + string([]byte{0xff}) + `after"}`
+
+	withoutMedia := requestJSONWithHeaders(
+		t,
+		handler,
+		http.MethodPost,
+		inputsPath,
+		`{"content_blocks":[`+invalidText+`]}`,
+		"",
+		http.StatusCreated,
+		authHeaders(project.AdminToken),
+	)
+	withMedia := requestJSONWithHeaders(
+		t,
+		handler,
+		http.MethodPost,
+		inputsPath,
+		`{"content_blocks":[`+invalidText+`,`+
+			`{"type":"media","media_type":"image/png","data":"`+
+			base64.StdEncoding.EncodeToString(testPNGBytes)+`"}]}`,
+		"",
+		http.StatusCreated,
+		authHeaders(project.AdminToken),
+	)
+
+	for _, response := range []map[string]any{withoutMedia, withMedia} {
+		blocks := response["agent_input"].(map[string]any)["content_blocks"].([]any)
+		if blocks[0].(map[string]any)["text"] != "before\uFFFDafter" {
+			t.Fatalf("decoded content blocks = %+v, want replacement character", blocks)
+		}
+	}
+}
+
 func TestSessionInputInlineMediaValidation(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -248,12 +296,16 @@ func TestSessionInputRejectedAttachmentLeavesNoArtifacts(t *testing.T) {
 	inputsPath := project.ProjectPath + "/agents/" + agentPublicID + "/inputs"
 
 	pngBase64 := base64.StdEncoding.EncodeToString(testPNGBytes)
-	// A valid attachment followed by an invalid one must reject the request
-	// before any artifact row is created.
 	requestJSONWithHeaders(t, handler, http.MethodPost, inputsPath,
 		`{"content_blocks":[`+
 			`{"type":"media","media_type":"image/png","data":"`+pngBase64+`"},`+
 			`{"type":"media","media_type":"image/tiff","data":"`+pngBase64+`"}`+
+			`]}`,
+		"", http.StatusBadRequest, authHeaders(project.AdminToken))
+	requestJSONWithHeaders(t, handler, http.MethodPost, inputsPath,
+		`{"content_blocks":[`+
+			`{"type":"media","media_type":"image/png","data":"`+pngBase64+`"},`+
+			`{"type":"text","text":"before\u0000after"}`+
 			`]}`,
 		"", http.StatusBadRequest, authHeaders(project.AdminToken))
 

--- a/internal/integration/slack/files.go
+++ b/internal/integration/slack/files.go
@@ -415,7 +415,7 @@ func attachmentFilename(
 		filename = strings.TrimSpace(file.ID)
 	}
 	filename = attachmentDefaultFilename(filename, contentType, defaultFilename)
-	if maxBytes > 0 && len(filename) > maxBytes {
+	if strings.IndexByte(filename, 0) >= 0 || (maxBytes > 0 && len(filename) > maxBytes) {
 		return attachmentDefaultFilename("", contentType, defaultFilename)
 	}
 	return filename

--- a/internal/integration/slack/files_test.go
+++ b/internal/integration/slack/files_test.go
@@ -98,6 +98,19 @@ func TestDownloadEventFilesResultUsesSlackErrorCode(t *testing.T) {
 	}
 }
 
+func TestAttachmentFilenameFallsBackForNUL(t *testing.T) {
+	t.Parallel()
+	got := attachmentFilename(
+		File{Name: "before\x00after.png"},
+		"image/png",
+		func(string, string) string { return "attachment.png" },
+		255,
+	)
+	if got != "attachment.png" {
+		t.Fatalf("attachment filename = %q, want fallback", got)
+	}
+}
+
 func TestDownloadEventFilesSkipsDeclaredOversize(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/model/response_validation.go
+++ b/internal/model/response_validation.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 	"unicode/utf8"
 
+	"github.com/omnara-ai/omnara/internal/dbsafe"
 	"github.com/omnara-ai/omnara/internal/modelenvelope"
 )
 
@@ -22,7 +22,7 @@ func ValidateProviderJSON(body []byte) error {
 	if !json.Valid(body) {
 		return errors.New("provider response is not valid JSON")
 	}
-	if containsNULJSONString(body) {
+	if err := dbsafe.JSONStrings(body); err != nil {
 		return errors.New("provider response contains a NUL string value")
 	}
 	return nil
@@ -149,26 +149,9 @@ func validateProviderRaw(raw json.RawMessage) error {
 		return errors.New("contains a NUL byte")
 	}
 	if json.Valid(raw) {
-		if containsNULJSONString(raw) {
+		if err := dbsafe.JSONStrings(raw); err != nil {
 			return errors.New("contains a NUL string value")
 		}
 	}
 	return nil
-}
-
-func containsNULJSONString(body []byte) bool {
-	decoder := json.NewDecoder(bytes.NewReader(body))
-	decoder.UseNumber()
-	for {
-		token, err := decoder.Token()
-		if errors.Is(err, io.EOF) {
-			return false
-		}
-		if err != nil {
-			return false
-		}
-		if value, ok := token.(string); ok && strings.IndexByte(value, 0) >= 0 {
-			return true
-		}
-	}
 }

--- a/internal/resourcemeta/resourcemeta.go
+++ b/internal/resourcemeta/resourcemeta.go
@@ -2,10 +2,10 @@ package resourcemeta
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
-	"strings"
 	"unicode/utf8"
+
+	"github.com/omnara-ai/omnara/internal/dbsafe"
 )
 
 const (
@@ -45,10 +45,10 @@ func (m Metadata) ValidateWithReservedKey(reserved string) error {
 }
 
 func ValidateEntry(key, value string) error {
-	if err := validateMetadataString(key); err != nil {
+	if err := dbsafe.Text(key); err != nil {
 		return fmt.Errorf("metadata key %w", err)
 	}
-	if err := validateMetadataString(value); err != nil {
+	if err := dbsafe.Text(value); err != nil {
 		return fmt.Errorf("metadata value %w", err)
 	}
 	if key == "" || utf8.RuneCountInString(key) > MaxKeyLength {
@@ -56,16 +56,6 @@ func ValidateEntry(key, value string) error {
 	}
 	if utf8.RuneCountInString(value) > MaxValueLength {
 		return fmt.Errorf("metadata values must be at most %d characters", MaxValueLength)
-	}
-	return nil
-}
-
-func validateMetadataString(value string) error {
-	if !utf8.ValidString(value) {
-		return errors.New("contains invalid UTF-8")
-	}
-	if strings.IndexByte(value, 0) >= 0 {
-		return errors.New("contains U+0000")
 	}
 	return nil
 }

--- a/internal/resourcemeta/resourcemeta.go
+++ b/internal/resourcemeta/resourcemeta.go
@@ -2,7 +2,9 @@ package resourcemeta
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 	"unicode/utf8"
 )
 
@@ -43,11 +45,27 @@ func (m Metadata) ValidateWithReservedKey(reserved string) error {
 }
 
 func ValidateEntry(key, value string) error {
+	if err := validateMetadataString(key); err != nil {
+		return fmt.Errorf("metadata key %w", err)
+	}
+	if err := validateMetadataString(value); err != nil {
+		return fmt.Errorf("metadata value %w", err)
+	}
 	if key == "" || utf8.RuneCountInString(key) > MaxKeyLength {
 		return fmt.Errorf("metadata keys must be 1-%d characters", MaxKeyLength)
 	}
 	if utf8.RuneCountInString(value) > MaxValueLength {
 		return fmt.Errorf("metadata values must be at most %d characters", MaxValueLength)
+	}
+	return nil
+}
+
+func validateMetadataString(value string) error {
+	if !utf8.ValidString(value) {
+		return errors.New("contains invalid UTF-8")
+	}
+	if strings.IndexByte(value, 0) >= 0 {
+		return errors.New("contains U+0000")
 	}
 	return nil
 }

--- a/internal/resourcemeta/resourcemeta_test.go
+++ b/internal/resourcemeta/resourcemeta_test.go
@@ -41,6 +41,10 @@ func TestValidate(t *testing.T) {
 		{name: "empty key", metadata: Metadata{"": "value"}},
 		{name: "oversized key", metadata: Metadata{strings.Repeat("k", MaxKeyLength+1): "v"}},
 		{name: "oversized value", metadata: Metadata{"k": strings.Repeat("v", MaxValueLength+1)}},
+		{name: "NUL key", metadata: Metadata{"before\x00after": "value"}},
+		{name: "NUL value", metadata: Metadata{"key": "before\x00after"}},
+		{name: "invalid UTF-8 key", metadata: Metadata{string([]byte{0xff}): "value"}},
+		{name: "invalid UTF-8 value", metadata: Metadata{"key": string([]byte{0xff})}},
 		{name: "too many entries", metadata: tooManyEntries},
 	}
 	for _, tt := range invalid {

--- a/internal/storage/artifacts_integration_test.go
+++ b/internal/storage/artifacts_integration_test.go
@@ -141,6 +141,46 @@ func TestCreateArtifactMaxBytesRejectsBeforeUpload(t *testing.T) {
 	}
 }
 
+func TestCreateArtifactRejectsDatabaseUnsafeTextBeforeUpload(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	pool := openIntegrationDB(t, ctx)
+	seedMigratedDB(t, ctx, pool)
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	store := newIntegrationStore(pool)
+	agentID := mustCreateAgent(t, ctx, store, now)
+
+	for _, test := range []struct {
+		name        string
+		contentType string
+		filename    string
+		want        string
+	}{
+		{name: "NUL content type", contentType: "image/\x00png", want: "U+0000"},
+		{name: "invalid UTF-8 content type", contentType: string([]byte{0xff}), want: "invalid UTF-8"},
+		{name: "NUL filename", contentType: "image/png", filename: "before\x00after.png", want: "U+0000"},
+		{name: "invalid UTF-8 filename", contentType: "image/png", filename: string([]byte{0xff}), want: "invalid UTF-8"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			blobs := newRecordingBlobStore()
+			store := newIntegrationStore(pool, WithBlobStore(blobs))
+			_, err := store.Artifacts().CreateArtifact(ctx, artifactstore.CreateArtifactInput{
+				ProjectID:   testProjectID,
+				AgentID:     agentID,
+				ContentType: test.contentType,
+				Filename:    test.filename,
+				Content:     []byte("artifact bytes"),
+			})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("create artifact error = %v, want %q", err, test.want)
+			}
+			if len(blobs.putKeys) != 0 {
+				t.Fatalf("uploaded blobs = %v, want none", blobs.putKeys)
+			}
+		})
+	}
+}
+
 func TestCreateArtifactCleansUploadedBlobWhenDBInsertFails(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/storage/artifacts_integration_test.go
+++ b/internal/storage/artifacts_integration_test.go
@@ -171,7 +171,8 @@ func TestCreateArtifactRejectsDatabaseUnsafeTextBeforeUpload(t *testing.T) {
 				Filename:    test.filename,
 				Content:     []byte("artifact bytes"),
 			})
-			if err == nil || !strings.Contains(err.Error(), test.want) {
+			if !errors.Is(err, storeerr.ErrInvalidRequest) ||
+				!strings.Contains(err.Error(), test.want) {
 				t.Fatalf("create artifact error = %v, want %q", err, test.want)
 			}
 			if len(blobs.putKeys) != 0 {

--- a/internal/storage/artifactstore/artifacts_store.go
+++ b/internal/storage/artifactstore/artifacts_store.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -54,6 +56,12 @@ func (s *Store) CreateArtifact(
 	}
 	if input.ContentType == "" {
 		return ArtifactRecord{}, errors.New("artifact content type is required")
+	}
+	if err := validateArtifactStringForStorage("content type", input.ContentType); err != nil {
+		return ArtifactRecord{}, err
+	}
+	if err := validateArtifactStringForStorage("filename", input.Filename); err != nil {
+		return ArtifactRecord{}, err
 	}
 	if len(input.Content) == 0 {
 		return ArtifactRecord{}, errors.New("artifact content is required")
@@ -107,6 +115,16 @@ func (s *Store) CreateArtifact(
 		return ArtifactRecord{}, cleanupUploadedBlob(fmt.Errorf("commit create artifact: %w", err))
 	}
 	return record, nil
+}
+
+func validateArtifactStringForStorage(field, value string) error {
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("artifact %s contains invalid UTF-8", field)
+	}
+	if strings.IndexByte(value, 0) >= 0 {
+		return fmt.Errorf("artifact %s contains U+0000", field)
+	}
+	return nil
 }
 
 func (s *Store) GetArtifact(

--- a/internal/storage/artifactstore/artifacts_store.go
+++ b/internal/storage/artifactstore/artifacts_store.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/omnara-ai/omnara/internal/blobstore"
+	"github.com/omnara-ai/omnara/internal/dbsafe"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
 	"github.com/omnara-ai/omnara/internal/storage/internal/storeutil"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
@@ -57,11 +56,15 @@ func (s *Store) CreateArtifact(
 	if input.ContentType == "" {
 		return ArtifactRecord{}, errors.New("artifact content type is required")
 	}
-	if err := validateArtifactStringForStorage("content type", input.ContentType); err != nil {
-		return ArtifactRecord{}, err
+	if err := dbsafe.Text(input.ContentType); err != nil {
+		return ArtifactRecord{}, storeerr.InvalidRequest(
+			fmt.Errorf("artifact content type %w", err),
+		)
 	}
-	if err := validateArtifactStringForStorage("filename", input.Filename); err != nil {
-		return ArtifactRecord{}, err
+	if err := dbsafe.Text(input.Filename); err != nil {
+		return ArtifactRecord{}, storeerr.InvalidRequest(
+			fmt.Errorf("artifact filename %w", err),
+		)
 	}
 	if len(input.Content) == 0 {
 		return ArtifactRecord{}, errors.New("artifact content is required")
@@ -115,16 +118,6 @@ func (s *Store) CreateArtifact(
 		return ArtifactRecord{}, cleanupUploadedBlob(fmt.Errorf("commit create artifact: %w", err))
 	}
 	return record, nil
-}
-
-func validateArtifactStringForStorage(field, value string) error {
-	if !utf8.ValidString(value) {
-		return fmt.Errorf("artifact %s contains invalid UTF-8", field)
-	}
-	if strings.IndexByte(value, 0) >= 0 {
-		return fmt.Errorf("artifact %s contains U+0000", field)
-	}
-	return nil
 }
 
 func (s *Store) GetArtifact(

--- a/internal/storage/executionstore/agent_launch_store.go
+++ b/internal/storage/executionstore/agent_launch_store.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/omnara-ai/omnara/internal/agentconfig"
+	"github.com/omnara-ai/omnara/internal/dbsafe"
 	"github.com/omnara-ai/omnara/internal/resourcename"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
@@ -85,7 +86,7 @@ func (s *Store) LaunchAgent(
 		}
 		return result, nil
 	}
-	if err := validateContentBlockStringForStorage(input.Message); err != nil {
+	if err := dbsafe.Text(input.Message); err != nil {
 		return LaunchAgentResult{}, storeerr.InvalidRequest(fmt.Errorf("message %w", err))
 	}
 	project, err := loadProjectTx(ctx, qtx, input.ProjectID)

--- a/internal/storage/executionstore/agent_launch_store.go
+++ b/internal/storage/executionstore/agent_launch_store.go
@@ -85,6 +85,9 @@ func (s *Store) LaunchAgent(
 		}
 		return result, nil
 	}
+	if err := validateContentBlockStringForStorage(input.Message); err != nil {
+		return LaunchAgentResult{}, storeerr.InvalidRequest(fmt.Errorf("message %w", err))
+	}
 	project, err := loadProjectTx(ctx, qtx, input.ProjectID)
 	if err != nil {
 		return LaunchAgentResult{}, err

--- a/internal/storage/executionstore/content_blocks_store.go
+++ b/internal/storage/executionstore/content_blocks_store.go
@@ -1,10 +1,15 @@
 package executionstore
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"strings"
+	"unicode/utf8"
 
+	"github.com/omnara-ai/omnara/internal/jsoncanonical"
 	"github.com/omnara-ai/omnara/internal/resourcemeta"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
 )
@@ -121,10 +126,7 @@ func decodeContentBlock(
 	}
 	metadata, err := resourcemeta.FromJSON(fields["metadata"])
 	if err != nil {
-		return "", nil, nil, errors.New("metadata must be a JSON object with string values")
-	}
-	if err := metadata.Validate(); err != nil {
-		return "", nil, nil, fmt.Errorf("metadata: %w", err)
+		return "", nil, nil, fmt.Errorf("invalid metadata: %w", err)
 	}
 	return kind, metadata, fields, nil
 }
@@ -142,6 +144,9 @@ func parseTextContentBlock(
 	var text string
 	if err := json.Unmarshal(rawText, &text); err != nil {
 		return CreateContentBlockInput{}, errors.New("text must be a string")
+	}
+	if err := validateContentBlockStringForStorage(text); err != nil {
+		return CreateContentBlockInput{}, fmt.Errorf("text %w", err)
 	}
 	return CreateContentBlockInput{
 		BlockKind:   ContentBlockKindText,
@@ -175,10 +180,52 @@ func parseStructuredDataContentBlock(
 	if !ok {
 		return CreateContentBlockInput{}, errors.New("value is required")
 	}
+	value, err := normalizeContentBlockJSONForStorage(value)
+	if err != nil {
+		return CreateContentBlockInput{}, fmt.Errorf("value %w", err)
+	}
 	return CreateContentBlockInput{
 		BlockKind:      ContentBlockKindStructuredData,
 		StructuredData: value,
 	}, nil
+}
+
+func validateContentBlockStringForStorage(value string) error {
+	if !utf8.ValidString(value) {
+		return errors.New("contains invalid UTF-8")
+	}
+	if strings.IndexByte(value, 0) >= 0 {
+		return errors.New("contains U+0000")
+	}
+	return nil
+}
+
+func normalizeContentBlockJSONForStorage(value json.RawMessage) (json.RawMessage, error) {
+	if !utf8.Valid(value) {
+		return nil, errors.New("contains invalid UTF-8")
+	}
+	normalized, err := jsoncanonical.Normalize(value)
+	if err != nil {
+		return nil, errors.New("is not valid JSON")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(normalized))
+	decoder.UseNumber()
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return normalized, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("decode JSON: %w", err)
+		}
+		text, ok := token.(string)
+		if !ok {
+			continue
+		}
+		if err := validateContentBlockStringForStorage(text); err != nil {
+			return nil, fmt.Errorf("JSON string %w", err)
+		}
+	}
 }
 
 func rejectContentBlockFields(

--- a/internal/storage/executionstore/content_blocks_store.go
+++ b/internal/storage/executionstore/content_blocks_store.go
@@ -1,14 +1,11 @@
 package executionstore
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"strings"
-	"unicode/utf8"
 
+	"github.com/omnara-ai/omnara/internal/dbsafe"
 	"github.com/omnara-ai/omnara/internal/jsoncanonical"
 	"github.com/omnara-ai/omnara/internal/resourcemeta"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
@@ -145,7 +142,7 @@ func parseTextContentBlock(
 	if err := json.Unmarshal(rawText, &text); err != nil {
 		return CreateContentBlockInput{}, errors.New("text must be a string")
 	}
-	if err := validateContentBlockStringForStorage(text); err != nil {
+	if err := dbsafe.Text(text); err != nil {
 		return CreateContentBlockInput{}, fmt.Errorf("text %w", err)
 	}
 	return CreateContentBlockInput{
@@ -190,42 +187,15 @@ func parseStructuredDataContentBlock(
 	}, nil
 }
 
-func validateContentBlockStringForStorage(value string) error {
-	if !utf8.ValidString(value) {
-		return errors.New("contains invalid UTF-8")
-	}
-	if strings.IndexByte(value, 0) >= 0 {
-		return errors.New("contains U+0000")
-	}
-	return nil
-}
-
 func normalizeContentBlockJSONForStorage(value json.RawMessage) (json.RawMessage, error) {
-	if !utf8.Valid(value) {
-		return nil, errors.New("contains invalid UTF-8")
-	}
 	normalized, err := jsoncanonical.Normalize(value)
 	if err != nil {
 		return nil, errors.New("is not valid JSON")
 	}
-	decoder := json.NewDecoder(bytes.NewReader(normalized))
-	decoder.UseNumber()
-	for {
-		token, err := decoder.Token()
-		if errors.Is(err, io.EOF) {
-			return normalized, nil
-		}
-		if err != nil {
-			return nil, fmt.Errorf("decode JSON: %w", err)
-		}
-		text, ok := token.(string)
-		if !ok {
-			continue
-		}
-		if err := validateContentBlockStringForStorage(text); err != nil {
-			return nil, fmt.Errorf("JSON string %w", err)
-		}
+	if err := dbsafe.JSONStrings(normalized); err != nil {
+		return nil, fmt.Errorf("JSON string %w", err)
 	}
+	return normalized, nil
 }
 
 func rejectContentBlockFields(

--- a/internal/storage/executionstore/content_blocks_store_test.go
+++ b/internal/storage/executionstore/content_blocks_store_test.go
@@ -178,18 +178,6 @@ func TestContentBlocksRejectDatabaseUnsafeStrings(t *testing.T) {
 	}
 }
 
-func TestPrepareContentBlockForStorageRejectsDatabaseUnsafeStrings(t *testing.T) {
-	for _, input := range []CreateContentBlockInput{
-		{TextContent: "before\x00after"},
-		{StructuredData: json.RawMessage(`{"value":"before\u0000after"}`)},
-		{Metadata: map[string]string{"key": "before\x00after"}},
-	} {
-		if _, err := prepareContentBlockForStorage(input); err == nil {
-			t.Fatalf("database-unsafe storage input passed validation: %+v", input)
-		}
-	}
-}
-
 func TestStructuredDataNormalizesUnpairedSurrogates(t *testing.T) {
 	blocks, err := parseToolResultContentBlocks(json.RawMessage(
 		`[{"type":"structured_data","value":{"\ud800":"before\ud800after"}}]`,
@@ -197,20 +185,31 @@ func TestStructuredDataNormalizesUnpairedSurrogates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse structured data: %v", err)
 	}
-	prepared, err := prepareContentBlockForStorage(CreateContentBlockInput{
-		StructuredData: json.RawMessage(`{"\ud800":"before\ud800after"}`),
-	})
-	if err != nil {
-		t.Fatalf("prepare structured data: %v", err)
+	var decoded map[string]string
+	if err := json.Unmarshal(blocks[0].StructuredData, &decoded); err != nil {
+		t.Fatalf("decode normalized structured data %s: %v", blocks[0].StructuredData, err)
 	}
-	for _, value := range []json.RawMessage{blocks[0].StructuredData, prepared.StructuredData} {
-		var decoded map[string]string
-		if err := json.Unmarshal(value, &decoded); err != nil {
-			t.Fatalf("decode normalized structured data %s: %v", value, err)
-		}
-		if decoded["\uFFFD"] != "before\uFFFDafter" {
-			t.Fatalf("normalized structured data = %s, want replacement characters", value)
-		}
+	if decoded["\uFFFD"] != "before\uFFFDafter" {
+		t.Fatalf("normalized structured data = %s, want replacement characters", blocks[0].StructuredData)
+	}
+}
+
+func TestStructuredDataNormalizesInvalidUTF8(t *testing.T) {
+	input := append(
+		[]byte(`[{"type":"structured_data","value":{"message":"before`),
+		0xff,
+	)
+	input = append(input, []byte(`after"}}]`)...)
+	blocks, err := parseToolResultContentBlocks(input)
+	if err != nil {
+		t.Fatalf("parse structured data: %v", err)
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal(blocks[0].StructuredData, &decoded); err != nil {
+		t.Fatalf("decode normalized structured data %s: %v", blocks[0].StructuredData, err)
+	}
+	if decoded["message"] != "before\uFFFDafter" {
+		t.Fatalf("normalized structured data = %s, want replacement character", blocks[0].StructuredData)
 	}
 }
 

--- a/internal/storage/executionstore/content_blocks_store_test.go
+++ b/internal/storage/executionstore/content_blocks_store_test.go
@@ -3,6 +3,7 @@ package executionstore
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
@@ -119,6 +120,97 @@ func TestToolResultContentBlocksAllowEmptyText(t *testing.T) {
 	if len(blocks) != 1 || blocks[0].BlockKind != ContentBlockKindText ||
 		blocks[0].TextContent != "" {
 		t.Fatalf("empty text blocks = %+v, want one empty text block", blocks)
+	}
+}
+
+func TestContentBlocksRejectDatabaseUnsafeStrings(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		parse func(json.RawMessage) ([]CreateContentBlockInput, error)
+		input json.RawMessage
+	}{
+		{
+			name:  "agent input text",
+			parse: parseAgentInputContentBlocks,
+			input: json.RawMessage(`[{"type":"text","text":"before\u0000after"}]`),
+		},
+		{
+			name:  "tool result text",
+			parse: parseToolResultContentBlocks,
+			input: json.RawMessage(`[{"type":"text","text":"before\u0000after"}]`),
+		},
+		{
+			name:  "structured data value",
+			parse: parseToolResultContentBlocks,
+			input: json.RawMessage(
+				`[{"type":"structured_data","value":{"nested":["before\u0000after"]}}]`,
+			),
+		},
+		{
+			name:  "structured data key",
+			parse: parseToolResultContentBlocks,
+			input: json.RawMessage(
+				`[{"type":"structured_data","value":{"before\u0000after":true}}]`,
+			),
+		},
+		{
+			name:  "metadata key",
+			parse: parseAgentInputContentBlocks,
+			input: json.RawMessage(
+				`[{"type":"text","text":"safe","metadata":{"before\u0000after":"value"}}]`,
+			),
+		},
+		{
+			name:  "metadata value",
+			parse: parseToolResultContentBlocks,
+			input: json.RawMessage(
+				`[{"type":"text","text":"safe","metadata":{"key":"before\u0000after"}}]`,
+			),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := test.parse(test.input)
+			if !errors.Is(err, storeerr.ErrInvalidRequest) ||
+				!strings.Contains(err.Error(), "U+0000") {
+				t.Fatalf("database-unsafe content error = %v, want invalid request for U+0000", err)
+			}
+		})
+	}
+}
+
+func TestPrepareContentBlockForStorageRejectsDatabaseUnsafeStrings(t *testing.T) {
+	for _, input := range []CreateContentBlockInput{
+		{TextContent: "before\x00after"},
+		{StructuredData: json.RawMessage(`{"value":"before\u0000after"}`)},
+		{Metadata: map[string]string{"key": "before\x00after"}},
+	} {
+		if _, err := prepareContentBlockForStorage(input); err == nil {
+			t.Fatalf("database-unsafe storage input passed validation: %+v", input)
+		}
+	}
+}
+
+func TestStructuredDataNormalizesUnpairedSurrogates(t *testing.T) {
+	blocks, err := parseToolResultContentBlocks(json.RawMessage(
+		`[{"type":"structured_data","value":{"\ud800":"before\ud800after"}}]`,
+	))
+	if err != nil {
+		t.Fatalf("parse structured data: %v", err)
+	}
+	prepared, err := prepareContentBlockForStorage(CreateContentBlockInput{
+		StructuredData: json.RawMessage(`{"\ud800":"before\ud800after"}`),
+	})
+	if err != nil {
+		t.Fatalf("prepare structured data: %v", err)
+	}
+	for _, value := range []json.RawMessage{blocks[0].StructuredData, prepared.StructuredData} {
+		var decoded map[string]string
+		if err := json.Unmarshal(value, &decoded); err != nil {
+			t.Fatalf("decode normalized structured data %s: %v", value, err)
+		}
+		if decoded["\uFFFD"] != "before\uFFFDafter" {
+			t.Fatalf("normalized structured data = %s, want replacement characters", value)
+		}
 	}
 }
 

--- a/internal/storage/executionstore/kernel_event_authority_constraints_integration_test.go
+++ b/internal/storage/executionstore/kernel_event_authority_constraints_integration_test.go
@@ -5,6 +5,7 @@ package executionstore_test
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -560,6 +561,45 @@ func TestKernelContentBlockOwnerAndOrdinalConstraints(t *testing.T) {
 	now := fixture.Now.Add(time.Minute)
 	toolCallID := createToolCallForProcessTest(t, ctx, fixture, "kernel_content_block_owner_ordinal", "read_process")
 	modelOutputID := modelOutputIDForToolCall(t, ctx, fixture.Store, fixture.AgentID, toolCallID)
+	for index, test := range []struct {
+		name  string
+		input executionstore.CreateContentBlockInput
+	}{
+		{
+			name: "text",
+			input: executionstore.CreateContentBlockInput{
+				BlockKind:   executionstore.ContentBlockKindText,
+				TextContent: "before\x00after",
+			},
+		},
+		{
+			name: "structured data",
+			input: executionstore.CreateContentBlockInput{
+				BlockKind:      executionstore.ContentBlockKindStructuredData,
+				StructuredData: json.RawMessage(`{"value":"before\u0000after"}`),
+			},
+		},
+		{
+			name: "metadata",
+			input: executionstore.CreateContentBlockInput{
+				BlockKind:   executionstore.ContentBlockKindText,
+				TextContent: "safe",
+				Metadata:    map[string]string{"key": "before\x00after"},
+			},
+		},
+	} {
+		t.Run("database unsafe "+test.name, func(t *testing.T) {
+			test.input.ProjectID = testProjectID
+			test.input.AgentID = fixture.AgentID
+			test.input.OwnerKind = executionstore.ContentBlockOwnerModelOutput
+			test.input.OwnerModelOutputID = modelOutputID
+			test.input.Ordinal = int32(index + 10)
+			_, err := executionstore.IntegrationCreateContentBlockTx(ctx, fixture.Store.pool, test.input)
+			if err == nil || !strings.Contains(err.Error(), "U+0000") {
+				t.Fatalf("create database-unsafe content block error = %v, want U+0000", err)
+			}
+		})
+	}
 
 	var block executionstore.ContentBlockRecord
 	var blockKind string

--- a/internal/storage/executionstore/kernel_event_authority_store.go
+++ b/internal/storage/executionstore/kernel_event_authority_store.go
@@ -96,8 +96,9 @@ func createContentBlockTx(
 			"project, agent, owner kind, and block kind are required",
 		)
 	}
-	if err := input.Metadata.Validate(); err != nil {
-		return ContentBlockRecord{}, fmt.Errorf("content block metadata: %w", err)
+	input, err := prepareContentBlockForStorage(input)
+	if err != nil {
+		return ContentBlockRecord{}, err
 	}
 	metadata, err := input.Metadata.JSON()
 	if err != nil {
@@ -129,6 +130,25 @@ func createContentBlockTx(
 		return ContentBlockRecord{}, fmt.Errorf("create content block: %w", err)
 	}
 	return contentBlockFromInsertSQLC(row), nil
+}
+
+func prepareContentBlockForStorage(
+	input CreateContentBlockInput,
+) (CreateContentBlockInput, error) {
+	if err := validateContentBlockStringForStorage(input.TextContent); err != nil {
+		return CreateContentBlockInput{}, fmt.Errorf("content block text %w", err)
+	}
+	if len(input.StructuredData) > 0 {
+		normalized, err := normalizeContentBlockJSONForStorage(input.StructuredData)
+		if err != nil {
+			return CreateContentBlockInput{}, fmt.Errorf("content block structured data %w", err)
+		}
+		input.StructuredData = normalized
+	}
+	if err := input.Metadata.Validate(); err != nil {
+		return CreateContentBlockInput{}, fmt.Errorf("content block metadata: %w", err)
+	}
+	return input, nil
 }
 
 func appendTypedAgentEventTx(

--- a/internal/storage/executionstore/kernel_event_authority_store.go
+++ b/internal/storage/executionstore/kernel_event_authority_store.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/omnara-ai/omnara/internal/dbsafe"
 	"github.com/omnara-ai/omnara/internal/events"
 	"github.com/omnara-ai/omnara/internal/modelenvelope"
 	"github.com/omnara-ai/omnara/internal/notifications"
@@ -96,9 +97,15 @@ func createContentBlockTx(
 			"project, agent, owner kind, and block kind are required",
 		)
 	}
-	input, err := prepareContentBlockForStorage(input)
-	if err != nil {
-		return ContentBlockRecord{}, err
+	if err := dbsafe.Text(input.TextContent); err != nil {
+		return ContentBlockRecord{}, fmt.Errorf("content block text %w", err)
+	}
+	if len(input.StructuredData) > 0 {
+		normalized, err := normalizeContentBlockJSONForStorage(input.StructuredData)
+		if err != nil {
+			return ContentBlockRecord{}, fmt.Errorf("content block structured data %w", err)
+		}
+		input.StructuredData = normalized
 	}
 	metadata, err := input.Metadata.JSON()
 	if err != nil {
@@ -130,25 +137,6 @@ func createContentBlockTx(
 		return ContentBlockRecord{}, fmt.Errorf("create content block: %w", err)
 	}
 	return contentBlockFromInsertSQLC(row), nil
-}
-
-func prepareContentBlockForStorage(
-	input CreateContentBlockInput,
-) (CreateContentBlockInput, error) {
-	if err := validateContentBlockStringForStorage(input.TextContent); err != nil {
-		return CreateContentBlockInput{}, fmt.Errorf("content block text %w", err)
-	}
-	if len(input.StructuredData) > 0 {
-		normalized, err := normalizeContentBlockJSONForStorage(input.StructuredData)
-		if err != nil {
-			return CreateContentBlockInput{}, fmt.Errorf("content block structured data %w", err)
-		}
-		input.StructuredData = normalized
-	}
-	if err := input.Metadata.Validate(); err != nil {
-		return CreateContentBlockInput{}, fmt.Errorf("content block metadata: %w", err)
-	}
-	return input, nil
 }
 
 func appendTypedAgentEventTx(


### PR DESCRIPTION
- reject database-unsafe U+0000 and invalid UTF-8 before PostgreSQL or blob writes, returning non-retryable validation errors for malformed public requests
- canonicalize structured-data JSON before storage so unsupported surrogate escapes become replacement characters while nested U+0000 keys and values are rejected
- preserve retry and idempotency behavior: rejected tool results remain ready for correction, artifact uploads avoid partial writes, and completed launch replays keep their existing semantics
- document the custom tool-result content contract for client implementers
