### PR TITLE
fix: deliver tool result images to chat completions models

### DIFF
--- a/internal/model/openaichatcompletions/media.go
+++ b/internal/model/openaichatcompletions/media.go
@@ -20,7 +20,7 @@ func (p protocol) ProjectRenderedMedia(bundle modelcontext.Bundle) []modelcontex
 		)
 	}
 	for _, occurrence := range modelcontext.ResolvedMediaOccurrences(bundle) {
-		if occurrence.MessageRole != modelprotocol.RoleUser ||
+		if (occurrence.MessageRole != modelprotocol.RoleUser && !occurrence.IsToolResult()) ||
 			occurrence.Media.Kind != modelcontext.AttachmentKindImage {
 			continue
 		}
@@ -113,8 +113,43 @@ func chatImagePart(resolved modelcontext.ResolvedMedia) (map[string]any, bool) {
 	return map[string]any{"type": "image_url", "image_url": map[string]string{"url": dataURL}}, true
 }
 
-func toolResultOutput(result modelcontext.ToolResultRef) string {
-	return textContentFromParts(result.ContentParts, nil)
+func toolResultOutput(
+	result modelcontext.ToolResultRef,
+	media map[string]modelcontext.ResolvedMedia,
+) string {
+	return textContentFromParts(result.ContentParts, media)
+}
+
+func toolResultMediaContent(
+	result modelcontext.ToolResultRef,
+	media map[string]modelcontext.ResolvedMedia,
+) []any {
+	var parts []map[string]json.RawMessage
+	if err := json.Unmarshal(result.ContentParts, &parts); err != nil {
+		return nil
+	}
+	var blocks []any
+	for _, part := range parts {
+		if jsonFieldText(part["type"]) != "media_ref" {
+			continue
+		}
+		artifactID := jsonFieldText(part["artifact_id"])
+		resolved, ok := media[artifactID]
+		if !ok {
+			continue
+		}
+		block, ok := chatImagePart(resolved)
+		if !ok {
+			continue
+		}
+		blocks = append(blocks, map[string]any{
+			"type": "text",
+			"text": "Attachment returned by tool " + result.Name + ". artifact_id: " +
+				modelcontext.ArtifactPublicID(artifactID),
+		})
+		blocks = append(blocks, block)
+	}
+	return blocks
 }
 
 func textContentFromParts(

--- a/internal/model/openaichatcompletions/media.go
+++ b/internal/model/openaichatcompletions/media.go
@@ -144,8 +144,8 @@ func toolResultMediaContent(
 		}
 		blocks = append(blocks, map[string]any{
 			"type": "text",
-			"text": "Attachment returned by tool " + result.Name + ". artifact_id: " +
-				modelcontext.ArtifactPublicID(artifactID),
+			"text": "Attachment returned by tool " + result.Name + ". tool_call_id: " +
+				result.ProviderCallID + ". artifact_id: " + modelcontext.ArtifactPublicID(artifactID),
 		})
 		blocks = append(blocks, block)
 	}

--- a/internal/model/openaichatcompletions/media_test.go
+++ b/internal/model/openaichatcompletions/media_test.go
@@ -219,6 +219,7 @@ func TestPrepareAddsToolResultImageAfterAllToolMessages(t *testing.T) {
 	}
 	if len(content) != 2 || content[0].Type != "text" || content[1].Type != "image_url" ||
 		!strings.Contains(content[0].Text, "screenshot") ||
+		!strings.Contains(content[0].Text, "tool_call_id: call_image") ||
 		!strings.Contains(content[0].Text, mediaTestPublicID(mediaTestImageID)) ||
 		content[1].ImageURL.URL != "data:image/png;base64,"+mediaTestImageData {
 		t.Fatalf("unexpected tool-result image content: %s", payload.Messages[4].Content)

--- a/internal/model/openaichatcompletions/media_test.go
+++ b/internal/model/openaichatcompletions/media_test.go
@@ -112,7 +112,24 @@ func TestPrepareKeepsAssistantMediaReferenceWhenSwitchingFormats(t *testing.T) {
 	}
 }
 
-func TestToolResultPreservesResolvedImageAsTextualReference(t *testing.T) {
+func TestProjectRenderedMediaIncludesToolResultImages(t *testing.T) {
+	client := Client{ProviderModelSlug: "gpt-test"}
+	rendered := client.ProjectRenderedMedia(modelcontext.Bundle{
+		ToolResults: []modelcontext.ToolResultRef{{
+			Name:                "inspect_image",
+			SourceEventSequence: 1,
+			ContentParts: json.RawMessage(
+				`[{"type":"media_ref","artifact_id":"` + mediaTestImageID + `"}]`,
+			),
+		}},
+		ResolvedMedia: mediaTestResolved(),
+	})
+	if len(rendered) != 1 || rendered[0].Media.ArtifactID != mediaTestImageID {
+		t.Fatalf("rendered media = %+v, want tool-result image", rendered)
+	}
+}
+
+func TestToolResultOutputOmitsResolvedImageFromText(t *testing.T) {
 	content := json.RawMessage(`[
 		{"type":"text","text":"before image"},
 		{"type":"media_ref","artifact_id":"` + mediaTestImageID + `"},
@@ -121,13 +138,90 @@ func TestToolResultPreservesResolvedImageAsTextualReference(t *testing.T) {
 	got := toolResultOutput(modelcontext.ToolResultRef{
 		Name:         "inspect_image",
 		ContentParts: content,
-	})
-	if !strings.Contains(got, "before image") || !strings.Contains(got, mediaTestPublicID(mediaTestImageID)) ||
-		!strings.Contains(got, "after image") {
+	}, mediaTestResolved())
+	if !strings.Contains(got, "before image") || !strings.Contains(got, "after image") {
 		t.Fatalf("resolved image tool result lost content: %q", got)
 	}
-	if strings.Contains(got, mediaTestImageData) {
-		t.Fatalf("text-only tool result unexpectedly inlined image bytes: %q", got)
+	if strings.Contains(got, mediaTestPublicID(mediaTestImageID)) || strings.Contains(got, mediaTestImageData) {
+		t.Fatalf("resolved image leaked into text-only tool result: %q", got)
+	}
+}
+
+func TestPrepareAddsToolResultImageAfterAllToolMessages(t *testing.T) {
+	client := Client{
+		EndpointPath:      testEndpointPath,
+		ProviderModelSlug: "gpt-test",
+		APIVariant:        modelprotocol.APIVariantOpenRouter,
+	}
+	prepared, err := client.Prepare(context.Background(), model.PrepareInput{
+		Context: modelcontext.Bundle{
+			Messages: []modelcontext.Message{
+				{Sequence: 1, Role: modelprotocol.RoleUser, Content: json.RawMessage(`[{"type":"text","text":"capture"}]`)},
+				messageAtSequence(assistantToolCallMessage("mcc_1", "tcl_text", "tcl_image"), 2),
+			},
+			ToolResults: []modelcontext.ToolResultRef{
+				{
+					ToolCallID:         "tcl_text",
+					ModelCallContextID: "mcc_1",
+					ProviderCallID:     "call_text",
+					Name:               "read_status",
+					Input:              json.RawMessage(`{}`),
+					ContentParts:       json.RawMessage(`[{"type":"text","text":"ready"}]`),
+				},
+				{
+					ToolCallID:         "tcl_image",
+					ModelCallContextID: "mcc_1",
+					ProviderCallID:     "call_image",
+					Name:               "screenshot",
+					Input:              json.RawMessage(`{}`),
+					ContentParts: json.RawMessage(`[
+						{"type":"structured_data","value":{"outcome":"succeeded"}},
+						{"type":"media_ref","artifact_id":"` + mediaTestImageID + `"}
+					]`),
+				},
+			},
+			ResolvedMedia: mediaTestResolved(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	var payload struct {
+		Messages []struct {
+			Role       string          `json:"role"`
+			Content    json.RawMessage `json:"content"`
+			ToolCallID string          `json:"tool_call_id"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(prepared.Body, &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if len(payload.Messages) != 5 ||
+		payload.Messages[2].Role != string(chatRoleTool) ||
+		payload.Messages[2].ToolCallID != "call_text" ||
+		payload.Messages[3].Role != string(chatRoleTool) ||
+		payload.Messages[3].ToolCallID != "call_image" ||
+		payload.Messages[4].Role != string(chatRoleUser) {
+		t.Fatalf("tool-result image message ordering is wrong: %s", prepared.Body)
+	}
+	if string(payload.Messages[3].Content) != `"{\"outcome\":\"succeeded\"}"` {
+		t.Fatalf("image tool result text = %s, want succeeded outcome", payload.Messages[3].Content)
+	}
+	var content []struct {
+		Type     string `json:"type"`
+		Text     string `json:"text"`
+		ImageURL struct {
+			URL string `json:"url"`
+		} `json:"image_url"`
+	}
+	if err := json.Unmarshal(payload.Messages[4].Content, &content); err != nil {
+		t.Fatalf("decode image message: %v", err)
+	}
+	if len(content) != 2 || content[0].Type != "text" || content[1].Type != "image_url" ||
+		!strings.Contains(content[0].Text, "screenshot") ||
+		!strings.Contains(content[0].Text, mediaTestPublicID(mediaTestImageID)) ||
+		content[1].ImageURL.URL != "data:image/png;base64,"+mediaTestImageData {
+		t.Fatalf("unexpected tool-result image content: %s", payload.Messages[4].Content)
 	}
 }
 

--- a/internal/model/openaichatcompletions/request.go
+++ b/internal/model/openaichatcompletions/request.go
@@ -218,6 +218,7 @@ func buildMessages(
 				entry.Message,
 				entry.AssistantContent,
 				entry.ToolResults,
+				bundle.ResolvedMedia,
 				replayIdentity,
 				policy,
 			)
@@ -297,12 +298,13 @@ func assistantMessagesForEntry(
 	source modelcontext.Message,
 	content []modelcontext.AssistantContentEntry,
 	group []modelcontext.ToolResultRef,
+	media map[string]modelcontext.ResolvedMedia,
 	replayIdentity modelenvelope.ProviderReplayIdentity,
 	policy model.RequestPolicy,
 ) ([]chatMessage, error) {
 	if policy.AllowsProviderReplay(source.Sequence) {
 		if replay, ok := completeChatReplay(source, content, replayIdentity); ok {
-			return appendToolResultMessages([]chatMessage{replay}, group), nil
+			return appendToolResultMessages([]chatMessage{replay}, group, media), nil
 		}
 	}
 	contentParts := make([]json.RawMessage, 0, len(content))
@@ -338,19 +340,25 @@ func assistantMessagesForEntry(
 	if assistant.Content == "" && len(assistant.ToolCalls) == 0 {
 		return nil, nil
 	}
-	return appendToolResultMessages([]chatMessage{assistant}, group), nil
+	return appendToolResultMessages([]chatMessage{assistant}, group, media), nil
 }
 
 func appendToolResultMessages(
 	messages []chatMessage,
 	results []modelcontext.ToolResultRef,
+	media map[string]modelcontext.ResolvedMedia,
 ) []chatMessage {
+	var mediaContent []any
 	for _, result := range results {
 		messages = append(messages, chatMessage{
 			Role:       chatRoleTool,
 			ToolCallID: result.ProviderCallID,
-			Content:    toolResultOutput(result),
+			Content:    toolResultOutput(result, media),
 		})
+		mediaContent = append(mediaContent, toolResultMediaContent(result, media)...)
+	}
+	if len(mediaContent) > 0 {
+		messages = append(messages, chatMessage{Role: chatRoleUser, Content: mediaContent})
 	}
 	return messages
 }


### PR DESCRIPTION
- Include custom-tool result images in Chat Completions media projection so selected artifacts remain available to the model.
- Keep all required `role: tool` messages contiguous, then attach resolved images in a follow-up multimodal user message with tool and artifact provenance.
- Preserve the existing textual fallback for omitted or unresolved media while avoiding duplicate artifact references for images that are rendered.
- Closes #447.