### PR TITLE
fix: expose agent IDs and ignore Slack system messages

### DIFF
--- a/internal/integration/slack/events.go
+++ b/internal/integration/slack/events.go
@@ -334,7 +334,8 @@ func RemoteUserEvent(workspaceID string, event Event) bool {
 }
 
 func BotOrSelfEvent(botUserID string, event Event) bool {
-	return event.User == "" || event.User == botUserID || event.BotID != "" || event.Subtype == "bot_message"
+	return event.User == "" || event.User == botUserID || event.User == "USLACK" || event.BotID != "" ||
+		event.Subtype == "bot_message"
 }
 
 func DisabledInstallEvent(botUserID string, event Event) bool {

--- a/internal/integration/slack/events_test.go
+++ b/internal/integration/slack/events_test.go
@@ -333,6 +333,20 @@ func TestInstallLifecycleEvents(t *testing.T) {
 	}
 }
 
+func TestBotOrSelfEventIgnoresSlackSystemUser(t *testing.T) {
+	event := Event{
+		Type:        "message",
+		User:        "USLACK",
+		Text:        "You have been removed from #general",
+		Channel:     "D123",
+		ChannelType: "im",
+		TS:          "111.222",
+	}
+	if !BotOrSelfEvent("U_BOT", event) {
+		t.Fatal("BotOrSelfEvent for Slack system notification = false, want true")
+	}
+}
+
 func TestDecodeEventsEnvelopeNameUpdates(t *testing.T) {
 	raw := []byte(`{"type":"event_callback","team_id":"T123","api_app_id":"A123",` +
 		`"event_id":"Ev1","event":{"type":"user_profile_changed","user":{"id":"U123",` +

--- a/internal/modelcontext/context.go
+++ b/internal/modelcontext/context.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/omnara-ai/omnara/internal/agentconfig"
+	"github.com/omnara-ai/omnara/internal/publicid"
 	"github.com/omnara-ai/omnara/internal/storage"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 	"github.com/omnara-ai/omnara/internal/storage/integrationstore"
@@ -28,6 +29,10 @@ func (b Builder) Build(ctx context.Context, input BuildInput) (Bundle, error) {
 	}
 	if input.Now.IsZero() {
 		return Bundle{}, fmt.Errorf("modelcontext build time is required")
+	}
+	agentPublicID, err := publicid.Encode(publicid.KindAgent, input.AgentID)
+	if err != nil {
+		return Bundle{}, fmt.Errorf("encode agent public id: %w", err)
 	}
 	var snapshot executionstore.AgentConfigSnapshotRecord
 	if input.AgentConfigSnapshot != nil {
@@ -129,7 +134,7 @@ func (b Builder) Build(ctx context.Context, input BuildInput) (Bundle, error) {
 		TurnID:             input.TurnID,
 		OpeningInputIDs:    input.OpeningInputIDs,
 		InputEventSequence: watermark,
-		SystemPrompt:       defaultSystemPromptForContract(contract, toolSpecs, catalogSkills),
+		SystemPrompt:       defaultSystemPromptForContract(agentPublicID, contract, toolSpecs, catalogSkills),
 	}
 	bundle.ContextCheckpoint = checkpointRef
 	if len(toolSpecs) > 0 {
@@ -255,11 +260,12 @@ func HasAnyTool(specs []ToolSpec, names ...string) bool {
 }
 
 func defaultSystemPromptForContract(
+	agentPublicID string,
 	contract agentconfig.RuntimeContract,
 	toolSpecs []ToolSpec,
 	skills []skillstore.SkillRecord,
 ) string {
-	parts := []string{DefaultSystemPrompt()}
+	parts := []string{DefaultSystemPrompt(), "Your Omnara agent ID is `" + agentPublicID + "`."}
 	if guidance := capabilityGuidance(toolSpecs); guidance != "" {
 		parts = append(parts, guidance)
 	}

--- a/internal/modelcontext/context_test.go
+++ b/internal/modelcontext/context_test.go
@@ -135,6 +135,13 @@ func TestBuildKeepsAllMessagesAndCrossTurnToolResultsThroughWatermark(t *testing
 	if !strings.Contains(bundle.SystemPrompt, "Help the user make progress.") {
 		t.Fatalf("expected system prompt to include agent instruction, got %q", bundle.SystemPrompt)
 	}
+	agentPublicID, err := publicid.Encode(publicid.KindAgent, testAgentID)
+	if err != nil {
+		t.Fatalf("encode agent public id: %v", err)
+	}
+	if !strings.Contains(bundle.SystemPrompt, "Your Omnara agent ID is `"+agentPublicID+"`.") {
+		t.Fatalf("expected system prompt to include agent public id, got %q", bundle.SystemPrompt)
+	}
 	if string(bundle.ToolResults[0].Input) != `{"command":"echo 750"}` {
 		t.Fatalf("expected tool input to survive context projection, got %+v", bundle.ToolResults[0])
 	}


### PR DESCRIPTION
- adds each agent public ID to its model system prompt immediately after the default Omnara instructions
- ignores Slack system notifications from `USLACK` before inbound routing so channel-removal notices cannot create DM agents
- adds regression coverage for the prompt identity and the production-shaped Slack system event