### PR TITLE
fix: improve compaction admission estimates

### DIFF
--- a/internal/e2e/service_e2e_compaction_test.go
+++ b/internal/e2e/service_e2e_compaction_test.go
@@ -344,7 +344,7 @@ func TestServiceE2EDeterministicCompactionKeepsToolGroupRaw(t *testing.T) {
 				failModelRequest(w, http.StatusBadRequest, "first request unexpectedly used the compaction prompt: %+v", body)
 				return
 			}
-			writeOpenAIFunctionCall(
+			writeOpenAIFunctionCallWithUsage(
 				w,
 				failModelRequest,
 				"resp_tool_before_split_compaction",
@@ -353,6 +353,8 @@ func TestServiceE2EDeterministicCompactionKeepsToolGroupRaw(t *testing.T) {
 				map[string]any{
 					"command": "printf '" + commandNeedle + "\\n' " + strings.Repeat("&& true ", 80),
 				},
+				1_250,
+				100,
 			)
 		case 2:
 			instructions, _ := body["instructions"].(string)

--- a/internal/e2e/service_e2e_daemon_process_tools_test.go
+++ b/internal/e2e/service_e2e_daemon_process_tools_test.go
@@ -2492,7 +2492,17 @@ func writeOpenAIFunctionCall(
 	responseID, callID, name string,
 	args map[string]any,
 ) {
-	writeOpenAIFunctionCalls(w, fail, responseID, fakeOpenAIFunctionCall{
+	writeOpenAIFunctionCallWithUsage(w, fail, responseID, callID, name, args, 10, 5)
+}
+
+func writeOpenAIFunctionCallWithUsage(
+	w http.ResponseWriter,
+	fail fakeModelFailureFunc,
+	responseID, callID, name string,
+	args map[string]any,
+	inputTokens, outputTokens int,
+) {
+	writeOpenAIFunctionCallsWithUsage(w, fail, responseID, inputTokens, outputTokens, fakeOpenAIFunctionCall{
 		CallID: callID,
 		Name:   name,
 		Args:   args,
@@ -2509,6 +2519,16 @@ func writeOpenAIFunctionCalls(
 	w http.ResponseWriter,
 	fail fakeModelFailureFunc,
 	responseID string,
+	calls ...fakeOpenAIFunctionCall,
+) {
+	writeOpenAIFunctionCallsWithUsage(w, fail, responseID, 10, 5, calls...)
+}
+
+func writeOpenAIFunctionCallsWithUsage(
+	w http.ResponseWriter,
+	fail fakeModelFailureFunc,
+	responseID string,
+	inputTokens, outputTokens int,
 	calls ...fakeOpenAIFunctionCall,
 ) {
 	output := make([]map[string]any, 0, len(calls))
@@ -2529,7 +2549,7 @@ func writeOpenAIFunctionCalls(
 		"id":     responseID,
 		"status": "completed",
 		"output": output,
-		"usage":  map[string]any{"input_tokens": 10, "output_tokens": 5},
+		"usage":  map[string]any{"input_tokens": inputTokens, "output_tokens": outputTokens},
 	})
 	if err != nil {
 		fail(w, http.StatusInternalServerError, "marshal OpenAI response: %v", err)

--- a/internal/e2e/service_e2e_live_test.go
+++ b/internal/e2e/service_e2e_live_test.go
@@ -317,7 +317,7 @@ WHERE call.project_id = $1
 	}
 }
 
-func assertLiveToolResultSummarized(
+func assertLiveToolResultRetainedAcrossCheckpoint(
 	t *testing.T,
 	ctx context.Context,
 	env *serviceE2EEnvironment,
@@ -325,10 +325,12 @@ func assertLiveToolResultSummarized(
 ) {
 	t.Helper()
 	var callSequence, resultSequence, summarizedThrough int64
+	var summary string
 	if err := env.db.QueryRow(ctx, `
 SELECT call.source_event_sequence,
        result_event.sequence,
-       checkpoint.summarized_through_event_sequence
+       checkpoint.summarized_through_event_sequence,
+       checkpoint.summary
 FROM tool_call_read_projection call
 JOIN tool_call_results result
   ON result.agent_id = call.agent_id
@@ -339,21 +341,23 @@ JOIN agent_events result_event
  AND result_event.event_kind = 'tool_result'
 JOIN context_checkpoints checkpoint
   ON checkpoint.agent_id = call.agent_id
- AND strpos(checkpoint.summary, $4) > 0
 WHERE call.project_id = $1
   AND call.agent_id = $2
   AND call.name = $3
 ORDER BY checkpoint.created_at DESC, checkpoint.id DESC
-LIMIT 1`, projectUUID, agentUUID, toolName, toolResult).Scan(
+LIMIT 1`, projectUUID, agentUUID, toolName).Scan(
 		&callSequence,
 		&resultSequence,
 		&summarizedThrough,
+		&summary,
 	); err != nil {
-		t.Fatalf("query summarized live tool boundary: %v", err)
+		t.Fatalf("query retained live tool boundary: %v", err)
 	}
-	if callSequence >= resultSequence || resultSequence > summarizedThrough {
+	retainedExactly := callSequence > summarizedThrough && resultSequence > summarizedThrough
+	retainedInSummary := resultSequence <= summarizedThrough && strings.Contains(summary, toolResult)
+	if callSequence >= resultSequence || (!retainedExactly && !retainedInSummary) {
 		t.Fatalf(
-			"live compaction cut tool boundary call=%d result=%d summarized_through=%d",
+			"live compaction lost tool result call=%d result=%d summarized_through=%d",
 			callSequence,
 			resultSequence,
 			summarizedThrough,
@@ -850,7 +854,7 @@ func runLiveServiceCompactionRecall(t *testing.T, ctx context.Context, opts live
 	project.createInput(t, ctx, agentID, secondPrompt)
 	waitForServiceE2EConditionUntil(t, ctx, time.Now().Add(5*time.Minute), func() (bool, string) {
 		var checkpoints, compactedContexts, failedBudgetContexts int
-		if err := env.db.QueryRow(ctx, `SELECT count(*) FROM context_checkpoints checkpoint JOIN agents agent ON agent.id = checkpoint.agent_id WHERE agent.project_id = $1 AND checkpoint.agent_id = $2 AND strpos(checkpoint.summary, $3) > 0 AND strpos(checkpoint.summary, $4) > 0 AND strpos(checkpoint.summary, $5) = 0`, projectUUID, agentUUID, projectLabel, sampleID, rawPaddingToken).
+		if err := env.db.QueryRow(ctx, `SELECT count(*) FROM context_checkpoints checkpoint JOIN agents agent ON agent.id = checkpoint.agent_id WHERE agent.project_id = $1 AND checkpoint.agent_id = $2 AND strpos(checkpoint.summary, $3) > 0 AND strpos(checkpoint.summary, $4) = 0`, projectUUID, agentUUID, projectLabel, rawPaddingToken).
 			Scan(&checkpoints); err != nil {
 			return false, err.Error()
 		}
@@ -923,7 +927,7 @@ func runLiveServiceCompactionRecall(t *testing.T, ctx context.Context, opts live
 		opts.RequireProviderReportedCost,
 	)
 	assertLiveToolResultEvidence(t, ctx, env, projectUUID, agentUUID, toolName, sampleID)
-	assertLiveToolResultSummarized(t, ctx, env, projectUUID, agentUUID, toolName, sampleID)
+	assertLiveToolResultRetainedAcrossCheckpoint(t, ctx, env, projectUUID, agentUUID, toolName, sampleID)
 
 	var beforeRecallSequence int64
 	if err := env.db.QueryRow(ctx, `SELECT coalesce(max(event.sequence), 0) FROM agent_events event JOIN agents agent ON agent.id = event.agent_id WHERE agent.project_id = $1 AND event.agent_id = $2`, projectUUID, agentUUID).

--- a/internal/harness/kernel/agent_executor_context.go
+++ b/internal/harness/kernel/agent_executor_context.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/omnara-ai/omnara/internal/agentconfig"
+	"github.com/omnara-ai/omnara/internal/log/logent"
 	"github.com/omnara-ai/omnara/internal/model"
 	"github.com/omnara-ai/omnara/internal/modelcontext"
 	"github.com/omnara-ai/omnara/internal/modelenvelope"
@@ -246,6 +247,11 @@ func (e AgentExecutor) executeModelStep(
 			Context:     bundle,
 			Policy:      policy,
 			ErrorSource: modelErrorSourceForClient(client),
+			ProviderUsageIdentity: &modelcontext.ModelRequestIdentity{
+				AgentConfigID:             claim.Context.AgentConfigID.String(),
+				ConfiguredModelRevisionID: claim.Context.ConfiguredModelRevisionID.String(),
+				ProviderRequestIdentity:   resolved.ProviderRequestIdentity,
+			},
 		},
 	)
 	if err != nil {
@@ -337,6 +343,16 @@ func (e AgentExecutor) executeModelStep(
 			response,
 		)
 	}
+	logent.ModelInputTokenEstimate(ctx, logent.ModelInputTokenEstimateRecord{
+		RequestedProviderModelSlug: client.RequestedProviderModelSlug(),
+		ServedProviderModelSlug:    response.ServedProviderModelSlug,
+		APIFormat:                  apiFormat,
+		APIVariant:                 apiVariant,
+		EstimatedTokens:            prepared.InputBudget.EstimatedInputTokens,
+		LocalEstimatedTokens:       prepared.InputTokenEstimate,
+		EstimatedMediaTokens:       prepared.InputMediaTokenEstimate,
+		ProviderReportedTokens:     response.Usage.InputTokens,
+	})
 	step := modelStep{
 		Context:             claim.Context,
 		Bundle:              bundle,

--- a/internal/harness/kernel/agent_executor_model_request_integration_test.go
+++ b/internal/harness/kernel/agent_executor_model_request_integration_test.go
@@ -3,6 +3,7 @@
 package kernel
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1148,11 +1149,20 @@ WHERE context.project_id = $1
 	}
 }
 
-func TestAgentExecutorRoutesSerializedProviderRequestOverflowThroughCompactionBeforeSend(t *testing.T) {
+func TestAgentExecutorRoutesProviderMeasuredRequestOverflowThroughCompactionBeforeSend(t *testing.T) {
 	ctx := context.Background()
 	fixture := newKernelFixture(t, ctx)
 	now := fixture.Now
-	agentID, userID := fixture.createAgent(t, ctx, "openai/serialized-overflow-history-model", now)
+	agentID, userID := fixture.createAgentWithModelOptions(
+		t,
+		ctx,
+		"openai/provider-measured-overflow-model",
+		now,
+		kernelConfiguredModelOptions{
+			ContextWindowTokens: intPtrForKernelCompactionTest(10_000),
+			MaxOutputTokens:     intPtrForKernelCompactionTest(500),
+		},
+	)
 	firstTurn := fixture.admitContentInputTurn(
 		t,
 		ctx,
@@ -1162,17 +1172,18 @@ func TestAgentExecutorRoutesSerializedProviderRequestOverflowThroughCompactionBe
 		now.Add(time.Millisecond),
 	)
 	modelClient := &sequenceKernelModel{
-		providerModelSlug:          "serialized-overflow-history-model",
+		providerModelSlug:          "provider-measured-overflow-model",
 		preparedInputTokenEstimate: 500,
-		preparedInputTokenEstimates: []int{
-			100,
-			200_000,
+		capabilities: model.Capabilities{
+			ContextWindowTokens: 10_000,
+			MaxOutputTokens:     500,
 		},
 		responses: []model.Response{
 			{
 				ID:         "resp-historical-turn",
 				Content:    []model.ResponsePart{{Type: model.ResponsePartTypeText, Text: "historical work completed"}},
 				StopReason: model.StopReasonEndTurn,
+				Usage:      model.Usage{InputTokens: 8_400, OutputTokens: 100},
 			},
 			{
 				ID:         "resp-compaction-summary",
@@ -1215,14 +1226,15 @@ func TestAgentExecutorRoutesSerializedProviderRequestOverflowThroughCompactionBe
 	)
 	currentNow = now.Add(13 * time.Millisecond)
 	if err := executor.ExecuteModelWork(ctx, secondTurn); err != nil {
-		t.Fatalf("execute serialized overflow turn: %v", err)
+		t.Fatalf("execute provider-measured overflow turn: %v", err)
 	}
 
 	var state executionstore.ModelCallState
 	var recoveryKind executionstore.ModelCallRecoveryKind
 	var errorCode string
+	var errorDetails json.RawMessage
 	if err := fixture.Pool.QueryRow(ctx, `
-SELECT context.state, context.recovery_kind, context.error_code
+SELECT context.state, context.recovery_kind, context.error_code, context.error_details
 FROM model_call_contexts context
 WHERE context.project_id = $1
   AND context.agent_id = $2
@@ -1231,17 +1243,21 @@ WHERE context.project_id = $1
 		&state,
 		&recoveryKind,
 		&errorCode,
+		&errorDetails,
 	); err != nil {
-		t.Fatalf("load compactable serialized overflow attempt: %v", err)
+		t.Fatalf("load compactable provider-measured overflow attempt: %v", err)
 	}
 	if state != executionstore.ModelCallContextFailed || recoveryKind != executionstore.ModelCallRecoveryCompact ||
 		errorCode != "configured_input_budget_exceeded" {
 		t.Fatalf(
-			"compactable serialized overflow attempt = %q/%q/%q",
+			"compactable provider-measured overflow attempt = %q/%q/%q",
 			state,
 			recoveryKind,
 			errorCode,
 		)
+	}
+	if !bytes.Contains(errorDetails, []byte(`"provider_usage_estimate"`)) {
+		t.Fatalf("compaction trigger omitted provider usage estimate: %s", errorDetails)
 	}
 	var compactionDependencies int
 	if err := fixture.Pool.QueryRow(ctx, `
@@ -1255,6 +1271,6 @@ WHERE context.project_id = $1
 		t.Fatalf("count compactable serialized overflow dependencies: %v", err)
 	}
 	if compactionDependencies != 1 {
-		t.Fatalf("serialized overflow compaction dependencies = %d, want 1", compactionDependencies)
+		t.Fatalf("provider-measured overflow compaction dependencies = %d, want 1", compactionDependencies)
 	}
 }

--- a/internal/log/logent/logent_test.go
+++ b/internal/log/logent/logent_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/omnara-ai/omnara/internal/log"
+	"github.com/omnara-ai/omnara/internal/modelprotocol"
 	"github.com/omnara-ai/omnara/internal/storage"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
@@ -102,6 +103,31 @@ func TestLogEntitiesAttachCanonicalFields(t *testing.T) {
 				"model_request.body_byte_limit":              float64(31_998_976),
 			},
 			banned: []string{"artifact_id", "content", "media_data"},
+		},
+		{
+			name: "Model input token estimate",
+			attach: func(ctx context.Context) {
+				ModelInputTokenEstimate(ctx, ModelInputTokenEstimateRecord{
+					RequestedProviderModelSlug: "gpt-requested",
+					ServedProviderModelSlug:    "gpt-served",
+					APIFormat:                  modelprotocol.APIFormatOpenAIResponses,
+					APIVariant:                 modelprotocol.APIVariantDefault,
+					EstimatedTokens:            1_200,
+					LocalEstimatedTokens:       900,
+					EstimatedMediaTokens:       300,
+					ProviderReportedTokens:     1_100,
+				})
+			},
+			want: map[string]any{
+				"model_request.requested_provider_model_slug": "gpt-requested",
+				"model_request.api_format":                    string(modelprotocol.APIFormatOpenAIResponses),
+				"model_request.api_variant":                   string(modelprotocol.APIVariantDefault),
+				"model_request.input_tokens.estimated":        float64(1_200),
+				"model_request.input_tokens.local_estimated":  float64(900),
+				"model_request.input_tokens.media_estimated":  float64(300),
+				"model_response.served_provider_model_slug":   "gpt-served",
+				"model_response.input_tokens.reported":        float64(1_100),
+			},
 		},
 		{
 			name: "Machine skips config blobs",

--- a/internal/log/logent/model.go
+++ b/internal/log/logent/model.go
@@ -4,8 +4,36 @@ import (
 	"context"
 
 	"github.com/omnara-ai/omnara/internal/log"
+	"github.com/omnara-ai/omnara/internal/modelprotocol"
 	"github.com/omnara-ai/omnara/internal/storage"
 )
+
+type ModelInputTokenEstimateRecord struct {
+	RequestedProviderModelSlug string
+	ServedProviderModelSlug    string
+	APIFormat                  modelprotocol.APIFormat
+	APIVariant                 modelprotocol.APIVariant
+	EstimatedTokens            int
+	LocalEstimatedTokens       int
+	EstimatedMediaTokens       int
+	ProviderReportedTokens     int
+}
+
+func ModelInputTokenEstimate(ctx context.Context, record ModelInputTokenEstimateRecord) {
+	if record.EstimatedTokens <= 0 || record.ProviderReportedTokens <= 0 {
+		return
+	}
+	log.Attach(ctx, log.Fields{
+		"model_request.requested_provider_model_slug": record.RequestedProviderModelSlug,
+		"model_request.api_format":                    record.APIFormat,
+		"model_request.api_variant":                   record.APIVariant,
+		"model_request.input_tokens.estimated":        record.EstimatedTokens,
+		"model_request.input_tokens.local_estimated":  record.LocalEstimatedTokens,
+		"model_request.input_tokens.media_estimated":  record.EstimatedMediaTokens,
+		"model_response.served_provider_model_slug":   record.ServedProviderModelSlug,
+		"model_response.input_tokens.reported":        record.ProviderReportedTokens,
+	})
+}
 
 func ModelCatalogProbeFailed(ctx context.Context, modelProviderConfigID storage.ID, message string) {
 	log.Attach(ctx, log.Fields{

--- a/internal/model/image_tokens.go
+++ b/internal/model/image_tokens.go
@@ -20,7 +20,8 @@ const (
 	anthropicStandardMaxImageTokens = 1_568
 	anthropicHighMaxImageEdge       = 2_576
 	anthropicHighMaxImageTokens     = 4_784
-	openAIUnknownImageTokens        = 25_501
+	openAIMaxImagePatches           = 30_000
+	openAIUnknownImageTokens        = 48_169
 )
 
 type imageResolutionLimits struct {
@@ -157,26 +158,30 @@ func openAIImageTokenEstimateForDimensions(providerModelSlug string, width, heig
 
 	switch {
 	case strings.HasPrefix(name, "gpt-5.6"):
-		return patches
+		return scaledPatchTokens(
+			min(openAIPatchCountWithinDimension(width, height, 65_535), openAIMaxImagePatches),
+			1.2,
+		)
 	case strings.HasPrefix(name, "gpt-5.5"):
-		return boundedOpenAIPatchCount(width, height, 10_000, 6_000)
-	case strings.HasPrefix(name, "gpt-5.4-mini"), strings.HasPrefix(name, "gpt-5-mini"):
-		return multipliedPatchTokens(boundedOpenAIPatchCount(width, height, 1_536, 2_048), 1.62)
-	case strings.HasPrefix(name, "gpt-5.4-nano"), strings.HasPrefix(name, "gpt-5-nano"):
-		return multipliedPatchTokens(boundedOpenAIPatchCount(width, height, 1_536, 2_048), 2.46)
+		return scaledPatchTokens(boundedOpenAIPatchCount(width, height, 10_000, 6_000), 1.2)
 	case strings.HasPrefix(name, "gpt-5.4"):
-		return boundedOpenAIPatchCount(width, height, 2_500, 2_048)
+		return scaledPatchTokens(boundedOpenAIPatchCount(width, height, 2_500, 2_048), 1.2)
+	case strings.HasPrefix(name, "gpt-5-mini"):
+		return scaledPatchTokens(boundedOpenAIPatchCount(width, height, 1_536, 2_048), 1.2)
+	case strings.HasPrefix(name, "gpt-5-nano"):
+		return scaledPatchTokens(boundedOpenAIPatchCount(width, height, 1_536, 2_048), 1.5)
 	case strings.HasPrefix(name, "gpt-4.1-mini"):
-		return multipliedPatchTokens(boundedOpenAIPatchCount(width, height, 1_536, 2_048), 1.62)
+		return scaledPatchTokens(boundedOpenAIPatchCount(width, height, 6_144, 2_048), 1.62)
 	case strings.HasPrefix(name, "gpt-4.1-nano"):
-		return multipliedPatchTokens(boundedOpenAIPatchCount(width, height, 1_536, 2_048), 2.46)
+		return scaledPatchTokens(boundedOpenAIPatchCount(width, height, 1_536, 2_048), 2.46)
 	case strings.HasPrefix(name, "o4-mini"):
-		return multipliedPatchTokens(boundedOpenAIPatchCount(width, height, 1_536, 2_048), 1.72)
-	case strings.HasPrefix(name, "gpt-5.2"),
-		strings.HasPrefix(name, "gpt-5.3-codex"),
+		return scaledPatchTokens(boundedOpenAIPatchCount(width, height, 1_536, 2_048), 1.72)
+	case strings.HasPrefix(name, "gpt-5.2"):
+		return scaledPatchTokens(boundedOpenAIPatchCount(width, height, 6_144, 2_048), 1.2)
+	case strings.HasPrefix(name, "gpt-5.3-codex"),
 		strings.HasPrefix(name, "gpt-5-codex-mini"),
 		strings.HasPrefix(name, "gpt-5.1-codex-mini"):
-		return boundedOpenAIPatchCount(width, height, 1_536, 2_048)
+		return scaledPatchTokens(boundedOpenAIPatchCount(width, height, 1_536, 2_048), 1.2)
 	case isGPT5TileModel(name):
 		return tileImageTokens(width, height, 70, 140)
 	case strings.HasPrefix(name, "gpt-4o-mini"):
@@ -191,10 +196,7 @@ func openAIImageTokenEstimateForDimensions(providerModelSlug string, width, heig
 		return tileImageTokens(width, height, 65, 129)
 	default:
 		return max(
-			max(
-				max(patches, multipliedPatchTokens(patches, 2.46)),
-				openAIUnknownImageTokens,
-			),
+			max(scaledPatchTokens(min(patches, openAIMaxImagePatches), 1.2), openAIUnknownImageTokens),
 			tileImageTokens(width, height, 2_833, 5_667),
 		)
 	}
@@ -221,14 +223,7 @@ func isClaudeFamilyModelSlug(providerModelSlug string) bool {
 }
 
 func boundedOpenAIPatchCount(width, height, patchBudget, maxDimension int) int {
-	scale := min(
-		1.0,
-		min(float64(maxDimension)/float64(width), float64(maxDimension)/float64(height)),
-	)
-	scaledWidth := float64(width) * scale
-	scaledHeight := float64(height) * scale
-	patches := ceilDiv(max(int(math.Ceil(scaledWidth)), 1), 32) *
-		ceilDiv(max(int(math.Ceil(scaledHeight)), 1), 32)
+	patches, scaledWidth, scaledHeight := openAIPatchDimensions(width, height, maxDimension)
 	if patches <= patchBudget {
 		return patches
 	}
@@ -240,14 +235,32 @@ func boundedOpenAIPatchCount(width, height, patchBudget, maxDimension int) int {
 		patchesWide/(scaledWidth*shrink/32),
 		patchesHigh/(scaledHeight*shrink/32),
 	)
-	resizedWidth := max(int(math.Round(scaledWidth*shrink*adjustment)), 1)
-	resizedHeight := max(int(math.Round(scaledHeight*shrink*adjustment)), 1)
+	resizedWidth := max(int(math.Floor(scaledWidth*shrink*adjustment)), 1)
+	resizedHeight := max(int(math.Floor(scaledHeight*shrink*adjustment)), 1)
 	return min(ceilDiv(resizedWidth, 32)*ceilDiv(resizedHeight, 32), patchBudget)
+}
+
+func openAIPatchCountWithinDimension(width, height, maxDimension int) int {
+	patches, _, _ := openAIPatchDimensions(width, height, maxDimension)
+	return patches
+}
+
+func openAIPatchDimensions(width, height, maxDimension int) (int, float64, float64) {
+	scale := min(
+		1.0,
+		min(float64(maxDimension)/float64(width), float64(maxDimension)/float64(height)),
+	)
+	scaledWidth := float64(width) * scale
+	scaledHeight := float64(height) * scale
+	patches := ceilDiv(max(int(math.Ceil(scaledWidth)), 1), 32) *
+		ceilDiv(max(int(math.Ceil(scaledHeight)), 1), 32)
+	return patches, scaledWidth, scaledHeight
 }
 
 func isGPT5TileModel(name string) bool {
 	return name == "gpt-5" || strings.HasPrefix(name, "gpt-5-20") ||
-		strings.HasPrefix(name, "gpt-5-chat-latest")
+		name == "gpt-5-chat-latest" || name == "gpt-5.1" ||
+		strings.HasPrefix(name, "gpt-5.1-20") || name == "gpt-5.1-chat-latest"
 }
 
 func imageDimensions(data []byte) (int, int, bool) {
@@ -266,11 +279,16 @@ func normalizedProviderModelName(slug string) string {
 	if variant := strings.IndexByte(name, ':'); variant >= 0 {
 		name = name[:variant]
 	}
+	for _, prefix := range []string{"anthropic.", "openai."} {
+		if index := strings.LastIndex(name, prefix); index >= 0 {
+			name = name[index+len(prefix):]
+		}
+	}
 	return name
 }
 
-func multipliedPatchTokens(patches int, multiplier float64) int {
-	return int(math.Ceil(float64(min(patches, 1_536)) * multiplier))
+func scaledPatchTokens(patches int, multiplier float64) int {
+	return int(math.Ceil(float64(patches) * multiplier))
 }
 
 func tileImageTokens(width, height, base, perTile int) int {
@@ -279,10 +297,10 @@ func tileImageTokens(width, height, base, perTile int) int {
 	w *= fit
 	h *= fit
 	shortest := min(w, h)
-	if shortest > 0 {
+	if shortest > 768 {
 		scale := 768 / shortest
-		w *= scale
-		h *= scale
+		w = math.Floor(w * scale)
+		h = math.Floor(h * scale)
 	}
 	tiles := int(math.Ceil(w/512) * math.Ceil(h/512))
 	return base + tiles*perTile

--- a/internal/model/image_tokens_test.go
+++ b/internal/model/image_tokens_test.go
@@ -22,11 +22,13 @@ func TestProviderImageTokenEstimates(t *testing.T) {
 			got:  AnthropicImageTokenEstimate("claude-sonnet-4-6", media),
 			want: 1_369,
 		},
-		{name: "openai original patches", got: OpenAIImageTokenEstimate("gpt-5.6", media), want: 1_024},
-		{name: "openai bounded patches", got: OpenAIImageTokenEstimate("gpt-5-mini", media), want: 1_659},
-		{name: "openai unmultiplied GPT-5.2 patches", got: OpenAIImageTokenEstimate("gpt-5.2", media), want: 1_024},
-		{name: "openai unmultiplied Codex patches", got: OpenAIImageTokenEstimate("gpt-5.3-codex", media), want: 1_024},
+		{name: "openai original patches", got: OpenAIImageTokenEstimate("gpt-5.6", media), want: 1_229},
+		{name: "openai bounded patches", got: OpenAIImageTokenEstimate("gpt-5-mini", media), want: 1_229},
+		{name: "openai GPT-5.2 patches", got: OpenAIImageTokenEstimate("gpt-5.2", media), want: 1_229},
+		{name: "openai Codex patches", got: OpenAIImageTokenEstimate("gpt-5.3-codex", media), want: 1_229},
+		{name: "bedrock openai slug", got: OpenAIImageTokenEstimate("openai.gpt-5.6-sol", media), want: 1_229},
 		{name: "openai GPT-5 snapshot tiles", got: OpenAIImageTokenEstimate("gpt-5-2025-08-07", media), want: 630},
+		{name: "openai GPT-5.1 tiles", got: OpenAIImageTokenEstimate("gpt-5.1", media), want: 630},
 		{name: "openai expensive tiles", got: OpenAIImageTokenEstimate("gpt-4o-mini", media), want: 25_501},
 	}
 	for _, test := range tests {
@@ -73,6 +75,13 @@ func TestAnthropicImageTokenEstimateMatchesDocumentedResolutionTiers(t *testing.
 			width:             100,
 			height:            3_000,
 			want:              112,
+		},
+		{
+			name:              "bedrock provider slug",
+			providerModelSlug: "anthropic.claude-haiku-4-5",
+			width:             1_920,
+			height:            1_080,
+			want:              1_560,
 		},
 		{
 			name:              "high resolution 1080p",
@@ -130,42 +139,49 @@ func TestOpenAIImageTokenEstimateMatchesDocumentedPatchExamples(t *testing.T) {
 			providerModelSlug: "gpt-5.6",
 			width:             1_800,
 			height:            2_400,
-			want:              4_275,
+			want:              5_130,
 		},
 		{
 			name:              "finite patch model resizes within budget",
 			providerModelSlug: "gpt-5.2",
 			width:             1_800,
 			height:            2_400,
-			want:              1_452,
+			want:              3_687,
 		},
 		{
 			name:              "finite patch model long edge",
 			providerModelSlug: "gpt-5.2",
 			width:             100,
 			height:            3_000,
-			want:              192,
+			want:              231,
 		},
 		{
 			name:              "original detail model long edge",
 			providerModelSlug: "gpt-5.5",
 			width:             100,
 			height:            7_000,
-			want:              564,
+			want:              677,
 		},
 		{
 			name:              "GPT-5.4 patch budget",
 			providerModelSlug: "gpt-5.4",
 			width:             2_048,
 			height:            2_048,
-			want:              2_500,
+			want:              3_000,
 		},
 		{
 			name:              "GPT-5.5 original patch budget",
 			providerModelSlug: "gpt-5.5",
 			width:             4_096,
 			height:            4_096,
-			want:              10_000,
+			want:              12_000,
+		},
+		{
+			name:              "tile model keeps a narrow image at native scale",
+			providerModelSlug: "gpt-4o",
+			width:             100,
+			height:            3_000,
+			want:              765,
 		},
 	}
 	for _, test := range tests {
@@ -235,8 +251,8 @@ func TestOpenAICompatibleFallbacksUseLargestImageEstimate(t *testing.T) {
 		[]string{"anthropic/claude-sonnet-4.6", "openai/gpt-5.6"},
 		media,
 	)
-	if got != 8_160 {
-		t.Fatalf("fallback estimate = %d, want 8160", got)
+	if got != 9_792 {
+		t.Fatalf("fallback estimate = %d, want 9792", got)
 	}
 }
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -124,6 +124,7 @@ type Resolver interface {
 type ResolvedClient struct {
 	Client                    Client
 	ConfiguredModelRevisionID string
+	ProviderRequestIdentity   modelenvelope.ProviderReplayIdentity
 }
 
 type PrepareInput struct {
@@ -134,20 +135,24 @@ type PrepareInput struct {
 type PreparedRequest struct {
 	// Body is the exact JSON byte sequence authorized by Prepare and passed to
 	// the provider transport. Respond must not rebuild or mutate it.
-	Body               json.RawMessage
-	InputTokenEstimate int
-	InputBudget        InputBudgetAssessment
+	Body                    json.RawMessage
+	InputTokenEstimate      int
+	InputMediaTokenEstimate int
+	InputBudget             InputBudgetAssessment
 }
 
 type PrepareForSendInput struct {
-	Context     modelcontext.Bundle
-	Policy      RequestPolicy
-	ErrorSource string
+	Context               modelcontext.Bundle
+	Policy                RequestPolicy
+	ErrorSource           string
+	ProviderUsageIdentity *modelcontext.ModelRequestIdentity
 }
 
 type InputBudgetAssessment struct {
-	EstimatedInputTokens int `json:"estimated_input_tokens"`
-	UsableInputTokens    int `json:"usable_input_tokens"`
+	LocalInputTokenEstimate int                                      `json:"local_input_token_estimate"`
+	EstimatedInputTokens    int                                      `json:"estimated_input_tokens"`
+	UsableInputTokens       int                                      `json:"usable_input_tokens"`
+	ProviderUsageEstimate   *modelcontext.ProviderUsageInputEstimate `json:"provider_usage_estimate,omitempty"`
 }
 
 func (a InputBudgetAssessment) Fits() bool {
@@ -198,10 +203,28 @@ func PrepareForSend(
 		estimate = modelcontext.EstimatePreparedRequest(prepared.Body, input.Context.RenderedMedia)
 	}
 	prepared.InputTokenEstimate = estimate
+	if prepared.InputMediaTokenEstimate <= 0 {
+		prepared.InputMediaTokenEstimate = modelcontext.EstimateRenderedMediaTokens(input.Context.RenderedMedia)
+	}
+	effectiveEstimate := estimate
+	var providerUsageEstimate *modelcontext.ProviderUsageInputEstimate
+	if input.ProviderUsageIdentity != nil {
+		providerEstimate, ok := modelcontext.EstimateInputFromProviderUsage(
+			input.Context,
+			*input.ProviderUsageIdentity,
+			input.Policy.ProviderReplayCutoffEventSequence,
+		)
+		if ok {
+			providerUsageEstimate = &providerEstimate
+			effectiveEstimate = providerEstimate.EstimatedInputTokens
+		}
+	}
 	window := modelWindowForRequest(CapabilitiesForClient(client), input.Policy)
 	prepared.InputBudget = InputBudgetAssessment{
-		EstimatedInputTokens: estimate,
-		UsableInputTokens:    window.UsableInputTokens(),
+		LocalInputTokenEstimate: estimate,
+		EstimatedInputTokens:    effectiveEstimate,
+		UsableInputTokens:       window.UsableInputTokens(),
+		ProviderUsageEstimate:   providerUsageEstimate,
 	}
 	return prepared, nil
 }

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -122,6 +122,53 @@ func TestPrepareForSendAssessesSerializedRequestEstimate(t *testing.T) {
 	}
 }
 
+func TestPrepareForSendUsesProviderUsageEstimate(t *testing.T) {
+	identity := modelcontext.ModelRequestIdentity{
+		AgentConfigID:             "config",
+		ConfiguredModelRevisionID: "revision",
+		ProviderRequestIdentity: modelenvelope.ProviderReplayIdentity{
+			ModelProviderConfigID:      "provider-config",
+			RequestedProviderModelSlug: "prepare-test",
+			APIFormat:                  modelprotocol.APIFormatOpenAIResponses,
+			APIVariant:                 modelprotocol.APIVariantDefault,
+		},
+	}
+	bundle := modelcontext.Bundle{
+		InputEventSequence: 3,
+		Messages: []modelcontext.Message{{
+			Role:     modelprotocol.RoleAssistant,
+			Sequence: 2,
+			ProviderUsageAnchor: &modelcontext.ProviderUsageAnchor{
+				Identity:           identity,
+				InputEventSequence: 1,
+				InputTokens:        1_000,
+				OutputTokens:       100,
+			},
+		}},
+	}
+	client := prepareForSendClient{
+		prepared: PreparedRequest{
+			Body:               json.RawMessage(`{"request":true}`),
+			InputTokenEstimate: 2_000,
+		},
+		capabilities: Capabilities{ContextWindowTokens: 10_000},
+	}
+	prepared, err := PrepareForSend(context.Background(), client, PrepareForSendInput{
+		Context:               bundle,
+		Policy:                RequestPolicy{MaxOutputTokens: 100},
+		ErrorSource:           "test_api",
+		ProviderUsageIdentity: &identity,
+	})
+	if err != nil {
+		t.Fatalf("prepare provider-anchored request: %v", err)
+	}
+	if prepared.InputBudget.ProviderUsageEstimate == nil ||
+		prepared.InputBudget.EstimatedInputTokens != 1_100 ||
+		prepared.InputBudget.LocalInputTokenEstimate != 2_000 {
+		t.Fatalf("provider-anchored assessment = %+v", prepared.InputBudget)
+	}
+}
+
 func TestPrepareForSendRejectsEmptyProviderRequest(t *testing.T) {
 	bundle := modelcontext.Bundle{}
 	_, err := PrepareForSend(

--- a/internal/model/route/route.go
+++ b/internal/model/route/route.go
@@ -344,7 +344,11 @@ func (c Client) Prepare(ctx context.Context, input model.PrepareInput) (model.Pr
 	}
 	renderedMedia := c.Protocol.ProjectRenderedMedia(input.Context)
 	inputTokenEstimate := modelcontext.EstimatePreparedRequest(body, renderedMedia)
-	return model.PreparedRequest{Body: body, InputTokenEstimate: inputTokenEstimate}, nil
+	return model.PreparedRequest{
+		Body:                    body,
+		InputTokenEstimate:      inputTokenEstimate,
+		InputMediaTokenEstimate: modelcontext.EstimateRenderedMediaTokens(renderedMedia),
+	}, nil
 }
 
 func (c Client) RespondStream(ctx context.Context, input model.Request) (model.Response, error) {

--- a/internal/modelcontext/budget.go
+++ b/internal/modelcontext/budget.go
@@ -3,7 +3,12 @@ package modelcontext
 import (
 	"encoding/base64"
 	"encoding/json"
+	"math"
 	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/omnara-ai/omnara/internal/modelprotocol"
 )
 
 const (
@@ -42,7 +47,7 @@ func DefaultSafetyMarginTokens(contextTokens int) int {
 // EstimatePreparedRequest replaces inline base64 with the adapter's media-token estimate.
 func EstimatePreparedRequest(body json.RawMessage, media []RenderedMedia) int {
 	projected := preparedRequestWithoutInlineMedia(body, media)
-	return len(projected)/4 + 1 + renderedMediaTokenEstimate(media)
+	return estimateSerializedTextTokens(projected) + EstimateRenderedMediaTokens(media)
 }
 
 func preparedRequestWithoutInlineMedia(body json.RawMessage, media []RenderedMedia) json.RawMessage {
@@ -124,7 +129,7 @@ func replaceEncodedField(object map[string]any, field string, encodedMedia map[s
 	}
 }
 
-func renderedMediaTokenEstimate(media []RenderedMedia) int {
+func EstimateRenderedMediaTokens(media []RenderedMedia) int {
 	estimate := 0
 	for _, item := range media {
 		if item.Representation == MediaRepresentationInlineText {
@@ -139,4 +144,168 @@ func renderedMediaTokenEstimate(media []RenderedMedia) int {
 		}
 	}
 	return estimate
+}
+
+type ProviderUsageInputEstimate struct {
+	AnchorInputEventSequence int64 `json:"anchor_input_event_sequence"`
+	ProviderInputTokens      int   `json:"provider_input_tokens"`
+	ProviderOutputTokens     int   `json:"provider_output_tokens"`
+	NewTailTokens            int   `json:"new_tail_tokens"`
+	EstimatedInputTokens     int   `json:"estimated_input_tokens"`
+}
+
+func EstimateInputFromProviderUsage(
+	bundle Bundle,
+	target ModelRequestIdentity,
+	providerReplayCutoffEventSequence int64,
+) (ProviderUsageInputEstimate, bool) {
+	if !modelRequestIdentityComplete(target) {
+		return ProviderUsageInputEstimate{}, false
+	}
+	for index := len(bundle.Messages) - 1; index >= 0; index-- {
+		message := bundle.Messages[index]
+		if message.Role != modelprotocol.RoleAssistant {
+			continue
+		}
+		anchor := message.ProviderUsageAnchor
+		if anchor == nil || !modelRequestIdentityMatches(anchor.Identity, target) ||
+			anchor.InputEventSequence <= 0 || anchor.InputEventSequence > bundle.InputEventSequence ||
+			anchor.InputTokens <= 0 || anchor.OutputTokens < 0 ||
+			(providerReplayCutoffEventSequence > 0 &&
+				anchor.InputEventSequence < providerReplayCutoffEventSequence) ||
+			!anchorIncludesCheckpoint(bundle.ContextCheckpoint, anchor.InputEventSequence) {
+			return ProviderUsageInputEstimate{}, false
+		}
+		tail := estimateModelVisibleSuffix(bundle, message.Sequence)
+		estimate, ok := checkedTokenSum(anchor.InputTokens, anchor.OutputTokens, tail)
+		if !ok {
+			return ProviderUsageInputEstimate{}, false
+		}
+		return ProviderUsageInputEstimate{
+			AnchorInputEventSequence: anchor.InputEventSequence,
+			ProviderInputTokens:      anchor.InputTokens,
+			ProviderOutputTokens:     anchor.OutputTokens,
+			NewTailTokens:            tail,
+			EstimatedInputTokens:     estimate,
+		}, true
+	}
+	return ProviderUsageInputEstimate{}, false
+}
+
+func modelRequestIdentityComplete(identity ModelRequestIdentity) bool {
+	provider := identity.ProviderRequestIdentity
+	return strings.TrimSpace(identity.AgentConfigID) != "" &&
+		strings.TrimSpace(identity.ConfiguredModelRevisionID) != "" &&
+		strings.TrimSpace(provider.ModelProviderConfigID) != "" &&
+		strings.TrimSpace(provider.RequestedProviderModelSlug) != "" &&
+		strings.TrimSpace(string(provider.APIFormat)) != "" &&
+		strings.TrimSpace(string(provider.APIVariant)) != ""
+}
+
+func modelRequestIdentityMatches(left, right ModelRequestIdentity) bool {
+	return left.AgentConfigID == right.AgentConfigID &&
+		left.ConfiguredModelRevisionID == right.ConfiguredModelRevisionID &&
+		left.ProviderRequestIdentity.Matches(right.ProviderRequestIdentity)
+}
+
+func anchorIncludesCheckpoint(checkpoint *CheckpointRef, inputEventSequence int64) bool {
+	if checkpoint == nil {
+		return true
+	}
+	return checkpoint.EventSequence > 0 && inputEventSequence >= checkpoint.EventSequence
+}
+
+func estimateModelVisibleSuffix(bundle Bundle, afterSequence int64) int {
+	type suffixMessage struct {
+		Role    modelprotocol.MessageRole `json:"role"`
+		Content json.RawMessage           `json:"content"`
+	}
+	type suffixToolResult struct {
+		Name         string          `json:"name"`
+		ContentParts json.RawMessage `json:"content_parts"`
+	}
+	projection := struct {
+		Messages    []suffixMessage    `json:"messages,omitempty"`
+		ToolResults []suffixToolResult `json:"tool_results,omitempty"`
+	}{}
+	for _, message := range bundle.Messages {
+		if message.Sequence > afterSequence {
+			projection.Messages = append(projection.Messages, suffixMessage{
+				Role:    message.Role,
+				Content: message.Content,
+			})
+		}
+	}
+	for _, result := range bundle.ToolResults {
+		if result.ResultEventSequence > afterSequence {
+			projection.ToolResults = append(projection.ToolResults, suffixToolResult{
+				Name:         result.Name,
+				ContentParts: result.ContentParts,
+			})
+		}
+	}
+	body, err := json.Marshal(projection)
+	if err != nil {
+		return 0
+	}
+	estimate := 0
+	if len(projection.Messages) > 0 || len(projection.ToolResults) > 0 {
+		estimate = estimateSerializedTextTokens(body)
+	}
+	for _, rendered := range bundle.RenderedMedia {
+		included := false
+		switch rendered.Occurrence.ownerKind {
+		case mediaOccurrenceOwnerUnknown:
+		case mediaOccurrenceOwnerMessage:
+			included = rendered.Occurrence.ownerIndex >= 0 &&
+				rendered.Occurrence.ownerIndex < len(bundle.Messages) &&
+				bundle.Messages[rendered.Occurrence.ownerIndex].Sequence > afterSequence
+		case mediaOccurrenceOwnerToolResult:
+			included = rendered.Occurrence.ownerIndex >= 0 &&
+				rendered.Occurrence.ownerIndex < len(bundle.ToolResults) &&
+				bundle.ToolResults[rendered.Occurrence.ownerIndex].ResultEventSequence > afterSequence
+		}
+		if !included {
+			continue
+		}
+		if rendered.Representation == MediaRepresentationInlineText {
+			estimate += estimateSerializedTextTokens(rendered.Media.Data)
+		} else {
+			estimate += EstimateRenderedMediaTokens([]RenderedMedia{rendered})
+		}
+	}
+	return estimate
+}
+
+func checkedTokenSum(values ...int) (int, bool) {
+	total := 0
+	for _, value := range values {
+		if value < 0 || total > math.MaxInt-value {
+			return 0, false
+		}
+		total += value
+	}
+	return total, true
+}
+
+func estimateSerializedTextTokens(value []byte) int {
+	denseBytes := 0
+	denseRunes := 0
+	for index := 0; index < len(value); {
+		if value[index] < utf8.RuneSelf {
+			index++
+			continue
+		}
+		r, size := utf8.DecodeRune(value[index:])
+		if unicode.In(r, unicode.Han, unicode.Hangul, unicode.Hiragana, unicode.Katakana) {
+			denseBytes += size
+			denseRunes++
+		}
+		index += size
+	}
+	return ceilDiv(len(value)-denseBytes, 4) + denseRunes
+}
+
+func ceilDiv(value, divisor int) int {
+	return (value + divisor - 1) / divisor
 }

--- a/internal/modelcontext/budget_test.go
+++ b/internal/modelcontext/budget_test.go
@@ -5,6 +5,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"testing"
+
+	"github.com/omnara-ai/omnara/internal/modelenvelope"
+	"github.com/omnara-ai/omnara/internal/modelprotocol"
 )
 
 func budgetFixtureJSON(t testing.TB, value any) json.RawMessage {
@@ -111,8 +114,115 @@ func TestPreparedRequestBudgetRemovesChatFileData(t *testing.T) {
 func TestEstimatePreparedRequestDoesNotInferAbsentMedia(t *testing.T) {
 	body := budgetFixtureJSON(t, map[string]any{"input": "small textual fallback"})
 	withNoRenderedMedia := EstimatePreparedRequest(body, nil)
-	if want := len(body)/4 + 1; withNoRenderedMedia != want {
+	if want := ceilDiv(len(body), 4); withNoRenderedMedia != want {
 		t.Fatalf("estimate = %d, want body-only estimate %d", withNoRenderedMedia, want)
+	}
+}
+
+func TestEstimateSerializedTextTokensAccountsForDenseScripts(t *testing.T) {
+	if got := estimateSerializedTextTokens([]byte("abcd你好世界")); got != 5 {
+		t.Fatalf("mixed text estimate = %d, want 5", got)
+	}
+}
+
+func TestEstimateInputFromProviderUsageAddsOnlyTheNewTail(t *testing.T) {
+	identity := testModelRequestIdentity()
+	bundle := Bundle{
+		InputEventSequence: 7,
+		Messages: []Message{
+			{
+				Role:     modelprotocol.RoleAssistant,
+				Sequence: 4,
+				ProviderUsageAnchor: &ProviderUsageAnchor{
+					Identity:           identity,
+					InputEventSequence: 3,
+					InputTokens:        1_000,
+					OutputTokens:       200,
+				},
+			},
+			{
+				Role:     modelprotocol.RoleUser,
+				Sequence: 5,
+				Content:  json.RawMessage(`[{"type":"text","text":"continue with new work"}]`),
+			},
+		},
+	}
+
+	estimate, ok := EstimateInputFromProviderUsage(bundle, identity, 0)
+	if !ok || estimate.ProviderInputTokens != 1_000 || estimate.ProviderOutputTokens != 200 ||
+		estimate.NewTailTokens <= 0 ||
+		estimate.EstimatedInputTokens != 1_200+estimate.NewTailTokens {
+		t.Fatalf("provider usage estimate = %+v, available=%t", estimate, ok)
+	}
+}
+
+func TestEstimateInputFromProviderUsageRejectsIncompatibleHistory(t *testing.T) {
+	identity := testModelRequestIdentity()
+	newBundle := func() Bundle {
+		return Bundle{
+			InputEventSequence: 7,
+			Messages: []Message{{
+				Role:     modelprotocol.RoleAssistant,
+				Sequence: 5,
+				ProviderUsageAnchor: &ProviderUsageAnchor{
+					Identity:           identity,
+					InputEventSequence: 4,
+					InputTokens:        1_000,
+					OutputTokens:       100,
+				},
+			}},
+		}
+	}
+
+	tests := map[string]func(*Bundle, *ModelRequestIdentity, *int64){
+		"config changed": func(_ *Bundle, target *ModelRequestIdentity, _ *int64) {
+			target.AgentConfigID = "other-config"
+		},
+		"model revision changed": func(_ *Bundle, target *ModelRequestIdentity, _ *int64) {
+			target.ConfiguredModelRevisionID = "other-revision"
+		},
+		"provider config changed": func(_ *Bundle, target *ModelRequestIdentity, _ *int64) {
+			target.ProviderRequestIdentity.ModelProviderConfigID = "other-provider-config"
+		},
+		"checkpoint replaced anchor": func(bundle *Bundle, _ *ModelRequestIdentity, _ *int64) {
+			bundle.ContextCheckpoint = &CheckpointRef{EventSequence: 6}
+		},
+		"replay rejected after anchor": func(_ *Bundle, _ *ModelRequestIdentity, cutoff *int64) {
+			*cutoff = 5
+		},
+		"newer output has no usage": func(bundle *Bundle, _ *ModelRequestIdentity, _ *int64) {
+			bundle.Messages = append(bundle.Messages, Message{Role: modelprotocol.RoleAssistant, Sequence: 6})
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			bundle := newBundle()
+			target := identity
+			var cutoff int64
+			mutate(&bundle, &target, &cutoff)
+			if _, ok := EstimateInputFromProviderUsage(bundle, target, cutoff); ok {
+				t.Fatal("incompatible provider measurement was used")
+			}
+		})
+	}
+
+	bundle := newBundle()
+	bundle.ContextCheckpoint = &CheckpointRef{EventSequence: 4}
+	if _, ok := EstimateInputFromProviderUsage(bundle, identity, 4); !ok {
+		t.Fatal("measurement made at the checkpoint and replay frontier was rejected")
+	}
+}
+
+func testModelRequestIdentity() ModelRequestIdentity {
+	return ModelRequestIdentity{
+		AgentConfigID:             "config",
+		ConfiguredModelRevisionID: "revision",
+		ProviderRequestIdentity: modelenvelope.ProviderReplayIdentity{
+			ModelProviderConfigID:      "provider-config",
+			RequestedProviderModelSlug: "model",
+			APIFormat:                  modelprotocol.APIFormatOpenAIResponses,
+			APIVariant:                 modelprotocol.APIVariantDefault,
+		},
 	}
 }
 

--- a/internal/modelcontext/context.go
+++ b/internal/modelcontext/context.go
@@ -73,6 +73,7 @@ func (b Builder) Build(ctx context.Context, input BuildInput) (Bundle, error) {
 			afterSequence = checkpoint.SummarizedThroughEventSequence
 			checkpointRef = &CheckpointRef{
 				ID:                             checkpoint.ID.String(),
+				EventSequence:                  checkpoint.CheckpointEventSequence,
 				SummarizedThroughEventSequence: checkpoint.SummarizedThroughEventSequence,
 				Summary:                        checkpoint.Summary,
 			}

--- a/internal/modelcontext/sources.go
+++ b/internal/modelcontext/sources.go
@@ -142,13 +142,24 @@ func contextEventsToMessages(records []executionstore.ContextEventRecord) ([]Mes
 		if err != nil {
 			return nil, err
 		}
-		modelCallContextID := ""
-		if event.ModelCallContextID != storage.NilID {
-			modelCallContextID = event.ModelCallContextID.String()
-		}
-		modelProviderConfigID := ""
-		if event.ModelProviderConfigID != storage.NilID {
-			modelProviderConfigID = event.ModelProviderConfigID.String()
+		modelCallContextID := idString(event.ModelCallContextID)
+		var usageAnchor *ProviderUsageAnchor
+		if modelCallContextID != "" && event.ModelStopReason != modelenvelope.StopReasonMaxTokens {
+			usageAnchor = &ProviderUsageAnchor{
+				Identity: ModelRequestIdentity{
+					AgentConfigID:             idString(event.AgentConfigID),
+					ConfiguredModelRevisionID: idString(event.ConfiguredModelRevisionID),
+					ProviderRequestIdentity: modelenvelope.ProviderReplayIdentity{
+						ModelProviderConfigID:      idString(event.ModelProviderConfigID),
+						RequestedProviderModelSlug: event.RequestedModelSlug,
+						APIFormat:                  event.APIFormat,
+						APIVariant:                 event.APIVariant,
+					},
+				},
+				InputEventSequence: event.ModelCallInputSequence,
+				InputTokens:        event.ProviderInputTokens,
+				OutputTokens:       event.ProviderOutputTokens,
+			}
 		}
 		out = append(
 			out,
@@ -161,15 +172,23 @@ func contextEventsToMessages(records []executionstore.ContextEventRecord) ([]Mes
 				Content:            event.ContentParts,
 				ProviderReplay:     event.ProviderReplay,
 				ProviderReplaySource: modelenvelope.ProviderReplayIdentity{
-					ModelProviderConfigID:      modelProviderConfigID,
+					ModelProviderConfigID:      idString(event.ModelProviderConfigID),
 					RequestedProviderModelSlug: event.RequestedModelSlug,
 					APIFormat:                  event.APIFormat,
 					APIVariant:                 event.APIVariant,
 				},
+				ProviderUsageAnchor: usageAnchor,
 			},
 		)
 	}
 	return out, nil
+}
+
+func idString(id storage.ID) string {
+	if id == storage.NilID {
+		return ""
+	}
+	return id.String()
 }
 
 func contextEventRole(event executionstore.ContextEventRecord) (modelprotocol.MessageRole, error) {

--- a/internal/modelcontext/types.go
+++ b/internal/modelcontext/types.go
@@ -89,6 +89,20 @@ type Message struct {
 	Content              json.RawMessage                      `json:"content"`
 	ProviderReplay       json.RawMessage                      `json:"-"`
 	ProviderReplaySource modelenvelope.ProviderReplayIdentity `json:"-"`
+	ProviderUsageAnchor  *ProviderUsageAnchor                 `json:"-"`
+}
+
+type ModelRequestIdentity struct {
+	AgentConfigID             string
+	ConfiguredModelRevisionID string
+	ProviderRequestIdentity   modelenvelope.ProviderReplayIdentity
+}
+
+type ProviderUsageAnchor struct {
+	Identity           ModelRequestIdentity
+	InputEventSequence int64
+	InputTokens        int
+	OutputTokens       int
 }
 
 type ToolSpec struct {
@@ -130,6 +144,7 @@ type MachinePoolRef struct {
 
 type CheckpointRef struct {
 	ID                             string `json:"-"`
+	EventSequence                  int64  `json:"-"`
 	SummarizedThroughEventSequence int64  `json:"summarized_through_event_sequence"`
 	Summary                        string `json:"summary"`
 }

--- a/internal/modelprovider/resolver.go
+++ b/internal/modelprovider/resolver.go
@@ -201,9 +201,7 @@ func (r Resolver) Resolve(ctx context.Context, selection model.Selection) (model
 			err,
 		)
 	}
-	resolved := model.ResolvedClient{
-		ConfiguredModelRevisionID: revision.ID.String(),
-	}
+	resolved := model.ResolvedClient{ConfiguredModelRevisionID: revision.ID.String()}
 	switch providerConfig.APIFormat {
 	case modelprotocol.APIFormatOpenAIResponses:
 		resolved.Client = openairesponses.Client{
@@ -217,7 +215,6 @@ func (r Resolver) Resolve(ctx context.Context, selection model.Selection) (model
 			APIVariant:            providerConfig.APIVariant,
 			APIVariantOptions:     revision.APIVariantOptions,
 		}
-		return resolved, nil
 	case modelprotocol.APIFormatOpenAIChatCompletions:
 		resolved.Client = openaichatcompletions.Client{
 			ModelProviderConfigID: providerConfig.ID.String(),
@@ -230,7 +227,6 @@ func (r Resolver) Resolve(ctx context.Context, selection model.Selection) (model
 			APIVariant:            providerConfig.APIVariant,
 			APIVariantOptions:     revision.APIVariantOptions,
 		}
-		return resolved, nil
 	case modelprotocol.APIFormatAnthropicMessages:
 		resolved.Client = anthropicmessages.Client{
 			ModelProviderConfigID: providerConfig.ID.String(),
@@ -243,7 +239,6 @@ func (r Resolver) Resolve(ctx context.Context, selection model.Selection) (model
 			APIVariant:            providerConfig.APIVariant,
 			APIVariantOptions:     revision.APIVariantOptions,
 		}
-		return resolved, nil
 	default:
 		return model.ResolvedClient{}, resolverError(
 			model.ErrorKindInvalidRequest,
@@ -252,6 +247,11 @@ func (r Resolver) Resolve(ctx context.Context, selection model.Selection) (model
 			fmt.Errorf("unsupported api_format %q", providerConfig.APIFormat),
 		)
 	}
+	resolved.ProviderRequestIdentity = model.ProviderReplayIdentityForClient(
+		providerConfig.ID.String(),
+		resolved.Client,
+	)
+	return resolved, nil
 }
 
 func resolverError(kind model.ErrorKind, code, message string, cause error) error {

--- a/internal/storage/executionstore/context_events_store.go
+++ b/internal/storage/executionstore/context_events_store.go
@@ -8,28 +8,35 @@ import (
 	"time"
 
 	"github.com/omnara-ai/omnara/internal/events"
+	"github.com/omnara-ai/omnara/internal/modelenvelope"
 	"github.com/omnara-ai/omnara/internal/modelprotocol"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
 )
 
 type ContextEventRecord struct {
-	ID                    ID
-	SourceEventID         ID
-	AgentInputID          ID
-	ProjectID             ID
-	AgentID               ID
-	TurnID                ID
-	ModelOutputID         ID
-	ModelCallContextID    ID
-	ModelProviderConfigID ID
-	Role                  modelprotocol.MessageRole
-	Sequence              int64
-	ContentParts          json.RawMessage
-	RequestedModelSlug    string
-	APIFormat             modelprotocol.APIFormat
-	APIVariant            modelprotocol.APIVariant
-	ProviderReplay        json.RawMessage
-	CreatedAt             time.Time
+	ID                        ID
+	SourceEventID             ID
+	AgentInputID              ID
+	ProjectID                 ID
+	AgentID                   ID
+	TurnID                    ID
+	ModelOutputID             ID
+	ModelCallContextID        ID
+	AgentConfigID             ID
+	ConfiguredModelRevisionID ID
+	ModelCallInputSequence    int64
+	ModelProviderConfigID     ID
+	Role                      modelprotocol.MessageRole
+	Sequence                  int64
+	ContentParts              json.RawMessage
+	RequestedModelSlug        string
+	APIFormat                 modelprotocol.APIFormat
+	APIVariant                modelprotocol.APIVariant
+	ProviderInputTokens       int
+	ProviderOutputTokens      int
+	ModelStopReason           modelenvelope.StopReason
+	ProviderReplay            json.RawMessage
+	CreatedAt                 time.Time
 }
 
 func (s *Store) ListContextEvents(
@@ -64,18 +71,24 @@ func (s *Store) ListContextEvents(
 	out := make([]ContextEventRecord, 0, len(rows))
 	for _, row := range rows {
 		record := ContextEventRecord{
-			SourceEventID:         row.ID,
-			AgentInputID:          idFromSQLCPtr(row.AgentInputID),
-			Sequence:              row.Sequence,
-			CreatedAt:             row.CreatedAt,
-			ContentParts:          row.ContentParts,
-			ModelOutputID:         idFromSQLCPtr(row.ModelOutputID),
-			ModelCallContextID:    idFromSQLCPtr(row.ModelCallContextID),
-			ModelProviderConfigID: idFromSQLCPtr(row.ModelProviderConfigID),
-			RequestedModelSlug:    row.RequestedProviderModelSlug,
-			APIFormat:             modelprotocol.APIFormat(row.ApiFormat),
-			APIVariant:            modelprotocol.APIVariant(row.ApiVariant),
-			ProviderReplay:        rawMessageFromSQLCPtr(row.ProviderReplay),
+			SourceEventID:             row.ID,
+			AgentInputID:              idFromSQLCPtr(row.AgentInputID),
+			Sequence:                  row.Sequence,
+			CreatedAt:                 row.CreatedAt,
+			ContentParts:              row.ContentParts,
+			ModelOutputID:             idFromSQLCPtr(row.ModelOutputID),
+			ModelCallContextID:        idFromSQLCPtr(row.ModelCallContextID),
+			AgentConfigID:             idFromSQLCPtr(row.AgentConfigID),
+			ConfiguredModelRevisionID: idFromSQLCPtr(row.ConfiguredModelRevisionID),
+			ModelCallInputSequence:    int64FromSQLCPtr(row.InputEventSequence),
+			ModelProviderConfigID:     idFromSQLCPtr(row.ModelProviderConfigID),
+			RequestedModelSlug:        row.RequestedProviderModelSlug,
+			APIFormat:                 modelprotocol.APIFormat(row.ApiFormat),
+			APIVariant:                modelprotocol.APIVariant(row.ApiVariant),
+			ProviderInputTokens:       intFromSQLCPtr(row.InputTokensTotal),
+			ProviderOutputTokens:      intFromSQLCPtr(row.OutputTokensTotal),
+			ModelStopReason:           modelenvelope.StopReason(row.ModelStopReason),
+			ProviderReplay:            rawMessageFromSQLCPtr(row.ProviderReplay),
 		}
 		record.ID = record.SourceEventID
 		record.ProjectID = projectID

--- a/internal/storage/executionstore/db_values.go
+++ b/internal/storage/executionstore/db_values.go
@@ -26,6 +26,13 @@ func idFromSQLCPtr(value *ID) ID {
 	return *value
 }
 
+func int64FromSQLCPtr(value *int64) int64 {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
 func nullableTimeToZero(value *time.Time) time.Time {
 	if value == nil {
 		return time.Time{}

--- a/internal/storage/internal/dbsqlc/agent_turns.sql.go
+++ b/internal/storage/internal/dbsqlc/agent_turns.sql.go
@@ -393,10 +393,16 @@ SELECT event.id,
        event.event_kind,
        event.model_output_id,
        output.model_call_context_id,
+       context.agent_config_id,
+       context.configured_model_revision_id,
+       context.input_event_sequence,
        revision.model_provider_config_id,
        coalesce(revision.provider_model_slug, '') AS requested_provider_model_slug,
        coalesce(context.api_format, '') AS api_format,
        coalesce(context.api_variant, '') AS api_variant,
+       context.input_tokens_total,
+       context.output_tokens_total,
+       coalesce(output.stop_reason, '') AS model_stop_reason,
        output.provider_replay,
        CASE
          WHEN event.event_kind = 'agent_input' AND input.input_kind = 'config_change' AND event.sequence > 1 THEN
@@ -453,9 +459,12 @@ WHERE scoped_agent.project_id = $1
     )
   )
 GROUP BY event.id, event.sequence, event.created_at, event.event_kind,
-  event.model_output_id, output.model_call_context_id, revision.model_provider_config_id,
+  event.model_output_id, output.model_call_context_id, context.agent_config_id,
+  context.configured_model_revision_id, context.input_event_sequence,
+  revision.model_provider_config_id,
   revision.provider_model_slug, context.api_format, context.api_variant,
-  output.provider_replay, input.input_kind
+  context.input_tokens_total, context.output_tokens_total,
+  output.stop_reason, output.provider_replay, input.input_kind
 ORDER BY event.sequence ASC
 LIMIT $5
 `
@@ -476,10 +485,16 @@ type ListContextEventsRow struct {
 	EventKind                  string
 	ModelOutputID              *uuid.UUID
 	ModelCallContextID         *uuid.UUID
+	AgentConfigID              *uuid.UUID
+	ConfiguredModelRevisionID  *uuid.UUID
+	InputEventSequence         *int64
 	ModelProviderConfigID      *uuid.UUID
 	RequestedProviderModelSlug string
 	ApiFormat                  string
 	ApiVariant                 string
+	InputTokensTotal           *int32
+	OutputTokensTotal          *int32
+	ModelStopReason            string
 	ProviderReplay             *json.RawMessage
 	ContentParts               json.RawMessage
 }
@@ -507,10 +522,16 @@ func (q *Queries) ListContextEvents(ctx context.Context, arg ListContextEventsPa
 			&i.EventKind,
 			&i.ModelOutputID,
 			&i.ModelCallContextID,
+			&i.AgentConfigID,
+			&i.ConfiguredModelRevisionID,
+			&i.InputEventSequence,
 			&i.ModelProviderConfigID,
 			&i.RequestedProviderModelSlug,
 			&i.ApiFormat,
 			&i.ApiVariant,
+			&i.InputTokensTotal,
+			&i.OutputTokensTotal,
+			&i.ModelStopReason,
 			&i.ProviderReplay,
 			&i.ContentParts,
 		); err != nil {

--- a/internal/storage/queries/agent_turns.sql
+++ b/internal/storage/queries/agent_turns.sql
@@ -195,10 +195,16 @@ SELECT event.id,
        event.event_kind,
        event.model_output_id,
        output.model_call_context_id,
+       context.agent_config_id,
+       context.configured_model_revision_id,
+       context.input_event_sequence,
        revision.model_provider_config_id,
        coalesce(revision.provider_model_slug, '') AS requested_provider_model_slug,
        coalesce(context.api_format, '') AS api_format,
        coalesce(context.api_variant, '') AS api_variant,
+       context.input_tokens_total,
+       context.output_tokens_total,
+       coalesce(output.stop_reason, '') AS model_stop_reason,
        output.provider_replay,
        CASE
          WHEN event.event_kind = 'agent_input' AND input.input_kind = 'config_change' AND event.sequence > 1 THEN
@@ -255,8 +261,11 @@ WHERE scoped_agent.project_id = sqlc.arg(project_id)
     )
   )
 GROUP BY event.id, event.sequence, event.created_at, event.event_kind,
-  event.model_output_id, output.model_call_context_id, revision.model_provider_config_id,
+  event.model_output_id, output.model_call_context_id, context.agent_config_id,
+  context.configured_model_revision_id, context.input_event_sequence,
+  revision.model_provider_config_id,
   revision.provider_model_slug, context.api_format, context.api_variant,
-  output.provider_replay, input.input_kind
+  context.input_tokens_total, context.output_tokens_total,
+  output.stop_reason, output.provider_replay, input.input_kind
 ORDER BY event.sequence ASC
 LIMIT sqlc.arg(page_limit);

--- a/internal/testutil/modelresolver/resolver.go
+++ b/internal/testutil/modelresolver/resolver.go
@@ -56,6 +56,10 @@ func (r LiveGrant) Resolve(
 	return model.ResolvedClient{
 		Client:                    r.Client,
 		ConfiguredModelRevisionID: revision.ID.String(),
+		ProviderRequestIdentity: model.ProviderReplayIdentityForClient(
+			revision.ModelProviderConfigID.String(),
+			r.Client,
+		),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- estimate normal-request context from the latest compatible provider-reported input and output total plus only the model-visible tail added afterward
- fall back to estimating the complete prepared request when no safe provider measurement exists, and keep rewritten compaction candidates local-only
- improve the fallback estimate for dense text and provider-specific image accounting
- preserve the existing provider-overflow compact-and-retry path and expose both local and provider-anchored admission diagnostics

## Scope

This reuses usage already persisted with successful model calls. It adds no migration, token-estimator state, prompt-cache behavior, or provider token-count request. Measurements are rejected across incompatible agent configs, model revisions, provider request identities, checkpoints, and replay cutoffs.

## Verification

- `make verify` with the repository-supported Node 24 runtime
- `make test-integration-runtime`
- focused model-context, model, logging, and resolver tests
- live OpenAI Responses, OpenAI Chat Completions, OpenRouter, and Anthropic model-turn, process-tool, compaction-recall, and checkpoint tests
