### PR TITLE
docs: surface self-hosting pages in the Mintlify nav

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -79,6 +79,14 @@
             ]
           },
           {
+            "group": "Self-hosting",
+            "pages": [
+              "self-hosting/deployment",
+              "self-hosting/configuration",
+              "self-hosting/architecture"
+            ]
+          },
+          {
             "group": "Agents",
             "pages": [
               "agents/overview",


### PR DESCRIPTION
## Summary

- Add a Self-hosting group to `docs/docs.json`.
- Pages already exist: deployment, configuration, architecture (README already links them).

## Test plan

- [ ] `python -m json.tool docs/docs.json` succeeds
- [ ] Mintlify nav shows Self-hosting after Get started
- [ ] `/self-hosting/deployment` still resolves
