### PR TITLE
docs: point CONTRIBUTING local setup at a real README heading

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thanks for helping improve Omnara. Bug reports, documentation fixes, feature
 ideas, and code contributions are welcome.
 
-Follow the README [Quickstart](README.md#quickstart) for local setup. Report
+Follow the README [Get started](README.md#get-started) section for local setup. Report
 vulnerabilities through [SECURITY.md](SECURITY.md), not a public issue.
 
 ## Pull requests


### PR DESCRIPTION
## Summary
- CONTRIBUTING.md linked to `README.md#quickstart`, which is not a heading in README.md, so GitHub 404s the anchor.
- Point new contributors at `README.md#get-started` (local setup / self-host).

## Test plan
- [ ] Click the CONTRIBUTING local-setup link on GitHub and land on Get started.
- [ ] Confirm `#development` still works for the later Development section link.
