### PR TITLE
docs: fix README CLI heading markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ open https://app.omnara.com/projects/[$PROJECT_ID]/agents/[$AGENT_ID]
   - <ins><strong>Queryable state</strong></ins>. Self-hosted deployments can
     query agent history directly in Postgres for analytics, evals, prompt
     analysis, and training datasets.
-- <ins><string>CLI and SDK</strong></ins>. Use Omnara programmatically via the CLI, Typescript CLI, or REST API.
+- <ins><strong>CLI and SDK</strong></ins>. Use Omnara programmatically via the CLI, Typescript CLI, or REST API.
 
 ## Get started
 


### PR DESCRIPTION
## Summary

- The Features list used `<ins><string>CLI and SDK</strong>` instead of `<ins><strong>`.
- Matches the other bullets so the heading renders as strong text.

## Test plan

- [ ] Diff is one character in `README.md`
- [ ] Rendered README shows **CLI and SDK** like the other feature labels
