### PR TITLE
feat: support sending artifacts to Slack

### DIFF
--- a/docs/tools/built-in.mdx
+++ b/docs/tools/built-in.mdx
@@ -168,7 +168,7 @@ Use `upload_artifact` to make a regular file on an attached machine available fo
 
 Files must be non-empty and may be up to 10 MiB. The upload process has a 30-second execution timeout.
 
-On success, the artifact appears in the conversation and the durable tool result contains its public `artifact_id` and a `media_ref` that clients can use to display or download it. The artifact's contents are not added to later model context or delivered through external integrations.
+On success, the artifact appears in the conversation and the durable tool result contains its public `artifact_id` and a `media_ref` that clients can use to display or download it. The artifact's contents are not added to later model context. To deliver one through an external integration, pass its `artifact_id` to `send_integration_message`.
 
 ### `download_artifact`
 
@@ -180,7 +180,7 @@ Quick transfers return their terminal process result. If a transfer is still run
 
 ### `send_integration_message`
 
-Sends a message to the agent's current [integration target](/integrations/slack#how-slack-conversations-map-to-agents), such as a Slack thread or DM. Requires `text`. For agents reached through an integration, only messages sent with this tool are visible there; ordinary model output remains in Omnara. This tool supports only `always_allow`.
+Sends a message to the agent's current [integration target](/integrations/slack#how-slack-conversations-map-to-agents), such as a Slack thread or DM. Requires `text`; pass `artifact_id` to attach one artifact owned by the agent. For agents reached through an integration, only messages sent with this tool are visible there; ordinary model output remains in Omnara. This tool supports only `always_allow`.
 
 ### `set_integration_target`
 

--- a/docs/tools/built-in.mdx
+++ b/docs/tools/built-in.mdx
@@ -168,7 +168,7 @@ Use `upload_artifact` to make a regular file on an attached machine available fo
 
 Files must be non-empty and may be up to 10 MiB. The upload process has a 30-second execution timeout.
 
-On success, the artifact appears in the conversation and the durable tool result contains its public `artifact_id` and a `media_ref` that clients can use to display or download it. The artifact's contents are not added to later model context. To deliver one through an external integration, pass its `artifact_id` to `send_integration_message`.
+On success, the artifact appears in the conversation and the durable tool result contains its public `artifact_id` and a `media_ref` that clients can use to display or download it. The artifact's contents are not added to later model context. To deliver one or more through an external integration, pass their IDs in `artifact_ids` to `send_integration_message`.
 
 ### `download_artifact`
 
@@ -180,7 +180,7 @@ Quick transfers return their terminal process result. If a transfer is still run
 
 ### `send_integration_message`
 
-Sends a message to the agent's current [integration target](/integrations/slack#how-slack-conversations-map-to-agents), such as a Slack thread or DM. Requires `text`; pass `artifact_id` to attach one artifact owned by the agent. For agents reached through an integration, only messages sent with this tool are visible there; ordinary model output remains in Omnara. This tool supports only `always_allow`.
+Sends a message to the agent's current [integration target](/integrations/slack#how-slack-conversations-map-to-agents), such as a Slack thread or DM. Requires `text`; pass `artifact_ids` to attach artifacts owned by the agent. For agents reached through an integration, only messages sent with this tool are visible there; ordinary model output remains in Omnara. This tool supports only `always_allow`.
 
 ### `set_integration_target`
 

--- a/internal/harness/tools/integration_requests.go
+++ b/internal/harness/tools/integration_requests.go
@@ -13,8 +13,8 @@ import (
 var integrationTargetRefPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*-[a-z2-9]{4}$`)
 
 type integrationMessageRequest struct {
-	Text       string `json:"text"`
-	ArtifactID string `json:"artifact_id,omitempty"`
+	Text        string   `json:"text"`
+	ArtifactIDs []string `json:"artifact_ids,omitempty"`
 }
 
 type integrationTargetRequest struct {
@@ -29,9 +29,9 @@ func resolveIntegrationMessageRequest(raw json.RawMessage) (integrationMessageRe
 	if strings.TrimSpace(input.Text) == "" {
 		return integrationMessageRequest{}, errors.New("text is required")
 	}
-	if input.ArtifactID != "" {
-		if _, err := publicid.Decode(publicid.KindArtifact, input.ArtifactID); err != nil {
-			return integrationMessageRequest{}, fmt.Errorf("artifact_id is invalid: %w", err)
+	for _, artifactID := range input.ArtifactIDs {
+		if _, err := publicid.Decode(publicid.KindArtifact, artifactID); err != nil {
+			return integrationMessageRequest{}, fmt.Errorf("artifact_ids contains an invalid artifact ID: %w", err)
 		}
 	}
 	return input, nil

--- a/internal/harness/tools/integration_requests.go
+++ b/internal/harness/tools/integration_requests.go
@@ -6,12 +6,15 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/omnara-ai/omnara/internal/publicid"
 )
 
 var integrationTargetRefPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*-[a-z2-9]{4}$`)
 
 type integrationMessageRequest struct {
-	Text string `json:"text"`
+	Text       string `json:"text"`
+	ArtifactID string `json:"artifact_id,omitempty"`
 }
 
 type integrationTargetRequest struct {
@@ -25,6 +28,11 @@ func resolveIntegrationMessageRequest(raw json.RawMessage) (integrationMessageRe
 	}
 	if strings.TrimSpace(input.Text) == "" {
 		return integrationMessageRequest{}, errors.New("text is required")
+	}
+	if input.ArtifactID != "" {
+		if _, err := publicid.Decode(publicid.KindArtifact, input.ArtifactID); err != nil {
+			return integrationMessageRequest{}, fmt.Errorf("artifact_id is invalid: %w", err)
+		}
 	}
 	return input, nil
 }

