### PR TITLE
fix: normalize legacy OMNARA_API_URL environment overrides

### DIFF
--- a/internal/omnarad/daemon_config.go
+++ b/internal/omnarad/daemon_config.go
@@ -144,7 +144,7 @@ func applyDaemonEnvironment(config *daemonConfig) (bool, error) {
 		if err != nil {
 			return false, fmt.Errorf("OMNARA_API_URL: %w", err)
 		}
-		config.APIURL = apiURL
+		config.APIURL = migrateLegacyAPIURL(apiURL)
 	}
 	if token := os.Getenv("OMNARA_MACHINE_TOKEN"); token != "" {
 		config.MachineToken = token

--- a/internal/omnarad/daemon_config_test.go
+++ b/internal/omnarad/daemon_config_test.go
@@ -606,7 +606,7 @@ func TestLoadRuntimeConfigAppliesTemporaryEnvironment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load runtime config: %v", err)
 	}
-	if config.APIURL != "https://other.example.com" || config.MachineToken != "environment-token" ||
+	if config.APIURL != "https://other.example.com/api/v1" || config.MachineToken != "environment-token" ||
 		config.DaemonVersion != version ||
 		config.ExpectedInstallationID != "inst-stored" || config.ExpectedMachineID != "mch-stored" ||
 		config.RunnerPath != "/environment/bin" {


### PR DESCRIPTION
omnarad 0.1.14 (#428) moved the daemon routes under an `api_url` that carries the `/api/v1` mount and migrates legacy origins in `loadDaemonConfig`, but the `OMNARA_API_URL` environment override in `applyDaemonEnvironment` was left un-migrated. Managed machines apply that override on every start, so sandboxes provisioned with `OMNARA_API_URL=https://app.omnara.com` posted to `https://app.omnara.com/daemon/bootstrap` after self-updating, got a 404 from the edge, and retried until runtime protection deleted them. 22 pre-deploy sandboxes are currently asleep with that env and will follow on their next few minutes of awake time unless this is on the stable channel first.

Apply `migrateLegacyAPIURL` to the environment override; update the existing temporary-environment test for the normalized value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
