### PR TITLE
fix: improve chat auto-scrolling

### DIFF
--- a/frontend/apps/web/package.json
+++ b/frontend/apps/web/package.json
@@ -22,7 +22,7 @@
     "@heroicons/react": "^2.2.0",
     "@omnara/react": "workspace:*",
     "@omnara/sdk": "workspace:*",
-    "@shadcn/react": "^0.2.0",
+    "@shadcn/react": "^0.2.1",
     "@tanstack/react-form": "^1.33.0",
     "@tanstack/react-query": "^5.59.0",
     "@tanstack/react-router": "^1.69.0",

--- a/frontend/apps/web/src/components/agents/AgentComposer.tsx
+++ b/frontend/apps/web/src/components/agents/AgentComposer.tsx
@@ -1,4 +1,5 @@
 import type { UseAgentChatResult } from '@omnara/react'
+import { useMessageScroller } from '@shadcn/react/message-scroller'
 import { type KeyboardEvent, type SyntheticEvent, useState } from 'react'
 
 import { SendHorizontal, Square } from '@/components/icons'
@@ -18,6 +19,7 @@ export function AgentComposer({
   cancelError?: Error | null
   canOperate: boolean
 }) {
+  const { scrollToEnd } = useMessageScroller()
   const [text, setText] = useState('')
   const working = chat.isWorking
   const canSend = canOperate && chat.historyStatus === 'success' && text.trim() !== ''
@@ -27,6 +29,7 @@ export function AgentComposer({
     const content = text.trim()
     setText('')
     try {
+      scrollToEnd()
       await chat.sendMessage({ text: content })
     } catch {
       setText(content)

--- a/frontend/apps/web/src/components/agents/AgentConversation.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConversation.tsx
@@ -8,7 +8,6 @@ import {
   MessageScrollerButton,
   MessageScrollerContent,
   MessageScrollerItem,
-  MessageScrollerProvider,
   MessageScrollerViewport,
 } from '@/components/ui/message-scroller'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -27,69 +26,67 @@ export function AgentConversation({
   agentID: string
 }) {
   return (
-    <MessageScrollerProvider>
-      <MessageScroller>
-        <MessageScrollerViewport>
-          <MessageScrollerContent className="mx-auto w-full max-w-3xl px-4 pb-2 pt-6 sm:px-6">
-            {chat.historyStatus === 'pending' ? (
-              <div className="space-y-6 py-4">
-                <Skeleton className="h-20 w-2/3" />
-                <Skeleton className="ml-auto h-14 w-1/2" />
-                <Skeleton className="h-28 w-3/4" />
+    <MessageScroller>
+      <MessageScrollerViewport
+        onWheelCapture={(event) => {
+          if (event.deltaY >= 0) event.stopPropagation()
+        }}
+      >
+        <MessageScrollerContent className="mx-auto w-full max-w-3xl px-4 pb-2 pt-6 sm:px-6">
+          {chat.historyStatus === 'pending' ? (
+            <div className="space-y-6 py-4">
+              <Skeleton className="h-20 w-2/3" />
+              <Skeleton className="ml-auto h-14 w-1/2" />
+              <Skeleton className="h-28 w-3/4" />
+            </div>
+          ) : chat.historyStatus === 'error' ? (
+            <div className="m-auto max-w-sm py-16 text-center">
+              <p className="font-medium">Conversation unavailable</p>
+              <p className="text-muted-foreground mt-1 text-sm">
+                Refresh the page to try loading it again.
+              </p>
+            </div>
+          ) : chat.messages.length === 0 ? (
+            <div className="m-auto flex max-w-sm flex-col items-center py-16 text-center">
+              <div className="bg-muted mb-4 flex size-10 items-center justify-center rounded-full">
+                <Bot className="size-5" />
               </div>
-            ) : chat.historyStatus === 'error' ? (
-              <div className="m-auto max-w-sm py-16 text-center">
-                <p className="font-medium">Conversation unavailable</p>
-                <p className="text-muted-foreground mt-1 text-sm">
-                  Refresh the page to try loading it again.
-                </p>
-              </div>
-            ) : chat.messages.length === 0 ? (
-              <div className="m-auto flex max-w-sm flex-col items-center py-16 text-center">
-                <div className="bg-muted mb-4 flex size-10 items-center justify-center rounded-full">
-                  <Bot className="size-5" />
-                </div>
-                <p className="font-medium">Start a conversation</p>
-                <p className="text-muted-foreground mt-1 text-sm">
-                  Send a message to give this agent its next task.
-                </p>
-              </div>
-            ) : (
-              <>
-                {chat.hasOlderMessages && (
-                  <div className="flex justify-center pb-4">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      disabled={chat.isLoadingOlderMessages}
-                      loading={chat.isLoadingOlderMessages}
-                      onClick={chat.loadOlderMessages}
-                    >
-                      Load earlier messages
-                    </Button>
-                  </div>
-                )}
-                {chat.messages.map((message, index) => (
-                  <MessageScrollerItem
-                    key={message.id}
-                    messageId={message.id}
-                    scrollAnchor={index === chat.messages.length - 1}
+              <p className="font-medium">Start a conversation</p>
+              <p className="text-muted-foreground mt-1 text-sm">
+                Send a message to give this agent its next task.
+              </p>
+            </div>
+          ) : (
+            <>
+              {chat.hasOlderMessages && (
+                <div className="flex justify-center pb-4">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={chat.isLoadingOlderMessages}
+                    loading={chat.isLoadingOlderMessages}
+                    onClick={chat.loadOlderMessages}
                   >
-                    <AgentChatMessage
-                      message={message}
-                      currentActorId={currentActorId}
-                      orgID={orgID}
-                      projectID={projectID}
-                      agentID={agentID}
-                    />
-                  </MessageScrollerItem>
-                ))}
-              </>
-            )}
-          </MessageScrollerContent>
-        </MessageScrollerViewport>
-        <MessageScrollerButton />
-      </MessageScroller>
-    </MessageScrollerProvider>
+                    Load earlier messages
+                  </Button>
+                </div>
+              )}
+              {chat.messages.map((message) => (
+                <MessageScrollerItem key={message.id} messageId={message.id}>
+                  <AgentChatMessage
+                    message={message}
+                    currentActorId={currentActorId}
+                    orgID={orgID}
+                    projectID={projectID}
+                    agentID={agentID}
+                  />
+                </MessageScrollerItem>
+              ))}
+            </>
+          )}
+        </MessageScrollerContent>
+      </MessageScrollerViewport>
+      <MessageScrollerButton />
+    </MessageScroller>
   )
 }

--- a/frontend/apps/web/src/routes/AgentView.tsx
+++ b/frontend/apps/web/src/routes/AgentView.tsx
@@ -25,6 +25,7 @@ import { hasPendingMcpBuilderOAuthOutcome } from '@/components/agents/pendingMcp
 import { SettingsIcon } from '@/components/icons'
 import { PageBreadcrumb } from '@/components/layout/PageBreadcrumb'
 import { Button } from '@/components/ui/button'
+import { MessageScrollerProvider } from '@/components/ui/message-scroller'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { errorMessage } from '@/lib/submit-status'
 import { useActiveOrg } from '@/lib/use-active-org'
@@ -91,118 +92,120 @@ export function AgentView() {
       className="h-[calc(100svh-3rem)] min-h-0 overflow-hidden"
       style={{ '--sidebar-width': '20rem' } as CSSProperties}
     >
-      <div
-        className="mx-auto flex h-full w-full min-w-0 max-w-5xl flex-1 flex-col overflow-hidden"
-        style={{ contain: 'paint' }}
-      >
-        <header className="shrink-0 pb-4">
-          <div className="flex min-w-0 items-center justify-between gap-2">
-            <PageBreadcrumb
-              items={[
-                { id: 'organization', label: activeOrg.name, to: '/' },
-                ...(project ? [{ id: 'project', label: project.name }] : []),
-                {
-                  id: 'agents',
-                  label: 'Agents',
-                  to: '/projects/$projectId/agents' as const,
-                  params: { projectId },
-                },
-                { id: 'agent', label: agent.name || 'Agent' },
-              ]}
-            />
-            <div className="flex shrink-0 items-center gap-1">
-              {agent.current_config_id !== undefined && (
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  aria-label="Agent configuration"
-                  className={cn('text-muted-foreground', configOpen && sidebarToggleActiveClass)}
-                  onClick={() => {
-                    if (!configOpen) {
-                      setConfigOpen(true)
-                      return
-                    }
-                    if (configDirty.current && !window.confirm(discardConfigEditsPrompt)) return
-                    closeConfig()
-                  }}
-                >
-                  <SettingsIcon />
-                </Button>
-              )}
-              <AgentSidebarToggle />
-            </div>
-          </div>
-        </header>
-
-        {configOpen ? (
-          <main className="min-h-0 flex-1 overflow-y-auto">
-            <AgentConfigPanel
-              orgId={activeOrg.id}
-              projectId={projectId}
-              agent={agent}
-              canManage={project?.access.can_manage ?? false}
-              onDirtyChange={(dirty) => {
-                configDirty.current = dirty
-              }}
-              onClose={closeConfig}
-            />
-          </main>
-        ) : (
-          <main className="min-h-0 flex-1">
-            <AgentConversation
-              chat={chat}
-              currentActorId={currentActorId}
-              orgID={activeOrg.id}
-              projectID={projectId}
-              agentID={agentId}
-            />
-          </main>
-        )}
-
-        <div className="mx-auto grid w-full max-w-3xl shrink-0 gap-3">
-          {!archived && (
-            <AgentInteractions
-              interactions={interactions.data?.data ?? []}
-              pending={resolveInteraction.isPending}
-              error={resolveInteraction.error}
-              loadError={
-                interactions.error != null
-                  ? errorMessage(interactions.error, 'Unknown error')
-                  : null
-              }
-              onResolve={resolve}
-              canOperate={canOperate}
-            />
-          )}
-          {archived ? (
-            !configOpen && (
-              <div className="bg-muted/30 rounded-xl border px-4 py-3 text-center">
-                <p className="text-sm font-medium">This agent is archived</p>
-                <p className="text-muted-foreground mt-1 text-xs">
-                  You can view its conversation, but it can no longer receive messages.
-                </p>
-              </div>
-            )
-          ) : (
-            <div className={cn('min-w-0', configOpen && 'hidden')}>
-              <AgentInputQueue
-                backlog={chat.inputBacklog}
-                canOperate={canOperate}
-                canSendNow={canSendNow}
+      <MessageScrollerProvider key={agentId} autoScroll>
+        <div
+          className="mx-auto flex h-full w-full min-w-0 max-w-5xl flex-1 flex-col overflow-hidden"
+          style={{ contain: 'paint' }}
+        >
+          <header className="shrink-0 pb-4">
+            <div className="flex min-w-0 items-center justify-between gap-2">
+              <PageBreadcrumb
+                items={[
+                  { id: 'organization', label: activeOrg.name, to: '/' },
+                  ...(project ? [{ id: 'project', label: project.name }] : []),
+                  {
+                    id: 'agents',
+                    label: 'Agents',
+                    to: '/projects/$projectId/agents' as const,
+                    params: { projectId },
+                  },
+                  { id: 'agent', label: agent.name || 'Agent' },
+                ]}
               />
-              {!configOpen && (
-                <AgentComposer
-                  chat={chat}
-                  cancelPending={cancelAgent.isPending}
-                  cancelError={cancelAgent.error}
-                  onCancel={cancelCurrent}
-                  canOperate={canOperate}
-                />
-              )}
+              <div className="flex shrink-0 items-center gap-1">
+                {agent.current_config_id !== undefined && (
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    aria-label="Agent configuration"
+                    className={cn('text-muted-foreground', configOpen && sidebarToggleActiveClass)}
+                    onClick={() => {
+                      if (!configOpen) {
+                        setConfigOpen(true)
+                        return
+                      }
+                      if (configDirty.current && !window.confirm(discardConfigEditsPrompt)) return
+                      closeConfig()
+                    }}
+                  >
+                    <SettingsIcon />
+                  </Button>
+                )}
+                <AgentSidebarToggle />
+              </div>
             </div>
+          </header>
+
+          {configOpen ? (
+            <main className="min-h-0 flex-1 overflow-y-auto">
+              <AgentConfigPanel
+                orgId={activeOrg.id}
+                projectId={projectId}
+                agent={agent}
+                canManage={project?.access.can_manage ?? false}
+                onDirtyChange={(dirty) => {
+                  configDirty.current = dirty
+                }}
+                onClose={closeConfig}
+              />
+            </main>
+          ) : (
+            <main className="min-h-0 flex-1">
+              <AgentConversation
+                chat={chat}
+                currentActorId={currentActorId}
+                orgID={activeOrg.id}
+                projectID={projectId}
+                agentID={agentId}
+              />
+            </main>
           )}
+
+          <div className="mx-auto grid w-full max-w-3xl shrink-0 gap-3 pt-3">
+            {!archived && (
+              <AgentInteractions
+                interactions={interactions.data?.data ?? []}
+                pending={resolveInteraction.isPending}
+                error={resolveInteraction.error}
+                loadError={
+                  interactions.error != null
+                    ? errorMessage(interactions.error, 'Unknown error')
+                    : null
+                }
+                onResolve={resolve}
+                canOperate={canOperate}
+              />
+            )}
+            {archived ? (
+              !configOpen && (
+                <div className="bg-muted/30 rounded-xl border px-4 py-3 text-center">
+                  <p className="text-sm font-medium">This agent is archived</p>
+                  <p className="text-muted-foreground mt-1 text-xs">
+                    You can view its conversation, but it can no longer receive messages.
+                  </p>
+                </div>
+              )
+            ) : (
+              <div className={cn('min-w-0', configOpen && 'hidden')}>
+                <AgentInputQueue
+                  backlog={chat.inputBacklog}
+                  canOperate={canOperate}
+                  canSendNow={canSendNow}
+                />
+                {!configOpen && (
+                  <AgentComposer
+                    chat={chat}
+                    cancelPending={cancelAgent.isPending}
+                    cancelError={cancelAgent.error}
+                    onCancel={cancelCurrent}
+                    canOperate={canOperate}
+                  />
+                )}
+              </div>
+            )}
+          </div>
         </div>
-      </div>
+      </MessageScrollerProvider>
       <AgentSidebar
         orgId={activeOrg.id}
         projectId={projectId}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sdk
       '@shadcn/react':
-        specifier: ^0.2.0
-        version: 0.2.0(@types/react@19.2.17)(react@19.3.0-canary-eb8feb71-20260814)
+        specifier: ^0.2.1
+        version: 0.2.1(@types/react@19.2.17)(react@19.3.0-canary-eb8feb71-20260814)
       '@tanstack/react-form':
         specifier: ^1.33.0
         version: 1.33.0(react-dom@19.3.0-canary-eb8feb71-20260814(react@19.3.0-canary-eb8feb71-20260814))(react@19.3.0-canary-eb8feb71-20260814)
@@ -1980,8 +1980,8 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
-  '@shadcn/react@0.2.0':
-    resolution: {integrity: sha512-g/LMtyL0eiHCHkOCelhYf32RC5nTMdtUNag1ZQRhSDCW+jnHxDY1Dajk7P6zJosOg8z2N4wzfKOY5sh54QTDYA==}
+  '@shadcn/react@0.2.1':
+    resolution: {integrity: sha512-5krgi3dRMKb5jH6a+qPzVJUy/54s0kKE4Rw4LjDfLqOdVQTWKUgxWf1kW8r912I0jX/Lzxqc+pgjkjWxUIK5BQ==}
     peerDependencies:
       '@types/react': '>=19'
       react: 19.3.0-canary-eb8feb71-20260814
@@ -7173,7 +7173,7 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@shadcn/react@0.2.0(@types/react@19.2.17)(react@19.3.0-canary-eb8feb71-20260814)':
+  '@shadcn/react@0.2.1(@types/react@19.2.17)(react@19.3.0-canary-eb8feb71-20260814)':
     optionalDependencies:
       '@types/react': 19.2.17
       react: 19.3.0-canary-eb8feb71-20260814


### PR DESCRIPTION
- Upgrade @shadcn/react to 0.2.1 and use its resize-aware auto-scroll behavior so long streaming responses remain pinned to the latest output.
- Share the message-scroller provider across the transcript and composer so sending a message immediately re-engages bottom-follow, with fresh state when switching agents.
- Preserve deliberate upward scrolling while ignoring downward or no-op trackpad momentum that would otherwise disengage follow at the live edge.
- Replace the moving last-message anchor with bottom-follow semantics and add a small visual gap above the composer.