--- a/internal/harness/tools/integration_requests_test.go
+++ b/internal/harness/tools/integration_requests_test.go
@@ -3,21 +3,33 @@ package tools
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/omnara-ai/omnara/internal/publicid"
 )
 
 func TestResolveIntegrationMessageRequest(t *testing.T) {
 	t.Parallel()
 
-	request, err := resolveIntegrationMessageRequest(json.RawMessage(`{"text":" hello "}`))
+	artifactID, err := publicid.Encode(
+		publicid.KindArtifact,
+		integrationToolTestID("integration-message-artifact"),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if request.Text != " hello " {
-		t.Fatalf("text = %q", request.Text)
+	request, err := resolveIntegrationMessageRequest(
+		json.RawMessage(`{"text":" hello ","artifact_id":"` + artifactID + `"}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.Text != " hello " || request.ArtifactID != artifactID {
+		t.Fatalf("request = %+v", request)
 	}
 	for _, raw := range []json.RawMessage{
 		json.RawMessage(`{"text":" "}`),
 		json.RawMessage(`{"text":null}`),
+		json.RawMessage(`{"text":"hello","artifact_id":"agt_invalid"}`),
 		json.RawMessage(`{"text":"hello","channel":"C123"}`),
 		json.RawMessage(`{"text":"hello"} {}`),
 	} {

--- a/internal/harness/tools/integration_requests_test.go
+++ b/internal/harness/tools/integration_requests_test.go
@@ -18,18 +18,19 @@ func TestResolveIntegrationMessageRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 	request, err := resolveIntegrationMessageRequest(
-		json.RawMessage(`{"text":" hello ","artifact_id":"` + artifactID + `"}`),
+		json.RawMessage(`{"text":" hello ","artifact_ids":["` + artifactID + `"]}`),
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if request.Text != " hello " || request.ArtifactID != artifactID {
+	if request.Text != " hello " || len(request.ArtifactIDs) != 1 || request.ArtifactIDs[0] != artifactID {
 		t.Fatalf("request = %+v", request)
 	}
 	for _, raw := range []json.RawMessage{
 		json.RawMessage(`{"text":" "}`),
 		json.RawMessage(`{"text":null}`),
-		json.RawMessage(`{"text":"hello","artifact_id":"agt_invalid"}`),
+		json.RawMessage(`{"text":"hello","artifact_ids":["agt_invalid"]}`),
+		json.RawMessage(`{"text":"hello","artifact_id":"` + artifactID + `"}`),
 		json.RawMessage(`{"text":"hello","channel":"C123"}`),
 		json.RawMessage(`{"text":"hello"} {}`),
 	} {

--- a/internal/harness/tools/integration_tools.go
+++ b/internal/harness/tools/integration_tools.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/omnara-ai/omnara/internal/integration/slack"
 	"github.com/omnara-ai/omnara/internal/model"
+	"github.com/omnara-ai/omnara/internal/modelcontext"
 	"github.com/omnara-ai/omnara/internal/publicid"
 	"github.com/omnara-ai/omnara/internal/storage"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
@@ -178,6 +179,9 @@ func (e Executor) dispatchIntegrationMessageSend(
 	if err != nil {
 		return toolResultContent{}, err
 	}
+	if input.ArtifactID != "" {
+		return e.dispatchIntegrationArtifactSend(ctx, turn, slackTarget, input)
+	}
 
 	agentPublicID, err := publicid.Encode(publicid.KindAgent, turn.AgentID)
 	if err != nil {
@@ -224,32 +228,134 @@ func (e Executor) dispatchIntegrationMessageSend(
 				return e.integrationDeliveryUnknown(target.TargetRef, errors.New(posted.Message))
 			}
 		default:
-			code := posted.Code
-			if code == "" {
-				code = "permanent_failure"
-			}
-			message := posted.Message
-			if message == "" {
-				message = code
-			}
-			content, err := structuredToolResultContent(
-				integrationToolResult{
-					Provider:  integrationstore.IntegrationProviderSlack,
-					Code:      code,
-					TargetRef: target.TargetRef,
-					Message:   message,
-				},
-			)
-			if err != nil {
-				return toolResultContent{}, err
-			}
-			return content, errors.New(message)
+			return integrationSlackFailureResult(target.TargetRef, posted)
 		}
 	}
 	return e.integrationDeliveryUnknown(
 		target.TargetRef,
 		errors.New("message delivery could not be confirmed"),
 	)
+}
+
+func (e Executor) dispatchIntegrationArtifactSend(
+	ctx context.Context,
+	turn Turn,
+	slackTarget slack.MessageTarget,
+	input integrationMessageRequest,
+) (toolResultContent, error) {
+	artifactID, err := publicid.Decode(publicid.KindArtifact, input.ArtifactID)
+	if err != nil {
+		return toolResultContent{}, err
+	}
+	content, artifact, err := e.Store.Artifacts().GetArtifactBlob(
+		ctx,
+		turn.ProjectID,
+		turn.AgentID,
+		artifactID,
+	)
+	if err != nil {
+		return toolResultContent{}, fmt.Errorf("load artifact %s: %w", input.ArtifactID, err)
+	}
+	filename := modelcontext.MediaFilename(artifact.Filename, artifact.ContentType)
+	var rateLimitSlept time.Duration
+	attempt := 1
+	var fileID string
+	for {
+		var result slack.APIResult
+		fileID, result, err = slack.UploadFile(
+			ctx,
+			e.IntegrationHTTPClient,
+			slackTarget,
+			filename,
+			content,
+			func(ctx context.Context) error {
+				return e.ensureIntegrationPostOwnership(ctx, turn)
+			},
+		)
+		if err != nil {
+			return toolResultContent{}, err
+		}
+		if fileID != "" {
+			break
+		}
+		switch {
+		case result.RateLimited:
+			if slept, err := sleepForIntegrationRateLimit(ctx, result.RetryAfter, &rateLimitSlept, attempt); err != nil {
+				return toolResultContent{}, err
+			} else if slept {
+				attempt++
+				continue
+			}
+			return e.integrationRateLimited(slackTarget.TargetRef, result.RetryAfter)
+		case result.TransientFailure && attempt < integrationMessageSendAttempts:
+			attempt++
+			continue
+		default:
+			return integrationSlackFailureResult(slackTarget.TargetRef, result)
+		}
+	}
+	for {
+		if err := e.ensureIntegrationPostOwnership(ctx, turn); err != nil {
+			return toolResultContent{}, err
+		}
+		result, err := slack.CompleteFileUpload(
+			ctx,
+			e.IntegrationHTTPClient,
+			slackTarget,
+			fileID,
+			filename,
+			input.Text,
+		)
+		if err != nil {
+			return toolResultContent{}, err
+		}
+		switch {
+		case result == (slack.APIResult{}):
+			return e.integrationDelivered(slackTarget.TargetRef, "")
+		case result.RateLimited:
+			if slept, err := sleepForIntegrationRateLimit(ctx, result.RetryAfter, &rateLimitSlept, attempt); err != nil {
+				return toolResultContent{}, err
+			} else if slept {
+				attempt++
+				continue
+			}
+			return e.integrationRateLimited(slackTarget.TargetRef, result.RetryAfter)
+		case result.DeliveryUnknown:
+			message := result.Message
+			if message == "" {
+				message = "file delivery could not be confirmed"
+			}
+			return e.integrationDeliveryUnknown(slackTarget.TargetRef, errors.New(message))
+		default:
+			return integrationSlackFailureResult(slackTarget.TargetRef, result)
+		}
+	}
+}
+
+func integrationSlackFailureResult(
+	targetRef string,
+	result slack.APIResult,
+) (toolResultContent, error) {
+	code := result.Code
+	if code == "" {
+		code = "permanent_failure"
+	}
+	message := result.Message
+	if message == "" {
+		message = code
+	}
+	content, err := structuredToolResultContent(
+		integrationToolResult{
+			Provider:  integrationstore.IntegrationProviderSlack,
+			Code:      code,
+			TargetRef: targetRef,
+			Message:   message,
+		},
+	)
+	if err != nil {
+		return toolResultContent{}, err
+	}
+	return content, errors.New(message)
 }
 
 func integrationTargetFailureResult(

--- a/internal/harness/tools/integration_tools.go
+++ b/internal/harness/tools/integration_tools.go
@@ -179,7 +179,7 @@ func (e Executor) dispatchIntegrationMessageSend(
 	if err != nil {
 		return toolResultContent{}, err
 	}
-	if input.ArtifactID != "" {
+	if len(input.ArtifactIDs) != 0 {
 		return e.dispatchIntegrationArtifactSend(ctx, turn, slackTarget, input)
 	}
 
@@ -243,69 +243,68 @@ func (e Executor) dispatchIntegrationArtifactSend(
 	slackTarget slack.MessageTarget,
 	input integrationMessageRequest,
 ) (toolResultContent, error) {
-	artifactID, err := publicid.Decode(publicid.KindArtifact, input.ArtifactID)
-	if err != nil {
-		return toolResultContent{}, err
-	}
-	content, artifact, err := e.Store.Artifacts().GetArtifactBlob(
-		ctx,
-		turn.ProjectID,
-		turn.AgentID,
-		artifactID,
-	)
-	if err != nil {
-		return toolResultContent{}, fmt.Errorf("load artifact %s: %w", input.ArtifactID, err)
-	}
-	filename := modelcontext.MediaFilename(artifact.Filename, artifact.ContentType)
 	var rateLimitSlept time.Duration
-	attempt := 1
-	var fileID string
-	for {
-		var result slack.APIResult
-		fileID, result, err = slack.UploadFile(
-			ctx,
-			e.IntegrationHTTPClient,
-			slackTarget,
-			filename,
-			content,
-			func(ctx context.Context) error {
-				return e.ensureIntegrationPostOwnership(ctx, turn)
-			},
-		)
+	uploadedFiles := make([]slack.UploadedFile, 0, len(input.ArtifactIDs))
+	for _, artifactPublicID := range input.ArtifactIDs {
+		artifactID, err := publicid.Decode(publicid.KindArtifact, artifactPublicID)
 		if err != nil {
 			return toolResultContent{}, err
 		}
-		if fileID != "" {
-			break
+		content, artifact, err := e.Store.Artifacts().GetArtifactBlob(
+			ctx,
+			turn.ProjectID,
+			turn.AgentID,
+			artifactID,
+		)
+		if err != nil {
+			return toolResultContent{}, fmt.Errorf("load artifact %s: %w", artifactPublicID, err)
 		}
-		switch {
-		case result.RateLimited:
-			if slept, err := sleepForIntegrationRateLimit(ctx, result.RetryAfter, &rateLimitSlept, attempt); err != nil {
+		filename := modelcontext.MediaFilename(artifact.Filename, artifact.ContentType)
+		var fileID string
+		for attempt := 1; attempt <= integrationMessageSendAttempts; attempt++ {
+			var result slack.APIResult
+			fileID, result, err = slack.UploadFile(
+				ctx,
+				e.IntegrationHTTPClient,
+				slackTarget,
+				filename,
+				content,
+				func(ctx context.Context) error {
+					return e.ensureIntegrationPostOwnership(ctx, turn)
+				},
+			)
+			if err != nil {
 				return toolResultContent{}, err
-			} else if slept {
-				attempt++
-				continue
 			}
-			return e.integrationRateLimited(slackTarget.TargetRef, result.RetryAfter)
-		case result.TransientFailure && attempt < integrationMessageSendAttempts:
-			attempt++
-			continue
-		default:
-			return integrationSlackFailureResult(slackTarget.TargetRef, result)
+			if fileID != "" {
+				break
+			}
+			switch {
+			case result.RateLimited:
+				if slept, err := sleepForIntegrationRateLimit(ctx, result.RetryAfter, &rateLimitSlept, attempt); err != nil {
+					return toolResultContent{}, err
+				} else if slept {
+					continue
+				}
+				return e.integrationRateLimited(slackTarget.TargetRef, result.RetryAfter)
+			case result.TransientFailure && attempt < integrationMessageSendAttempts:
+				continue
+			default:
+				return integrationSlackFailureResult(slackTarget.TargetRef, result)
+			}
 		}
+		uploadedFiles = append(uploadedFiles, slack.UploadedFile{ID: fileID, Title: filename})
 	}
-	attempt = 1
 	rateLimitSlept = 0
-	for {
+	for attempt := 1; attempt <= integrationMessageSendAttempts; attempt++ {
 		if err := e.ensureIntegrationPostOwnership(ctx, turn); err != nil {
 			return toolResultContent{}, err
 		}
-		result, err := slack.CompleteFileUpload(
+		result, err := slack.CompleteFileUploads(
 			ctx,
 			e.IntegrationHTTPClient,
 			slackTarget,
-			fileID,
-			filename,
+			uploadedFiles,
 			input.Text,
 		)
 		if err != nil {
@@ -318,7 +317,6 @@ func (e Executor) dispatchIntegrationArtifactSend(
 			if slept, err := sleepForIntegrationRateLimit(ctx, result.RetryAfter, &rateLimitSlept, attempt); err != nil {
 				return toolResultContent{}, err
 			} else if slept {
-				attempt++
 				continue
 			}
 			return e.integrationRateLimited(slackTarget.TargetRef, result.RetryAfter)
@@ -332,6 +330,10 @@ func (e Executor) dispatchIntegrationArtifactSend(
 			return integrationSlackFailureResult(slackTarget.TargetRef, result)
 		}
 	}
+	return e.integrationDeliveryUnknown(
+		slackTarget.TargetRef,
+		errors.New("file delivery could not be confirmed"),
+	)
 }
 
 func integrationSlackFailureResult(

--- a/internal/harness/tools/integration_tools.go
+++ b/internal/harness/tools/integration_tools.go
@@ -294,6 +294,8 @@ func (e Executor) dispatchIntegrationArtifactSend(
 			return integrationSlackFailureResult(slackTarget.TargetRef, result)
 		}
 	}
+	attempt = 1
+	rateLimitSlept = 0
 	for {
 		if err := e.ensureIntegrationPostOwnership(ctx, turn); err != nil {
 			return toolResultContent{}, err

--- a/internal/harness/tools/integration_tools_integration_test.go
+++ b/internal/harness/tools/integration_tools_integration_test.go
@@ -162,6 +162,7 @@ func TestIntegrationSendToolDispatchDeliversDistinctCalls(t *testing.T) {
 func TestIntegrationSendToolUploadsArtifactWithSafeRetries(t *testing.T) {
 	tests := []struct {
 		name                   string
+		artifactCount          int
 		uploadURLFailures      int
 		completionRateLimits   int
 		completionStatus       int
@@ -170,7 +171,7 @@ func TestIntegrationSendToolUploadsArtifactWithSafeRetries(t *testing.T) {
 		wantUploadRequests     int
 		wantCompletionRequests int
 	}{
-		{name: "success", wantCode: "delivered", wantUploadRequests: 1, wantCompletionRequests: 1},
+		{name: "success", artifactCount: 2, wantCode: "delivered", wantUploadRequests: 2, wantCompletionRequests: 1},
 		{name: "upload URL transient failure", uploadURLFailures: 1, wantCode: "delivered", wantUploadRequests: 1, wantCompletionRequests: 1},
 		{name: "upload retries do not consume completion retry budget", uploadURLFailures: 2, completionRateLimits: 1, wantCode: "delivered", wantUploadRequests: 1, wantCompletionRequests: 2},
 		{name: "completion rate limit", completionRateLimits: 1, wantCode: "delivered", wantUploadRequests: 1, wantCompletionRequests: 2},
@@ -189,22 +190,39 @@ func TestIntegrationSendToolUploadsArtifactWithSafeRetries(t *testing.T) {
 				false,
 				storage.WithBlobStore(integrationblob.MustOpen(t, ctx)),
 			)
-			artifactContent := []byte("artifact contents")
-			artifact, err := fixture.Store.Artifacts().CreateArtifact(ctx, artifactstore.CreateArtifactInput{
-				ProjectID:      toolsTestProjectID,
-				AgentID:        fixture.Agent.ID,
-				ContentType:    "text/plain",
-				Filename:       "report.txt",
-				Content:        artifactContent,
-				MaxBytes:       1024,
-				IdempotencyKey: seed,
-			})
-			if err != nil {
-				t.Fatalf("create artifact: %v", err)
+			artifactCount := tt.artifactCount
+			if artifactCount == 0 {
+				artifactCount = 1
 			}
-			artifactID, err := publicid.Encode(publicid.KindArtifact, artifact.ID)
-			if err != nil {
-				t.Fatalf("encode artifact id: %v", err)
+			artifactFiles := []struct {
+				filename   string
+				content    []byte
+				fileID     string
+				uploadPath string
+			}{
+				{filename: "report.txt", content: []byte("artifact contents"), fileID: "F123", uploadPath: "/upload/v1/artifact"},
+				{filename: "chart.txt", content: []byte("chart contents"), fileID: "F456", uploadPath: "/upload/v1/chart"},
+			}
+			artifactFiles = artifactFiles[:artifactCount]
+			artifactIDs := make([]string, 0, artifactCount)
+			for artifactIndex, file := range artifactFiles {
+				artifact, err := fixture.Store.Artifacts().CreateArtifact(ctx, artifactstore.CreateArtifactInput{
+					ProjectID:      toolsTestProjectID,
+					AgentID:        fixture.Agent.ID,
+					ContentType:    "text/plain",
+					Filename:       file.filename,
+					Content:        file.content,
+					MaxBytes:       1024,
+					IdempotencyKey: seed + "-" + strconv.Itoa(artifactIndex),
+				})
+				if err != nil {
+					t.Fatalf("create artifact: %v", err)
+				}
+				artifactID, err := publicid.Encode(publicid.KindArtifact, artifact.ID)
+				if err != nil {
+					t.Fatalf("encode artifact id: %v", err)
+				}
+				artifactIDs = append(artifactIDs, artifactID)
 			}
 			requests := make(map[string]int)
 			loseOwnership := func() {
@@ -228,7 +246,12 @@ func TestIntegrationSendToolUploadsArtifactWithSafeRetries(t *testing.T) {
 					if err := r.ParseForm(); err != nil {
 						t.Fatalf("parse upload URL request: %v", err)
 					}
-					if r.Form.Get("filename") != "report.txt" || r.Form.Get("length") != strconv.Itoa(len(artifactContent)) {
+					artifactIndex := requests[r.URL.Path] - tt.uploadURLFailures - 1
+					if artifactIndex >= len(artifactFiles) {
+						t.Fatalf("unexpected upload URL request %d", requests[r.URL.Path])
+					}
+					file := artifactFiles[artifactIndex]
+					if r.Form.Get("filename") != file.filename || r.Form.Get("length") != strconv.Itoa(len(file.content)) {
 						t.Fatalf("upload URL form = %v", r.Form)
 					}
 					if tt.loseAfterPath == r.URL.Path {
@@ -236,18 +259,26 @@ func TestIntegrationSendToolUploadsArtifactWithSafeRetries(t *testing.T) {
 					}
 					writeToolTestJSON(w, map[string]any{
 						"ok":         true,
-						"upload_url": "https://files.slack.com/upload/v1/artifact",
-						"file_id":    "F123",
+						"upload_url": "https://files.slack.com" + file.uploadPath,
+						"file_id":    file.fileID,
 					})
-				case "/upload/v1/artifact":
+				case "/upload/v1/artifact", "/upload/v1/chart":
 					if r.Header.Get("Authorization") != "" {
 						t.Fatalf("file upload included authorization")
 					}
+					artifactIndex := 0
+					if r.URL.Path == "/upload/v1/chart" {
+						artifactIndex = 1
+					}
+					if artifactIndex >= len(artifactFiles) {
+						t.Fatalf("unexpected artifact upload path %s", r.URL.Path)
+					}
+					file := artifactFiles[artifactIndex]
 					body, err := io.ReadAll(r.Body)
 					if err != nil {
 						t.Fatalf("read uploaded artifact: %v", err)
 					}
-					if string(body) != string(artifactContent) {
+					if string(body) != string(file.content) {
 						t.Fatalf("uploaded artifact = %q", body)
 					}
 					if tt.loseAfterPath == r.URL.Path {
@@ -267,10 +298,14 @@ func TestIntegrationSendToolUploadsArtifactWithSafeRetries(t *testing.T) {
 					if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 						t.Fatalf("decode completion payload: %v", err)
 					}
-					if len(payload.Files) != 1 || payload.Files[0].ID != "F123" || payload.Files[0].Title != "report.txt" ||
-						payload.ChannelID != "C123" || payload.ThreadTS != "111.222" ||
+					if len(payload.Files) != len(artifactFiles) || payload.ChannelID != "C123" || payload.ThreadTS != "111.222" ||
 						payload.InitialComment != "here is the report" {
 						t.Fatalf("completion payload = %+v", payload)
+					}
+					for artifactIndex, file := range artifactFiles {
+						if payload.Files[artifactIndex].ID != file.fileID || payload.Files[artifactIndex].Title != file.filename {
+							t.Fatalf("completion payload = %+v", payload)
+						}
 					}
 					if requests[r.URL.Path] <= tt.completionRateLimits {
 						w.Header().Set("Retry-After", "0")
@@ -306,18 +341,25 @@ func TestIntegrationSendToolUploadsArtifactWithSafeRetries(t *testing.T) {
 					ctx,
 					fixture.turn(),
 					slackTarget,
-					integrationMessageRequest{Text: "here is the report", ArtifactID: artifactID},
+					integrationMessageRequest{Text: "here is the report", ArtifactIDs: artifactIDs},
 				)
 				if !errors.Is(err, storeerr.ErrRuntimeLockInactive) {
 					t.Fatalf("artifact send error = %v, want ErrRuntimeLockInactive", err)
 				}
 			} else {
+				input, err := json.Marshal(map[string]any{
+					"text":         "here is the report",
+					"artifact_ids": artifactIDs,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
 				call := fixture.recordToolCall(
 					t,
 					ctx,
 					"call_"+seed,
 					"send_integration_message",
-					`{"text":"here is the report","artifact_id":"`+artifactID+`"}`,
+					string(input),
 					fixture.Now.Add(20*time.Second),
 				)
 				result, err := dispatchAsyncToolToTerminal(t, ctx, executor, fixture.turn(), call)
@@ -329,15 +371,15 @@ func TestIntegrationSendToolUploadsArtifactWithSafeRetries(t *testing.T) {
 					t.Fatalf("artifact send result = %+v", body)
 				}
 			}
-			wantRequests := map[string]int{
-				"/files.getUploadURLExternal":   1 + tt.uploadURLFailures,
-				"/upload/v1/artifact":           tt.wantUploadRequests,
-				"/files.completeUploadExternal": tt.wantCompletionRequests,
+			if requests["/files.getUploadURLExternal"] != artifactCount+tt.uploadURLFailures {
+				t.Fatalf("upload URL requests = %d, want %d", requests["/files.getUploadURLExternal"], artifactCount+tt.uploadURLFailures)
 			}
-			for path, want := range wantRequests {
-				if requests[path] != want {
-					t.Fatalf("requests[%q] = %d, want %d", path, requests[path], want)
-				}
+			uploadRequests := requests["/upload/v1/artifact"] + requests["/upload/v1/chart"]
+			if uploadRequests != tt.wantUploadRequests {
+				t.Fatalf("upload requests = %d, want %d", uploadRequests, tt.wantUploadRequests)
+			}
+			if requests["/files.completeUploadExternal"] != tt.wantCompletionRequests {
+				t.Fatalf("completion requests = %d, want %d", requests["/files.completeUploadExternal"], tt.wantCompletionRequests)
 			}
 		})
 	}

--- a/internal/harness/tools/integration_tools_integration_test.go
+++ b/internal/harness/tools/integration_tools_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -24,6 +25,7 @@ import (
 	"github.com/omnara-ai/omnara/internal/publicid"
 	"github.com/omnara-ai/omnara/internal/secrets"
 	"github.com/omnara-ai/omnara/internal/storage"
+	"github.com/omnara-ai/omnara/internal/storage/artifactstore"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
 	"github.com/omnara-ai/omnara/internal/storage/integrationstore"
@@ -31,6 +33,7 @@ import (
 	"github.com/omnara-ai/omnara/internal/storage/secretstore"
 	"github.com/omnara-ai/omnara/internal/storage/skillstore"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
+	"github.com/omnara-ai/omnara/internal/testutil/integrationblob"
 	"github.com/omnara-ai/omnara/internal/testutil/integrationdb"
 	"github.com/omnara-ai/omnara/internal/testutil/modeltest"
 	"github.com/omnara-ai/omnara/internal/testutil/storagetest"
@@ -153,6 +156,189 @@ func TestIntegrationSendToolDispatchDeliversDistinctCalls(t *testing.T) {
 	}
 	if readbackCount != 0 {
 		t.Fatalf("readback count = %d, want 0 for successful sends", readbackCount)
+	}
+}
+
+func TestIntegrationSendToolUploadsArtifactWithSafeRetries(t *testing.T) {
+	tests := []struct {
+		name                   string
+		uploadURLFailures      int
+		completionRateLimits   int
+		completionStatus       int
+		loseAfterPath          string
+		wantCode               string
+		wantUploadRequests     int
+		wantCompletionRequests int
+	}{
+		{name: "success", wantCode: "delivered", wantUploadRequests: 1, wantCompletionRequests: 1},
+		{name: "upload URL transient failure", uploadURLFailures: 1, wantCode: "delivered", wantUploadRequests: 1, wantCompletionRequests: 1},
+		{name: "completion rate limit", completionRateLimits: 1, wantCode: "delivered", wantUploadRequests: 1, wantCompletionRequests: 2},
+		{name: "completion failure", completionStatus: http.StatusInternalServerError, wantCode: "delivery_unknown", wantUploadRequests: 1, wantCompletionRequests: 1},
+		{name: "ownership lost before content upload", loseAfterPath: "/files.getUploadURLExternal"},
+		{name: "ownership lost before completion", loseAfterPath: "/upload/v1/artifact", wantUploadRequests: 1},
+	}
+	for index, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			seed := "send-artifact-" + strconv.Itoa(index)
+			fixture := newIntegrationToolFixtureWithMCP(
+				t,
+				ctx,
+				seed,
+				false,
+				storage.WithBlobStore(integrationblob.MustOpen(t, ctx)),
+			)
+			artifactContent := []byte("artifact contents")
+			artifact, err := fixture.Store.Artifacts().CreateArtifact(ctx, artifactstore.CreateArtifactInput{
+				ProjectID:      toolsTestProjectID,
+				AgentID:        fixture.Agent.ID,
+				ContentType:    "text/plain",
+				Filename:       "report.txt",
+				Content:        artifactContent,
+				MaxBytes:       1024,
+				IdempotencyKey: seed,
+			})
+			if err != nil {
+				t.Fatalf("create artifact: %v", err)
+			}
+			artifactID, err := publicid.Encode(publicid.KindArtifact, artifact.ID)
+			if err != nil {
+				t.Fatalf("encode artifact id: %v", err)
+			}
+			requests := make(map[string]int)
+			loseOwnership := func() {
+				if err := fixture.Store.Execution().ReleaseAgentRuntimeLock(
+					ctx,
+					toolsTestProjectID,
+					fixture.Agent.ID,
+					fixture.Lock.ID,
+				); err != nil {
+					t.Fatalf("release runtime lock: %v", err)
+				}
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests[r.URL.Path]++
+				switch r.URL.Path {
+				case "/files.getUploadURLExternal":
+					if requests[r.URL.Path] <= tt.uploadURLFailures {
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+					if err := r.ParseForm(); err != nil {
+						t.Fatalf("parse upload URL request: %v", err)
+					}
+					if r.Form.Get("filename") != "report.txt" || r.Form.Get("length") != strconv.Itoa(len(artifactContent)) {
+						t.Fatalf("upload URL form = %v", r.Form)
+					}
+					if tt.loseAfterPath == r.URL.Path {
+						loseOwnership()
+					}
+					writeToolTestJSON(w, map[string]any{
+						"ok":         true,
+						"upload_url": "https://files.slack.com/upload/v1/artifact",
+						"file_id":    "F123",
+					})
+				case "/upload/v1/artifact":
+					if r.Header.Get("Authorization") != "" {
+						t.Fatalf("file upload included authorization")
+					}
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Fatalf("read uploaded artifact: %v", err)
+					}
+					if string(body) != string(artifactContent) {
+						t.Fatalf("uploaded artifact = %q", body)
+					}
+					if tt.loseAfterPath == r.URL.Path {
+						loseOwnership()
+					}
+					w.WriteHeader(http.StatusOK)
+				case "/files.completeUploadExternal":
+					var payload struct {
+						Files []struct {
+							ID    string `json:"id"`
+							Title string `json:"title"`
+						} `json:"files"`
+						ChannelID      string `json:"channel_id"`
+						ThreadTS       string `json:"thread_ts"`
+						InitialComment string `json:"initial_comment"`
+					}
+					if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+						t.Fatalf("decode completion payload: %v", err)
+					}
+					if len(payload.Files) != 1 || payload.Files[0].ID != "F123" || payload.Files[0].Title != "report.txt" ||
+						payload.ChannelID != "C123" || payload.ThreadTS != "111.222" ||
+						payload.InitialComment != "here is the report" {
+						t.Fatalf("completion payload = %+v", payload)
+					}
+					if requests[r.URL.Path] <= tt.completionRateLimits {
+						w.Header().Set("Retry-After", "0")
+						w.WriteHeader(http.StatusTooManyRequests)
+						return
+					}
+					if tt.completionStatus != 0 {
+						w.WriteHeader(tt.completionStatus)
+						return
+					}
+					writeToolTestJSON(w, map[string]any{"ok": true})
+				default:
+					t.Fatalf("unexpected integration provider path %s", r.URL.Path)
+				}
+			}))
+			defer server.Close()
+
+			executor := Executor{
+				Store:                 fixture.Store,
+				IntegrationHTTPClient: integrationProviderTestClient(server),
+				Now:                   func() time.Time { return fixture.Now.Add(21 * time.Second) },
+			}
+			if tt.loseAfterPath != "" {
+				target, err := executor.currentIntegrationToolTarget(ctx, fixture.turn())
+				if err != nil {
+					t.Fatalf("resolve integration target: %v", err)
+				}
+				slackTarget, err := slackMessageTarget(target)
+				if err != nil {
+					t.Fatalf("resolve Slack target: %v", err)
+				}
+				_, err = executor.dispatchIntegrationArtifactSend(
+					ctx,
+					fixture.turn(),
+					slackTarget,
+					integrationMessageRequest{Text: "here is the report", ArtifactID: artifactID},
+				)
+				if !errors.Is(err, storeerr.ErrRuntimeLockInactive) {
+					t.Fatalf("artifact send error = %v, want ErrRuntimeLockInactive", err)
+				}
+			} else {
+				call := fixture.recordToolCall(
+					t,
+					ctx,
+					"call_"+seed,
+					"send_integration_message",
+					`{"text":"here is the report","artifact_id":"`+artifactID+`"}`,
+					fixture.Now.Add(20*time.Second),
+				)
+				result, err := dispatchAsyncToolToTerminal(t, ctx, executor, fixture.turn(), call)
+				if err != nil {
+					t.Fatalf("dispatch artifact send: %v", err)
+				}
+				body := integrationToolResultFromTestParts(t, result.ContentParts)
+				if body.Code != tt.wantCode || body.ProviderMessageID != "" || body.TargetRef != fixture.Target.TargetRef {
+					t.Fatalf("artifact send result = %+v", body)
+				}
+			}
+			wantRequests := map[string]int{
+				"/files.getUploadURLExternal":   1 + tt.uploadURLFailures,
+				"/upload/v1/artifact":           tt.wantUploadRequests,
+				"/files.completeUploadExternal": tt.wantCompletionRequests,
+			}
+			for path, want := range wantRequests {
+				if requests[path] != want {
+					t.Fatalf("requests[%q] = %d, want %d", path, requests[path], want)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/harness/tools/integration_tools_integration_test.go
+++ b/internal/harness/tools/integration_tools_integration_test.go
@@ -172,6 +172,7 @@ func TestIntegrationSendToolUploadsArtifactWithSafeRetries(t *testing.T) {
 	}{
 		{name: "success", wantCode: "delivered", wantUploadRequests: 1, wantCompletionRequests: 1},
 		{name: "upload URL transient failure", uploadURLFailures: 1, wantCode: "delivered", wantUploadRequests: 1, wantCompletionRequests: 1},
+		{name: "upload retries do not consume completion retry budget", uploadURLFailures: 2, completionRateLimits: 1, wantCode: "delivered", wantUploadRequests: 1, wantCompletionRequests: 2},
 		{name: "completion rate limit", completionRateLimits: 1, wantCode: "delivered", wantUploadRequests: 1, wantCompletionRequests: 2},
 		{name: "completion failure", completionStatus: http.StatusInternalServerError, wantCode: "delivery_unknown", wantUploadRequests: 1, wantCompletionRequests: 1},
 		{name: "ownership lost before content upload", loseAfterPath: "/files.getUploadURLExternal"},

--- a/internal/harness/tools/registry_test.go
+++ b/internal/harness/tools/registry_test.go
@@ -205,13 +205,17 @@ func TestIntegrationMessageImplementationValidatorBinding(t *testing.T) {
 	); err != nil {
 		t.Fatalf("valid integration message rejected: %v", err)
 	}
-	for _, input := range []json.RawMessage{
-		json.RawMessage(`{"text":"hello","artifact_id":null}`),
+	if err := validateRegisteredToolInput(
+		"send_integration_message",
 		json.RawMessage(`{"text":"hello","artifact_id":""}`),
-	} {
-		if err := validateRegisteredToolInput("send_integration_message", input); err == nil {
-			t.Fatalf("invalid integration message accepted: %s", input)
-		}
+	); err != nil {
+		t.Fatalf("empty artifact_id rejected: %v", err)
+	}
+	if err := validateRegisteredToolInput(
+		"send_integration_message",
+		json.RawMessage(`{"text":"hello","artifact_id":null}`),
+	); err == nil {
+		t.Fatal("null artifact_id accepted")
 	}
 }
 

--- a/internal/harness/tools/registry_test.go
+++ b/internal/harness/tools/registry_test.go
@@ -201,21 +201,41 @@ func TestIntegrationMessageImplementationValidatorBinding(t *testing.T) {
 	}
 	if err := validateRegisteredToolInput(
 		"send_integration_message",
-		json.RawMessage(`{"text":"hello","artifact_id":"`+artifactID+`"}`),
+		json.RawMessage(`{"text":"hello","artifact_ids":["`+artifactID+`"]}`),
 	); err != nil {
 		t.Fatalf("valid integration message rejected: %v", err)
 	}
 	if err := validateRegisteredToolInput(
 		"send_integration_message",
-		json.RawMessage(`{"text":"hello","artifact_id":""}`),
+		json.RawMessage(`{"text":"hello","artifact_ids":[]}`),
 	); err != nil {
-		t.Fatalf("empty artifact_id rejected: %v", err)
+		t.Fatalf("empty artifact_ids rejected: %v", err)
 	}
 	if err := validateRegisteredToolInput(
 		"send_integration_message",
-		json.RawMessage(`{"text":"hello","artifact_id":null}`),
+		json.RawMessage(`{"text":"hello","artifact_ids":null}`),
 	); err == nil {
-		t.Fatal("null artifact_id accepted")
+		t.Fatal("null artifact_ids accepted")
+	}
+	if err := validateRegisteredToolInput(
+		"send_integration_message",
+		json.RawMessage(`{"text":"hello","artifact_ids":[""]}`),
+	); err == nil {
+		t.Fatal("empty artifact ID accepted")
+	}
+	tooManyArtifactIDs := make([]string, 21)
+	for index := range tooManyArtifactIDs {
+		tooManyArtifactIDs[index] = artifactID
+	}
+	tooManyInput, err := json.Marshal(map[string]any{
+		"text":         "hello",
+		"artifact_ids": tooManyArtifactIDs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateRegisteredToolInput("send_integration_message", tooManyInput); err == nil {
+		t.Fatal("more than 20 artifact IDs accepted")
 	}
 }
 

--- a/internal/harness/tools/registry_test.go
+++ b/internal/harness/tools/registry_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/omnara-ai/omnara/internal/publicid"
 	"github.com/omnara-ai/omnara/internal/toolcatalog"
 )
 
@@ -187,6 +188,30 @@ func TestAskQuestionImplementationValidatorBinding(t *testing.T) {
 		),
 	); err == nil {
 		t.Fatal("model-provided text capability was accepted")
+	}
+}
+
+func TestIntegrationMessageImplementationValidatorBinding(t *testing.T) {
+	artifactID, err := publicid.Encode(
+		publicid.KindArtifact,
+		integrationToolTestID("integration-message-validator"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateRegisteredToolInput(
+		"send_integration_message",
+		json.RawMessage(`{"text":"hello","artifact_id":"`+artifactID+`"}`),
+	); err != nil {
+		t.Fatalf("valid integration message rejected: %v", err)
+	}
+	for _, input := range []json.RawMessage{
+		json.RawMessage(`{"text":"hello","artifact_id":null}`),
+		json.RawMessage(`{"text":"hello","artifact_id":""}`),
+	} {
+		if err := validateRegisteredToolInput("send_integration_message", input); err == nil {
+			t.Fatalf("invalid integration message accepted: %s", input)
+		}
 	}
 }
 

--- a/internal/integration/slack/files.go
+++ b/internal/integration/slack/files.go
@@ -78,6 +78,11 @@ type completeUploadExternalResponse struct {
 	Error string `json:"error"`
 }
 
+type UploadedFile struct {
+	ID    string `json:"id"`
+	Title string `json:"title,omitempty"`
+}
+
 func UploadFile(
 	ctx context.Context,
 	client *http.Client,
@@ -131,16 +136,15 @@ func UploadFile(
 	return uploadURL.FileID, APIResult{}, nil
 }
 
-func CompleteFileUpload(
+func CompleteFileUploads(
 	ctx context.Context,
 	client *http.Client,
 	target MessageTarget,
-	fileID string,
-	filename string,
+	files []UploadedFile,
 	initialComment string,
 ) (APIResult, error) {
 	payload := map[string]any{
-		"files":           []map[string]string{{"id": fileID, "title": filename}},
+		"files":           files,
 		"channel_id":      target.Channel,
 		"initial_comment": initialComment,
 	}

--- a/internal/integration/slack/files.go
+++ b/internal/integration/slack/files.go
@@ -1,13 +1,16 @@
 package slack
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"mime"
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 )
@@ -61,6 +64,184 @@ type fileInfoResponse struct {
 	OK    bool   `json:"ok"`
 	Error string `json:"error"`
 	File  File   `json:"file"`
+}
+
+type getUploadURLExternalResponse struct {
+	OK        bool   `json:"ok"`
+	Error     string `json:"error"`
+	UploadURL string `json:"upload_url"`
+	FileID    string `json:"file_id"`
+}
+
+type completeUploadExternalResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error"`
+}
+
+func UploadFile(
+	ctx context.Context,
+	client *http.Client,
+	target MessageTarget,
+	filename string,
+	content []byte,
+	beforeRequest func(context.Context) error,
+) (string, APIResult, error) {
+	if err := beforeRequest(ctx); err != nil {
+		return "", APIResult{}, err
+	}
+	var uploadURL getUploadURLExternalResponse
+	result, err := callFormAt(
+		ctx,
+		client,
+		defaultAPIURL,
+		target.BotToken,
+		"files.getUploadURLExternal",
+		url.Values{
+			"filename": {filename},
+			"length":   {strconv.Itoa(len(content))},
+		},
+		&uploadURL,
+	)
+	if err != nil {
+		return "", APIResult{}, err
+	}
+	if result != (APIResult{}) {
+		return "", filePreShareResult(result), nil
+	}
+	if !uploadURL.OK {
+		return "", filePreShareResult(ErrorResult(uploadURL.Error)), nil
+	}
+	if uploadURL.UploadURL == "" || uploadURL.FileID == "" {
+		return "", APIResult{
+			Code:             "transient_failure",
+			TransientFailure: true,
+			Message:          "Slack returned an incomplete file upload URL response.",
+		}, nil
+	}
+	if err := beforeRequest(ctx); err != nil {
+		return "", APIResult{}, err
+	}
+	result, err = uploadFileContent(ctx, client, uploadURL.UploadURL, content)
+	if err != nil {
+		return "", APIResult{}, err
+	}
+	if result != (APIResult{}) {
+		return "", filePreShareResult(result), nil
+	}
+	return uploadURL.FileID, APIResult{}, nil
+}
+
+func CompleteFileUpload(
+	ctx context.Context,
+	client *http.Client,
+	target MessageTarget,
+	fileID string,
+	filename string,
+	initialComment string,
+) (APIResult, error) {
+	payload := map[string]any{
+		"files":           []map[string]string{{"id": fileID, "title": filename}},
+		"channel_id":      target.Channel,
+		"initial_comment": initialComment,
+	}
+	if target.ThreadTS != "" {
+		payload["thread_ts"] = target.ThreadTS
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return APIResult{}, err
+	}
+	var completed completeUploadExternalResponse
+	result, err := callJSONAt(
+		ctx,
+		client,
+		defaultAPIURL,
+		target.BotToken,
+		"files.completeUploadExternal",
+		body,
+		&completed,
+	)
+	if err != nil {
+		return APIResult{}, err
+	}
+	if result != (APIResult{}) {
+		return fileCompletionResult(result), nil
+	}
+	if !completed.OK {
+		return fileCompletionResult(ErrorResult(completed.Error)), nil
+	}
+	return APIResult{}, nil
+}
+
+func uploadFileContent(
+	ctx context.Context,
+	client *http.Client,
+	rawURL string,
+	content []byte,
+) (APIResult, error) {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || !allowedSlackFileURL(parsed, "") {
+		return APIResult{
+			Code:             "invalid_file_url",
+			PermanentFailure: true,
+			Message:          "invalid Slack file upload URL",
+		}, nil
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, defaultToolTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, parsed.String(), bytes.NewReader(content))
+	if err != nil {
+		return APIResult{PermanentFailure: true, Message: err.Error()}, nil
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	resp, err := httpClientWithoutRedirects(client).Do(req)
+	if err != nil {
+		return APIResult{DeliveryUnknown: true, Message: "Slack file upload request failed."}, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return APIResult{
+			RateLimited: true,
+			RetryAfter:  retryAfter(resp.Header.Get("Retry-After")),
+			Message:     "Slack rate limited the file upload request.",
+		}, nil
+	}
+	if resp.StatusCode == http.StatusOK {
+		return APIResult{}, nil
+	}
+	if resp.StatusCode >= 500 {
+		return APIResult{
+			Code:             "transient_failure",
+			TransientFailure: true,
+			Message:          fmt.Sprintf("Slack returned status %d while uploading the file.", resp.StatusCode),
+		}, nil
+	}
+	return APIResult{
+		Code:             "permanent_failure",
+		PermanentFailure: true,
+		Message:          fmt.Sprintf("Slack returned status %d while uploading the file.", resp.StatusCode),
+	}, nil
+}
+
+func filePreShareResult(result APIResult) APIResult {
+	if result.ProviderCode == "missing_scope" {
+		result.Message = "Slack integration must be reauthorized with files:write before it can send artifacts."
+	}
+	if result.DeliveryUnknown {
+		result.Code = "transient_failure"
+		result.TransientFailure = true
+		result.DeliveryUnknown = false
+	}
+	return result
+}
+
+func fileCompletionResult(result APIResult) APIResult {
+	if result.TransientFailure {
+		result.Code = "delivery_unknown"
+		result.TransientFailure = false
+		result.DeliveryUnknown = true
+	}
+	return result
 }
 
 func DownloadEventFiles(

--- a/internal/integration/slack/files_test.go
+++ b/internal/integration/slack/files_test.go
@@ -63,7 +63,8 @@ func TestUploadFile(t *testing.T) {
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 				t.Fatalf("decode completion request: %v", err)
 			}
-			if len(payload.Files) != 1 || payload.Files[0].ID != "F123" || payload.Files[0].Title != "report.txt" ||
+			if len(payload.Files) != 2 || payload.Files[0].ID != "F123" || payload.Files[0].Title != "report.txt" ||
+				payload.Files[1].ID != "F456" || payload.Files[1].Title != "chart.png" ||
 				payload.ChannelID != "C123" || payload.ThreadTS != "111.222" ||
 				payload.InitialComment != "here is the report" {
 				t.Fatalf("completion payload = %+v", payload)
@@ -89,12 +90,11 @@ func TestUploadFile(t *testing.T) {
 	if fileID != "F123" || result != (APIResult{}) {
 		t.Fatalf("upload file id=%q result=%+v", fileID, result)
 	}
-	result, err = CompleteFileUpload(
+	result, err = CompleteFileUploads(
 		context.Background(),
 		slackTestClient(server),
 		MessageTarget{Channel: "C123", ThreadTS: "111.222", BotToken: "xoxb-test"},
-		fileID,
-		"report.txt",
+		[]UploadedFile{{ID: fileID, Title: "report.txt"}, {ID: "F456", Title: "chart.png"}},
 		"here is the report",
 	)
 	if err != nil {
@@ -109,7 +109,7 @@ func TestUploadFile(t *testing.T) {
 	}
 }
 
-func TestCompleteFileUploadServerErrorIsDeliveryUnknown(t *testing.T) {
+func TestCompleteFileUploadsServerErrorIsDeliveryUnknown(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/files.completeUploadExternal" {
@@ -120,12 +120,11 @@ func TestCompleteFileUploadServerErrorIsDeliveryUnknown(t *testing.T) {
 	}))
 	defer server.Close()
 
-	result, err := CompleteFileUpload(
+	result, err := CompleteFileUploads(
 		context.Background(),
 		slackTestClient(server),
 		MessageTarget{Channel: "C123", BotToken: "xoxb-test"},
-		"F123",
-		"report.txt",
+		[]UploadedFile{{ID: "F123", Title: "report.txt"}},
 		"here is the report",
 	)
 	if err != nil {

--- a/internal/integration/slack/files_test.go
+++ b/internal/integration/slack/files_test.go
@@ -2,12 +2,202 @@ package slack
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
 )
+
+func TestUploadFile(t *testing.T) {
+	content := []byte("artifact contents")
+	requests := make([]string, 0, 3)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.Path)
+		switch r.URL.Path {
+		case "/files.getUploadURLExternal":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("parse upload URL request: %v", err)
+			}
+			if r.Header.Get("Authorization") != "Bearer xoxb-test" ||
+				r.Form.Get("filename") != "report.txt" ||
+				r.Form.Get("length") != "17" {
+				t.Fatalf("upload URL request auth=%q form=%v", r.Header.Get("Authorization"), r.Form)
+			}
+			writeSlackTestJSON(w, map[string]any{
+				"ok":         true,
+				"upload_url": "https://files.slack.com/upload/v1/test",
+				"file_id":    "F123",
+			})
+		case "/upload/v1/test":
+			if auth := r.Header.Get("Authorization"); auth != "" {
+				t.Fatalf("file upload authorization = %q, want none", auth)
+			}
+			if r.Header.Get("Content-Type") != "application/octet-stream" || r.ContentLength != int64(len(content)) {
+				t.Fatalf("file upload content type=%q length=%d", r.Header.Get("Content-Type"), r.ContentLength)
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read file upload: %v", err)
+			}
+			if string(body) != string(content) {
+				t.Fatalf("file upload body = %q", body)
+			}
+			w.WriteHeader(http.StatusOK)
+		case "/files.completeUploadExternal":
+			if r.Header.Get("Authorization") != "Bearer xoxb-test" {
+				t.Fatalf("complete upload authorization = %q", r.Header.Get("Authorization"))
+			}
+			var payload struct {
+				Files []struct {
+					ID    string `json:"id"`
+					Title string `json:"title"`
+				} `json:"files"`
+				ChannelID      string `json:"channel_id"`
+				ThreadTS       string `json:"thread_ts"`
+				InitialComment string `json:"initial_comment"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode completion request: %v", err)
+			}
+			if len(payload.Files) != 1 || payload.Files[0].ID != "F123" || payload.Files[0].Title != "report.txt" ||
+				payload.ChannelID != "C123" || payload.ThreadTS != "111.222" ||
+				payload.InitialComment != "here is the report" {
+				t.Fatalf("completion payload = %+v", payload)
+			}
+			writeSlackTestJSON(w, map[string]any{"ok": true})
+		default:
+			t.Fatalf("unexpected Slack path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	fileID, result, err := UploadFile(
+		context.Background(),
+		slackTestClient(server),
+		MessageTarget{Channel: "C123", ThreadTS: "111.222", BotToken: "xoxb-test"},
+		"report.txt",
+		content,
+		allowFileUploadRequest,
+	)
+	if err != nil {
+		t.Fatalf("upload file: %v", err)
+	}
+	if fileID != "F123" || result != (APIResult{}) {
+		t.Fatalf("upload file id=%q result=%+v", fileID, result)
+	}
+	result, err = CompleteFileUpload(
+		context.Background(),
+		slackTestClient(server),
+		MessageTarget{Channel: "C123", ThreadTS: "111.222", BotToken: "xoxb-test"},
+		fileID,
+		"report.txt",
+		"here is the report",
+	)
+	if err != nil {
+		t.Fatalf("complete file upload: %v", err)
+	}
+	if result != (APIResult{}) {
+		t.Fatalf("completion result = %+v", result)
+	}
+	want := []string{"/files.getUploadURLExternal", "/upload/v1/test", "/files.completeUploadExternal"}
+	if strings.Join(requests, ",") != strings.Join(want, ",") {
+		t.Fatalf("requests = %v, want %v", requests, want)
+	}
+}
+
+func TestCompleteFileUploadServerErrorIsDeliveryUnknown(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/files.completeUploadExternal" {
+			t.Fatalf("unexpected Slack path %s", r.URL.Path)
+		}
+		requests++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	result, err := CompleteFileUpload(
+		context.Background(),
+		slackTestClient(server),
+		MessageTarget{Channel: "C123", BotToken: "xoxb-test"},
+		"F123",
+		"report.txt",
+		"here is the report",
+	)
+	if err != nil {
+		t.Fatalf("complete file upload: %v", err)
+	}
+	if !result.DeliveryUnknown || result.TransientFailure {
+		t.Fatalf("upload result = %+v, want delivery unknown", result)
+	}
+	if requests != 1 {
+		t.Fatalf("completion requests = %d, want 1", requests)
+	}
+}
+
+func TestUploadFileRejectsUnsafeUploadURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeSlackTestJSON(w, map[string]any{
+			"ok":         true,
+			"upload_url": "https://example.com/upload",
+			"file_id":    "F123",
+		})
+	}))
+	defer server.Close()
+
+	fileID, result, err := UploadFile(
+		context.Background(),
+		slackTestClient(server),
+		MessageTarget{Channel: "C123", BotToken: "xoxb-test"},
+		"report.txt",
+		[]byte("artifact contents"),
+		allowFileUploadRequest,
+	)
+	if err != nil {
+		t.Fatalf("upload file: %v", err)
+	}
+	if fileID != "" || !result.PermanentFailure || result.Code != "invalid_file_url" {
+		t.Fatalf("upload result = %+v", result)
+	}
+}
+
+func TestUploadFileContentHidesSignedURLOnTransportFailure(t *testing.T) {
+	result, err := uploadFileContent(
+		context.Background(),
+		&http.Client{Transport: failingUploadTransport{}},
+		"https://files.slack.com/upload/v1/signed-secret",
+		[]byte("artifact contents"),
+	)
+	if err != nil {
+		t.Fatalf("upload file content: %v", err)
+	}
+	if !result.DeliveryUnknown || result.Message != "Slack file upload request failed." {
+		t.Fatalf("upload result = %+v", result)
+	}
+}
+
+func TestFilePreShareResultExplainsMissingScope(t *testing.T) {
+	t.Parallel()
+	result := filePreShareResult(ErrorResult("missing_scope"))
+	if result.Code != "permanent_failure" || result.ProviderCode != "missing_scope" ||
+		result.Message != "Slack integration must be reauthorized with files:write before it can send artifacts." {
+		t.Fatalf("pre-share result = %+v", result)
+	}
+}
+
+type failingUploadTransport struct{}
+
+func (failingUploadTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("network down")
+}
+
+func allowFileUploadRequest(context.Context) error {
+	return nil
+}
 
 func TestDownloadEventFilesHydratesMissingPrivateURL(t *testing.T) {
 	t.Parallel()

--- a/internal/integration/slack/oauth.go
+++ b/internal/integration/slack/oauth.go
@@ -27,6 +27,7 @@ var RequiredBotScopes = []string{
 	"channels:history",
 	"channels:read",
 	"files:read",
+	"files:write",
 	"groups:history",
 	"groups:read",
 	"im:history",

--- a/internal/toolcatalog/catalog.go
+++ b/internal/toolcatalog/catalog.go
@@ -41,7 +41,7 @@ const (
 	sendIntegrationMessageToolDescription = "Send a user-visible message to the current integration target. " +
 		"When responding to a message received from an integration such as Slack, you must use this tool " +
 		"for every user-visible response, including progress updates, questions, and final answers. " +
-		"Optionally attach one artifact by its artifact_id. " +
+		"Attach one artifact by its artifact_id only when the response is intentionally sending that file. " +
 		"Normal assistant text is internal and is not delivered to the external user, so use this tool " +
 		"to communicate with them."
 	setIntegrationTargetToolDescription = "Set which integration target future integration messages " +
@@ -363,8 +363,7 @@ func integrationSendTool() (Entry, error) {
 			},
 			"artifact_id": map[string]any{
 				"type":        "string",
-				"minLength":   1,
-				"description": "Public artifact_id for one artifact owned by this agent to attach to the message.",
+				"description": "Use an exact artifact_id returned by Omnara; omit it or leave it empty for text-only messages.",
 			},
 		},
 	)

--- a/internal/toolcatalog/catalog.go
+++ b/internal/toolcatalog/catalog.go
@@ -41,6 +41,7 @@ const (
 	sendIntegrationMessageToolDescription = "Send a user-visible message to the current integration target. " +
 		"When responding to a message received from an integration such as Slack, you must use this tool " +
 		"for every user-visible response, including progress updates, questions, and final answers. " +
+		"Optionally attach one artifact by its artifact_id. " +
 		"Normal assistant text is internal and is not delivered to the external user, so use this tool " +
 		"to communicate with them."
 	setIntegrationTargetToolDescription = "Set which integration target future integration messages " +
@@ -359,6 +360,11 @@ func integrationSendTool() (Entry, error) {
 				"type":        "string",
 				"minLength":   1,
 				"description": "User-visible message text to send to the current integration target.",
+			},
+			"artifact_id": map[string]any{
+				"type":        "string",
+				"minLength":   1,
+				"description": "Public artifact_id for one artifact owned by this agent to attach to the message.",
 			},
 		},
 	)

--- a/internal/toolcatalog/catalog.go
+++ b/internal/toolcatalog/catalog.go
@@ -41,7 +41,7 @@ const (
 	sendIntegrationMessageToolDescription = "Send a user-visible message to the current integration target. " +
 		"When responding to a message received from an integration such as Slack, you must use this tool " +
 		"for every user-visible response, including progress updates, questions, and final answers. " +
-		"Attach one artifact by its artifact_id only when the response is intentionally sending that file. " +
+		"Attach artifacts by their artifact_ids only when the response is intentionally sending those files. " +
 		"Normal assistant text is internal and is not delivered to the external user, so use this tool " +
 		"to communicate with them."
 	setIntegrationTargetToolDescription = "Set which integration target future integration messages " +
@@ -361,9 +361,14 @@ func integrationSendTool() (Entry, error) {
 				"minLength":   1,
 				"description": "User-visible message text to send to the current integration target.",
 			},
-			"artifact_id": map[string]any{
-				"type":        "string",
-				"description": "Use an exact artifact_id returned by Omnara; omit it or leave it empty for text-only messages.",
+			"artifact_ids": map[string]any{
+				"type":     "array",
+				"maxItems": 20,
+				"items": map[string]any{
+					"type":      "string",
+					"minLength": 1,
+				},
+				"description": "Use exact artifact_ids returned by Omnara; omit this field or use an empty array for text-only messages.",
 			},
 		},
 	)


### PR DESCRIPTION
- allow send_integration_message to accept an optional artifact_id and load the referenced artifact within the active agent and project
- implement the Slack external file upload flow with signed URL validation, runtime ownership checks before each request, and phase-aware retry behavior
- request files:write for Slack installs and return actionable reconnect guidance when an existing installation lacks the scope
- update the built-in tool schema and documentation for artifact delivery
<img width="509" height="894" alt="image" src="https://github.com/user-attachments/assets/af9e2b6b-2046-4c62-ae09-28c0779d9114" />
