### PR TITLE
fix: revalidate model grants on agent launch

### DIFF
--- a/internal/crontrigger/service.go
+++ b/internal/crontrigger/service.go
@@ -59,7 +59,7 @@ func (s *Service) FireDueTriggers(ctx context.Context) (FireStats, error) {
 		fired := false
 		if err := s.fireTrigger(ctx, trigger); err != nil {
 			stats.Failures++
-			retry := !permanentFireError(err)
+			retry := shouldRetryFiring(err)
 			s.logger.Error(
 				"fire cron trigger",
 				"cron_trigger_id", trigger.TriggerID,
@@ -217,10 +217,12 @@ func cronTriggerActorParams(
 	}, nil
 }
 
-func permanentFireError(err error) bool {
-	return errors.Is(err, storeerr.ErrNotFound) ||
-		errors.Is(err, storeerr.ErrInvalidRequest) ||
-		errors.Is(err, storeerr.ErrIdempotencyConflict)
+// Unknown failures retry. Deterministic errors consume this occurrence; later
+// scheduled occurrences remain eligible to run.
+func shouldRetryFiring(err error) bool {
+	return !errors.Is(err, storeerr.ErrNotFound) &&
+		!errors.Is(err, storeerr.ErrInvalidRequest) &&
+		!errors.Is(err, storeerr.ErrIdempotencyConflict)
 }
 
 func fireIdempotencyKey(trigger executionstore.ClaimedCronTrigger) string {

--- a/internal/storage/executionstore/agent_configs_integration_test.go
+++ b/internal/storage/executionstore/agent_configs_integration_test.go
@@ -123,8 +123,12 @@ model:
 		CompilerVersion:         agentconfig.CompilerVersion,
 		EffectiveDefinitionHash: compiled.Hash,
 	})
-	if !errors.Is(err, storeerr.ErrInvalidModelProviderConfig) {
-		t.Fatalf("create agent config with model runtime options error = %v, want ErrInvalidModelProviderConfig", err)
+	if !errors.Is(err, storeerr.ErrInvalidRequest) ||
+		!errors.Is(err, storeerr.ErrInvalidModelProviderConfig) {
+		t.Fatalf(
+			"create agent config with model runtime options error = %v, want invalid model request",
+			err,
+		)
 	}
 }
 

--- a/internal/storage/executionstore/agent_configs_store.go
+++ b/internal/storage/executionstore/agent_configs_store.go
@@ -294,6 +294,22 @@ func validateAgentConfigModelContractTx(ctx context.Context, qtx *dbsqlc.Queries
 	if err != nil {
 		return fmt.Errorf("validate agent config runtime contract: %w", err)
 	}
+	return validateAgentConfigModelForUseTx(
+		ctx,
+		qtx,
+		input.OrgID,
+		input.ProjectID,
+		input.ConfiguredModelID,
+		contract,
+	)
+}
+
+func validateAgentConfigModelForUseTx(
+	ctx context.Context,
+	qtx *dbsqlc.Queries,
+	orgID, projectID, configuredModelID ID,
+	contract agentconfig.RuntimeContract,
+) error {
 	if contract.Model.ConfiguredModelID == "" {
 		return errors.New("agent config compiled model must include configured_model_id")
 	}
@@ -301,25 +317,25 @@ func validateAgentConfigModelContractTx(ctx context.Context, qtx *dbsqlc.Queries
 	if err != nil {
 		return fmt.Errorf("parse compiled configured model id: %w", err)
 	}
-	if compiledModelID != input.ConfiguredModelID {
+	if compiledModelID != configuredModelID {
 		return fmt.Errorf("compiled configured model does not match agent config row: %w", storeerr.ErrIdempotencyConflict)
 	}
 	effectiveModel, err := modelstore.ResolveForAgentTx(
 		ctx,
 		qtx,
-		input.OrgID,
-		input.ProjectID,
-		input.ConfiguredModelID,
+		orgID,
+		projectID,
+		configuredModelID,
 		contract.Model.Overrides(),
 	)
 	if err != nil {
 		return fmt.Errorf("resolve configured model for agent config: %w", err)
 	}
 	if contract.RequiresModelToolSupport() && !effectiveModel.SupportsTools {
-		return fmt.Errorf(
+		return storeerr.InvalidRequest(fmt.Errorf(
 			"agent config requires tools but configured model project grant does not support tools: %w",
 			storeerr.ErrInvalidModelProviderConfig,
-		)
+		))
 	}
 	return nil
 }

--- a/internal/storage/executionstore/agent_launch_integration_test.go
+++ b/internal/storage/executionstore/agent_launch_integration_test.go
@@ -351,6 +351,78 @@ tools:
 	}
 }
 
+func TestLaunchAgentRevalidatesProfileModelGrant(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	pool := openIntegrationDB(t, ctx)
+	seedMigratedDB(t, ctx, pool)
+	store := newIntegrationStore(pool)
+	now := time.Date(2026, 6, 16, 10, 5, 0, 0, time.UTC)
+	user := mustCreateProjectDeveloperUser(
+		t,
+		ctx,
+		store,
+		"launch-model-grant@example.com",
+		"Launch Model Grant",
+	)
+	profile := mustCreateConfigAndProfileBookmarkFromYAML(
+		t,
+		ctx,
+		store,
+		"launch-model-grant",
+		"Launch Model Grant",
+		`
+instruction: Revalidate the model grant before launch.
+model:
+  provider_config: openai-prod
+  name: gpt-test
+tools: {}
+`,
+		now,
+	)
+	launch := func(idempotencyKey string) (executionstore.LaunchAgentResult, error) {
+		return store.Execution().LaunchAgent(ctx, executionstore.LaunchAgentInput{
+			ProjectID:      testProjectID,
+			ProfileID:      profile.ID,
+			AgentConfigID:  profile.CurrentConfigID,
+			LaunchedBy:     userPrincipal(user.ID),
+			IdempotencyKey: idempotencyKey,
+		})
+	}
+	launched, err := launch("idem-launch-model-grant")
+	if err != nil {
+		t.Fatalf("launch agent before model grant revoke: %v", err)
+	}
+	grant, err := store.Models().GetActiveProjectModelGrantForConfiguredModel(
+		ctx,
+		testOrgID,
+		testProjectID,
+		launched.AgentConfig.ConfiguredModelID,
+	)
+	if err != nil {
+		t.Fatalf("load active model grant: %v", err)
+	}
+	if _, err := store.Models().DeleteProjectModelGrant(
+		ctx,
+		testOrgID,
+		testProjectID,
+		grant.ID,
+	); err != nil {
+		t.Fatalf("revoke model grant: %v", err)
+	}
+
+	replayed, err := launch("idem-launch-model-grant")
+	if err != nil {
+		t.Fatalf("replay launch after model grant revoke: %v", err)
+	}
+	requireCurrentAgentLaunchReplay(t, replayed, launched.Agent)
+
+	_, err = launch("idem-launch-model-grant-after-revoke")
+	if !errors.Is(err, storeerr.ErrNotFound) {
+		t.Fatalf("fresh launch after model grant revoke error = %v, want ErrNotFound", err)
+	}
+}
+
 func TestConcurrentSameKeyLaunchIgnoresLosingBody(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/storage/executionstore/agent_launch_store.go
+++ b/internal/storage/executionstore/agent_launch_store.go
@@ -336,6 +336,19 @@ func launchConfigTx(
 	if err != nil {
 		return AgentConfigRecord{}, agentconfig.RuntimeContract{}, err
 	}
+	if err := validateAgentConfigModelForUseTx(
+		ctx,
+		qtx,
+		config.OrgID,
+		config.ProjectID,
+		config.ConfiguredModelID,
+		contract,
+	); err != nil {
+		return AgentConfigRecord{}, agentconfig.RuntimeContract{}, fmt.Errorf(
+			"validate agent config model for launch: %w",
+			err,
+		)
+	}
 	return config, contract, nil
 }
 

--- a/internal/storage/modelstore/agent_resolution.go
+++ b/internal/storage/modelstore/agent_resolution.go
@@ -23,6 +23,12 @@ func ResolveForAgentTx(
 		OrgID: orgID,
 		ID:    configuredModelID,
 	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ConfiguredModelRevisionRecord{}, fmt.Errorf(
+			"configured model is unavailable: %w",
+			storeerr.ErrNotFound,
+		)
+	}
 	if err != nil {
 		return ConfiguredModelRevisionRecord{}, fmt.Errorf("load configured model: %w", err)
 	}
@@ -31,6 +37,12 @@ func ResolveForAgentTx(
 		OrgID: orgID,
 		ID:    configuredModel.ModelProviderConfigID,
 	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ConfiguredModelRevisionRecord{}, fmt.Errorf(
+			"model provider config is unavailable: %w",
+			storeerr.ErrNotFound,
+		)
+	}
 	if err != nil {
 		return ConfiguredModelRevisionRecord{}, fmt.Errorf("load model provider config: %w", err)
 	}
@@ -58,7 +70,7 @@ func ResolveForAgentTx(
 		options,
 	)
 	if err != nil {
-		return ConfiguredModelRevisionRecord{}, err
+		return ConfiguredModelRevisionRecord{}, storeerr.InvalidRequest(err)
 	}
 	return effective, nil
 }


### PR DESCRIPTION
## Summary

- revalidate a stored agent configuration's live project model grant before a fresh launch
- reuse the same effective-model and tool-support validation used when configurations are created
- preserve idempotent replays of agents that were already launched before a grant was revoked
- classify model-policy validation as an invalid launch request so failed cron occurrences are consumed instead of retried indefinitely

## Why

Agent profiles intentionally retain immutable historical configurations after access changes. A fresh launch could reuse one of those configurations after its project model grant had been revoked or restricted, creating an agent that could not run. Fresh launches now fail before inserting the agent, while historical state and completed launch replays remain intact. A scheduled occurrence that encounters a deterministic policy error is recorded as failed and completed; later scheduled occurrences remain eligible after an administrator fixes the policy.

## Verification

- go test ./internal/storage/modelstore ./internal/storage/executionstore
- go test -tags=integration ./internal/storage/executionstore -run ^\(TestCreateAgentConfigValidatesRuntimeModelOverridesAgainstGrant\|TestLaunchAgentRevalidatesProfileModelGrant\)$ -count=1
- make verify