### PR TITLE
fix(auth): canonicalize email identity keys

### DIFF
--- a/internal/authn/password.go
+++ b/internal/authn/password.go
@@ -9,7 +9,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/omnara-ai/omnara/internal/emailaddr"
 	"golang.org/x/crypto/argon2"
+	"golang.org/x/text/unicode/norm"
 )
 
 const (
@@ -35,7 +37,7 @@ func (e PasswordPolicyError) Error() string {
 	return e.Reason
 }
 
-func ValidateNewPassword(password, normalizedEmail string) error {
+func ValidateNewPassword(password, email string) error {
 	if len(password) > MaxPasswordBytes {
 		return PasswordPolicyError{Reason: "password is too long"}
 	}
@@ -63,10 +65,18 @@ func ValidateNewPassword(password, normalizedEmail string) error {
 			Reason: "password must include at least one lowercase letter, one uppercase letter, one number, and one symbol",
 		}
 	}
-	lower := strings.ToLower(password)
-	normalizedEmail = strings.ToLower(strings.TrimSpace(normalizedEmail))
-	if normalizedEmail != "" && strings.Contains(lower, normalizedEmail) {
-		return PasswordPolicyError{Reason: "password must not include the email address"}
+	lowered := strings.ToLower(strings.TrimSpace(password))
+	haystacks := []string{lowered, norm.NFC.String(lowered)}
+	address := strings.ToLower(strings.TrimSpace(email))
+	for _, spelling := range []string{address, norm.NFC.String(address), emailaddr.Normalize(email)} {
+		if spelling == "" {
+			continue
+		}
+		for _, haystack := range haystacks {
+			if strings.Contains(haystack, spelling) {
+				return PasswordPolicyError{Reason: "password must not include the email address"}
+			}
+		}
 	}
 	return nil
 }

--- a/internal/authn/password_test.go
+++ b/internal/authn/password_test.go
@@ -147,6 +147,30 @@ func TestValidateNewPassword(t *testing.T) {
 			password: "Andes Mountain 1!",
 			email:    "an@corp.com",
 		},
+		{
+			name:     "contains unicode email as typed",
+			password: "xÜser@BÜCHER.example1!",
+			email:    "üser@bücher.example",
+			wantErr:  "password must not include the email address",
+		},
+		{
+			name:     "contains decomposed spelling of email",
+			password: "xu\u0308ser@bu\u0308cher.example1A!",
+			email:    "üser@bücher.example",
+			wantErr:  "password must not include the email address",
+		},
+		{
+			name:     "contains email followed by a combining mark",
+			password: "Owner@Example.com\u0301A1!",
+			email:    "owner@example.com",
+			wantErr:  "password must not include the email address",
+		},
+		{
+			name:     "contains punycode identity key of email",
+			password: "xüser@xn--bcher-kva.example1A!",
+			email:    "Üser@BÜCHER.example",
+			wantErr:  "password must not include the email address",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/emailaddr/emailaddr.go
+++ b/internal/emailaddr/emailaddr.go
@@ -1,0 +1,36 @@
+package emailaddr
+
+import (
+	"strings"
+
+	"golang.org/x/net/idna"
+)
+
+var domain = idna.New(idna.MapForLookup(), idna.BidiRule(), idna.VerifyDNSLength(true))
+
+func Normalize(email string) string {
+	trimmed := strings.TrimSpace(email)
+	at := strings.LastIndexByte(trimmed, '@')
+	if at <= 0 || at == len(trimmed)-1 {
+		return strings.ToLower(trimmed)
+	}
+	local, host := trimmed[:at], trimmed[at+1:]
+	ascii, err := domain.ToASCII(host)
+	if err != nil {
+		ascii = asciiLower(host)
+	}
+	return strings.ToLower(local) + "@" + ascii
+}
+
+func Equal(a, b string) bool {
+	return Normalize(a) == Normalize(b)
+}
+
+func asciiLower(text string) string {
+	return strings.Map(func(r rune) rune {
+		if 'A' <= r && r <= 'Z' {
+			return r + 'a' - 'A'
+		}
+		return r
+	}, text)
+}

--- a/internal/emailaddr/emailaddr_test.go
+++ b/internal/emailaddr/emailaddr_test.go
@@ -1,0 +1,163 @@
+package emailaddr
+
+import (
+	"math/rand/v2"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/idna"
+)
+
+func TestNormalize(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		email string
+		want  string
+	}{
+		{name: "ascii", email: " User+Tag@Example.COM ", want: "user+tag@example.com"},
+		{name: "unicode domain", email: "User@BÜCHER.example", want: "user@xn--bcher-kva.example"},
+		{name: "decomposed domain", email: "User@BU\u0308CHER.example", want: "user@xn--bcher-kva.example"},
+		{name: "punycode domain", email: "User@XN--BCHER-KVA.example", want: "user@xn--bcher-kva.example"},
+		{name: "ideographic dot", email: "User@Example。COM", want: "user@example.com"},
+		{name: "sharp s is not transitional", email: "user@straße.de", want: "user@xn--strae-oqa.de"},
+		{name: "capital sharp s maps per UTS 46", email: "user@STRAẞE.de", want: "user@strasse.de"},
+		{name: "dotted capital I composed", email: "user@İstanbul.com", want: "user@xn--istanbul-o0e.com"},
+		{name: "dotted capital I decomposed", email: "user@I\u0307stanbul.com", want: "user@xn--istanbul-o0e.com"},
+		{name: "unicode local is lowercased only", email: "Üser@Example.com", want: "üser@example.com"},
+		{name: "decomposed local is not recomposed", email: "U\u0308ser@Example.com", want: "u\u0308ser@example.com"},
+		{name: "invalid hostname keeps legacy key", email: "User@exa_mple.com", want: "user@exa_mple.com"},
+		{name: "empty label keeps legacy key", email: "user@a..b.com", want: "user@a..b.com"},
+		{name: "bare ace prefix label keeps legacy key", email: "user@xn--.example", want: "user@xn--.example"},
+		{name: "host that maps to nothing keeps legacy key", email: "user@\u00ad", want: "user@\u00ad"},
+		{
+			name:  "over-long label keeps legacy key",
+			email: "user@" + strings.Repeat("a", 64) + ".com",
+			want:  "user@" + strings.Repeat("a", 64) + ".com",
+		},
+		{
+			name:  "invalid unicode domain keeps spelling, ascii case folded",
+			email: "User@BÜCHER..Example",
+			want:  "user@bÜcher..example",
+		},
+		{name: "space before at is preserved", email: "a b @Example.com", want: "a b @example.com"},
+		{name: "space after at keeps legacy key", email: "User@ Example.com", want: "user@ example.com"},
+		{name: "missing local part", email: "@Example.com", want: "@example.com"},
+		{name: "missing domain", email: "User@", want: "user@"},
+		{name: "not an email", email: " Not-An-Email ", want: "not-an-email"},
+		{name: "empty", email: "", want: ""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := Normalize(test.email); got != test.want {
+				t.Fatalf("Normalize(%q) = %q, want %q", test.email, got, test.want)
+			}
+		})
+	}
+}
+
+func TestEqual(t *testing.T) {
+	t.Parallel()
+	same := [][2]string{
+		{"User@BÜCHER.example", "user@bücher.example"},
+		{"user@bücher.example", "user@bu\u0308cher.example"},
+		{"user@bücher.example", "user@xn--bcher-kva.example"},
+		{"Üser@example.com", "üser@example.com"},
+		{" user@example.com ", "USER@EXAMPLE.COM"},
+	}
+	for _, pair := range same {
+		if !Equal(pair[0], pair[1]) {
+			t.Errorf("Equal(%q, %q) = false, want true", pair[0], pair[1])
+		}
+	}
+	different := [][2]string{
+		{"user@example.com", "user@example.org"},
+		{"user@example.com", "other@example.com"},
+		{"user@example.com", "user@example.com."},
+		{"üser@example.com", "u\u0308ser@example.com"},
+	}
+	for _, pair := range different {
+		if Equal(pair[0], pair[1]) {
+			t.Errorf("Equal(%q, %q) = true, want false", pair[0], pair[1])
+		}
+	}
+}
+
+func TestNormalizeIsIdempotent(t *testing.T) {
+	t.Parallel()
+	alphabet := []rune("aZ09.-_+@ üÜ\u0308ßẞİ。中文\u0301ex")
+	r := rand.New(rand.NewPCG(7, 0))
+	for range 50000 {
+		runes := make([]rune, r.IntN(24))
+		for j := range runes {
+			runes[j] = alphabet[r.IntN(len(alphabet))]
+		}
+		input := string(runes)
+		once := Normalize(input)
+		if twice := Normalize(once); twice != once {
+			t.Fatalf("Normalize is not idempotent for %q: %q then %q", input, once, twice)
+		}
+	}
+}
+
+func asciiCorpus() []string {
+	const ldh = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-"
+	domains := []string{
+		"example.com", "EXAMPLE.COM", "example.com.", "-bad.com", "bad-.com", "ab--cd.com",
+		"xn--bcher-kva.example", "XN--BCHER-KVA.example", "xn--zzzz.example", "xn--.example",
+		"example.xn--", "a.xn--.b", "xn--", "a_b.com", "localhost", "1.2.3.4", "[1.2.3.4]",
+		"exa mple.com", "ex!ample.com", "", ".", "a..b.com", ".example.com",
+		strings.Repeat("a", 63) + ".com", strings.Repeat("a", 64) + ".com",
+		strings.Repeat("a.", 130) + "com",
+	}
+	r := rand.New(rand.NewPCG(1, 0))
+	for range 50000 {
+		labels := make([]string, 1+r.IntN(4))
+		for j := range labels {
+			label := make([]byte, 1+r.IntN(12))
+			for k := range label {
+				label[k] = ldh[r.IntN(len(ldh))]
+			}
+			if r.IntN(10) == 0 {
+				labels[j] = "xn--" + string(label)
+			} else {
+				labels[j] = string(label)
+			}
+		}
+		domains = append(domains, strings.Join(labels, "."))
+	}
+	return domains
+}
+
+func TestNormalizeASCIIIsFixedPoint(t *testing.T) {
+	t.Parallel()
+	locals := []string{"User+Tag", "a b", "a ", "\"quoted@part\"", "x.y_z-9", "A"}
+	for _, domain := range asciiCorpus() {
+		for _, local := range locals {
+			for _, input := range []string{" " + local + "@" + domain + " ", local + "@ " + domain} {
+				if got, want := Normalize(input), strings.ToLower(strings.TrimSpace(input)); got != want {
+					t.Fatalf("ASCII input %q changed: got %q, want %q", input, got, want)
+				}
+			}
+		}
+	}
+}
+
+func TestDomainProfileOnlyAddsFailuresToLookup(t *testing.T) {
+	t.Parallel()
+	inputs := append(asciiCorpus(),
+		"bücher.example", "BÜCHER.example", "bu\u0308cher.example", "straße.de", "STRAẞE.de",
+		"İstanbul.com", "I\u0307stanbul.com", "example。com", "\u0308example.com", "中文.中国",
+	)
+	for _, input := range inputs {
+		want, lookupErr := idna.Lookup.ToASCII(input)
+		got, err := domain.ToASCII(input)
+		if lookupErr != nil && err == nil {
+			t.Fatalf("domain profile accepted %q which idna.Lookup rejects: %v", input, lookupErr)
+		}
+		if err == nil && got != want {
+			t.Fatalf("domain profile ToASCII(%q) = %q, idna.Lookup = %q", input, got, want)
+		}
+	}
+}

--- a/internal/httpapi/auth/handler.go
+++ b/internal/httpapi/auth/handler.go
@@ -17,7 +17,7 @@ type Store interface {
 		context.Context,
 		identitystore.PasswordSignupStartInput,
 	) (identitystore.PasswordSignupStartRecord, error)
-	ActiveAuthTokenNormalizedEmail(context.Context, string, string) (string, error)
+	ActiveAuthTokenEmail(context.Context, string, string) (string, error)
 	CompletePasswordSignup(
 		context.Context,
 		identitystore.CompletePasswordSignupInput,

--- a/internal/httpapi/auth/oauth_routes.go
+++ b/internal/httpapi/auth/oauth_routes.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/omnara-ai/omnara/internal/emailaddr"
 	"github.com/omnara-ai/omnara/internal/httpapi/apierror"
 	"github.com/omnara-ai/omnara/internal/httpapi/openapi"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
@@ -284,7 +285,7 @@ func (h *Handler) oidcIdentity(
 			if userInfoClaims.Subject == "" || userInfoClaims.Subject != claims.Subject {
 				return externalIdentity{}, errors.New("oidc userinfo subject mismatch")
 			}
-			if claims.Email != "" && userInfoClaims.Email != "" && !strings.EqualFold(claims.Email, userInfoClaims.Email) {
+			if claims.Email != "" && userInfoClaims.Email != "" && !emailaddr.Equal(claims.Email, userInfoClaims.Email) {
 				return externalIdentity{}, errors.New("oidc userinfo email mismatch")
 			}
 			if claims.Email == "" {
@@ -292,7 +293,7 @@ func (h *Handler) oidcIdentity(
 				claims.EmailVerified = userInfoClaims.EmailVerified
 			} else if claims.EmailVerified == nil &&
 				userInfoClaims.Email != "" &&
-				strings.EqualFold(claims.Email, userInfoClaims.Email) {
+				emailaddr.Equal(claims.Email, userInfoClaims.Email) {
 				claims.EmailVerified = userInfoClaims.EmailVerified
 			}
 			if claims.Name == "" {

--- a/internal/httpapi/auth/password_routes.go
+++ b/internal/httpapi/auth/password_routes.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/omnara-ai/omnara/internal/authn"
+	"github.com/omnara-ai/omnara/internal/emailaddr"
 	"github.com/omnara-ai/omnara/internal/httpapi/apierror"
 	"github.com/omnara-ai/omnara/internal/httpapi/openapi"
 	"github.com/omnara-ai/omnara/internal/storage"
@@ -161,7 +162,7 @@ func (h *Handler) completeEmailVerificationRoute(w http.ResponseWriter, r *http.
 	) {
 		return
 	}
-	normalizedEmail, err := h.store.ActiveAuthTokenNormalizedEmail(
+	email, err := h.store.ActiveAuthTokenEmail(
 		r.Context(),
 		body.Token,
 		identitystore.UserAuthTokenPurposeEmailVerification,
@@ -170,7 +171,7 @@ func (h *Handler) completeEmailVerificationRoute(w http.ResponseWriter, r *http.
 		h.writeAuthTokenStorageError(w, r, err)
 		return
 	}
-	passwordHash, ok := passwordHashForNewPassword(w, body.Password, normalizedEmail)
+	passwordHash, ok := passwordHashForNewPassword(w, body.Password, email)
 	if !ok {
 		return
 	}
@@ -332,7 +333,7 @@ func (h *Handler) completePasswordResetRoute(w http.ResponseWriter, r *http.Requ
 	) {
 		return
 	}
-	normalizedEmail, err := h.store.ActiveAuthTokenNormalizedEmail(
+	email, err := h.store.ActiveAuthTokenEmail(
 		r.Context(),
 		body.Token,
 		identitystore.UserAuthTokenPurposePasswordReset,
@@ -341,7 +342,7 @@ func (h *Handler) completePasswordResetRoute(w http.ResponseWriter, r *http.Requ
 		h.writeAuthTokenStorageError(w, r, err)
 		return
 	}
-	passwordHash, ok := passwordHashForNewPassword(w, body.Password, normalizedEmail)
+	passwordHash, ok := passwordHashForNewPassword(w, body.Password, email)
 	if !ok {
 		return
 	}
@@ -414,7 +415,7 @@ func (h *Handler) changePasswordRoute(w http.ResponseWriter, r *http.Request) {
 		h.writeAuthServerError(w, r, err)
 		return
 	}
-	passwordHash, ok := passwordHashForNewPassword(w, body.NewPassword, email.NormalizedEmail)
+	passwordHash, ok := passwordHashForNewPassword(w, body.NewPassword, email.Email)
 	if !ok {
 		return
 	}
@@ -493,8 +494,8 @@ func (h *Handler) requirePublicAuthJSON(w http.ResponseWriter, r *http.Request) 
 	return true
 }
 
-func passwordHashForNewPassword(w http.ResponseWriter, password, normalizedEmail string) (string, bool) {
-	if err := authn.ValidateNewPassword(password, normalizedEmail); err != nil {
+func passwordHashForNewPassword(w http.ResponseWriter, password, email string) (string, bool) {
+	if err := authn.ValidateNewPassword(password, email); err != nil {
 		apierror.Write(w, openapi.ErrorCodeValidationFailed, err.Error())
 		return "", false
 	}
@@ -510,9 +511,9 @@ func normalizeAuthEmail(email string) (string, string, bool) {
 	trimmed := strings.TrimSpace(email)
 	parsed, err := mail.ParseAddress(trimmed)
 	if err != nil || parsed.Address != trimmed {
-		return "", identitystore.NormalizeEmail(email), false
+		return "", emailaddr.Normalize(email), false
 	}
-	return parsed.Address, identitystore.NormalizeEmail(parsed.Address), true
+	return parsed.Address, emailaddr.Normalize(parsed.Address), true
 }
 
 func padPublicAuthResponse(ctx context.Context, start time.Time) {

--- a/internal/httpapi/auth/password_routes_test.go
+++ b/internal/httpapi/auth/password_routes_test.go
@@ -42,3 +42,11 @@ func TestSafeSignupReturnToAllowsOnlyDeviceApproval(t *testing.T) {
 		}
 	}
 }
+
+func TestNormalizeAuthEmailCanonicalizesInternationalizedDomain(t *testing.T) {
+	t.Parallel()
+	email, normalized, valid := normalizeAuthEmail("User@BÜCHER.example")
+	if !valid || email != "User@BÜCHER.example" || normalized != "user@xn--bcher-kva.example" {
+		t.Fatalf("normalize auth email = (%q, %q, %t)", email, normalized, valid)
+	}
+}

--- a/internal/httpapi/org_members_route_integration_test.go
+++ b/internal/httpapi/org_members_route_integration_test.go
@@ -46,19 +46,17 @@ func TestListOrgMembers(t *testing.T) {
 		t.Fatalf("create split member: %v", err)
 	}
 	if _, err := store.Identity().CreateUserEmail(ctx, identitystore.CreateUserEmailInput{
-		UserID:          split.ID,
-		Email:           "members-split-primary@example.com",
-		NormalizedEmail: identitystore.NormalizeEmail("members-split-primary@example.com"),
-		IsPrimary:       true,
+		UserID:    split.ID,
+		Email:     "members-split-primary@example.com",
+		IsPrimary: true,
 	}); err != nil {
 		t.Fatalf("create split unverified primary email: %v", err)
 	}
 	if _, err := store.Identity().CreateUserEmail(ctx, identitystore.CreateUserEmailInput{
-		UserID:          split.ID,
-		Email:           "members-split-secondary@example.com",
-		NormalizedEmail: identitystore.NormalizeEmail("members-split-secondary@example.com"),
-		Verified:        true,
-		IsPrimary:       false,
+		UserID:    split.ID,
+		Email:     "members-split-secondary@example.com",
+		Verified:  true,
+		IsPrimary: false,
 	}); err != nil {
 		t.Fatalf("create split verified secondary email: %v", err)
 	}

--- a/internal/storage/identity_integration_test.go
+++ b/internal/storage/identity_integration_test.go
@@ -3105,6 +3105,37 @@ func TestOrgInvitationAcceptDoesNotChangeExistingMembership(t *testing.T) {
 	}
 }
 
+func TestOrgInvitationCanonicalizesInternationalizedDomain(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	pool := openIntegrationDB(t, ctx)
+	store := newIntegrationStore(pool)
+	seedDefaultProject(t, ctx, store)
+
+	user := mustCreateIdentityUser(t, ctx, store, "Invitee@BÜCHER.example", "Invitee")
+	invite, err := store.Identity().CreateOrgInvitation(
+		ctx,
+		identitystore.CreateOrgInvitationInput{
+			OrgID: testOrgID,
+			Email: "invitee@xn--bcher-kva.example",
+			Role:  "member",
+		},
+	)
+	if err != nil {
+		t.Fatalf("create invitation: %v", err)
+	}
+	if invite.NormalizedEmail != "invitee@xn--bcher-kva.example" {
+		t.Fatalf("invitation normalized email = %q, want canonical key", invite.NormalizedEmail)
+	}
+	accepted, err := store.Identity().AcceptOrgInvitation(
+		ctx,
+		identitystore.AcceptOrgInvitationInput{ID: invite.ID, UserID: user.ID},
+	)
+	if err != nil || accepted.ID != invite.ID {
+		t.Fatalf("accept invitation with unicode spelling: record=%+v err=%v", accepted, err)
+	}
+}
+
 func TestListOrgInvitationsPaginatesConsumedInvitesAway(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -3597,7 +3628,11 @@ func TestResolveTrustedAuthIdentityLinksExistingVerifiedEmail(t *testing.T) {
 	ctx := context.Background()
 	pool := openIntegrationDB(t, ctx)
 	store := newSecretIntegrationStore(pool)
-	existing := mustCreateIdentityUser(t, ctx, store, "same-email@example.com", "Existing")
+	const (
+		unicodeEmail   = "same-email@bücher.example"
+		canonicalEmail = "same-email@xn--bcher-kva.example"
+	)
+	existing := mustCreateIdentityUser(t, ctx, store, unicodeEmail, "Existing")
 	connector, err := store.Identity().UpsertAuthConnector(
 		ctx,
 		identitystore.CreateAuthConnectorInput{
@@ -3622,7 +3657,7 @@ func TestResolveTrustedAuthIdentityLinksExistingVerifiedEmail(t *testing.T) {
 			AuthConnectorID: connector.ID,
 			Issuer:          "https://idp.example.com",
 			Subject:         "subject-1",
-			Email:           "same-email@example.com",
+			Email:           canonicalEmail,
 			EmailVerified:   true,
 			DisplayName:     "OIDC User",
 		},
@@ -3640,7 +3675,7 @@ func TestResolveTrustedAuthIdentityLinksExistingVerifiedEmail(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list resolved user emails: %v", err)
 	}
-	if len(emails) != 1 || emails[0].Email != "same-email@example.com" {
+	if len(emails) != 1 || emails[0].Email != unicodeEmail {
 		t.Fatalf("resolved user emails = %+v, want existing verified email", emails)
 	}
 	replayed, err := resolveAuthIdentitySessionForTest(
@@ -3669,7 +3704,7 @@ func TestResolveTrustedAuthIdentityLinksExistingVerifiedEmail(t *testing.T) {
 			AuthConnectorID: connector.ID,
 			Issuer:          "https://other-idp.example.com",
 			Subject:         "subject-1",
-			Email:           "same-email@example.com",
+			Email:           unicodeEmail,
 			EmailVerified:   true,
 			DisplayName:     "OIDC User",
 		},
@@ -3686,7 +3721,7 @@ func TestResolveTrustedAuthIdentityLinksExistingVerifiedEmail(t *testing.T) {
 			AuthConnectorID: connector.ID,
 			Issuer:          "https://idp.example.com",
 			Subject:         "subject-2",
-			Email:           "same-email@example.com",
+			Email:           canonicalEmail,
 			EmailVerified:   true,
 			DisplayName:     "Second OIDC User",
 		},
@@ -3880,8 +3915,8 @@ func TestResolveTrustedAuthIdentityConcurrentFirstLinkSerializesEmailOwner(t *te
 	results := make(chan result, 2)
 	start := make(chan struct{})
 	for _, input := range []identitystore.ResolveAuthIdentityInput{
-		{AuthConnectorID: firstConnector.ID, Issuer: firstConnector.Issuer, Subject: "race-a", Email: "race@example.com", EmailVerified: true, DisplayName: "Race A"},
-		{AuthConnectorID: secondConnector.ID, Issuer: secondConnector.Issuer, Subject: "race-b", Email: "race@example.com", EmailVerified: true, DisplayName: "Race B"},
+		{AuthConnectorID: firstConnector.ID, Issuer: firstConnector.Issuer, Subject: "race-a", Email: "race@bücher.example", EmailVerified: true, DisplayName: "Race A"},
+		{AuthConnectorID: secondConnector.ID, Issuer: secondConnector.Issuer, Subject: "race-b", Email: "race@xn--bcher-kva.example", EmailVerified: true, DisplayName: "Race B"},
 	} {
 		input := input
 		go func() {
@@ -3903,7 +3938,7 @@ func TestResolveTrustedAuthIdentityConcurrentFirstLinkSerializesEmailOwner(t *te
 	if err := pool.QueryRow(ctx, `SELECT count(*) FROM users`).Scan(&userCount); err != nil {
 		t.Fatalf("count users: %v", err)
 	}
-	if err := pool.QueryRow(ctx, `SELECT count(*) FROM user_emails WHERE normalized_email = 'race@example.com' AND verified_at IS NOT NULL`).
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM user_emails WHERE normalized_email = 'race@xn--bcher-kva.example' AND verified_at IS NOT NULL`).
 		Scan(&emailCount); err != nil {
 		t.Fatalf("count verified race emails: %v", err)
 	}
@@ -5058,19 +5093,70 @@ func TestUserAuthTokenSchemaEnforcesEmailOwnership(t *testing.T) {
 	}
 }
 
+func TestPasswordSignupCanonicalizesInternationalizedDomain(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	pool := openIntegrationDB(t, ctx)
+	store := newIntegrationStore(pool)
+
+	const (
+		unicodeEmail   = "User@BÜCHER.example"
+		canonicalEmail = "user@xn--bcher-kva.example"
+		password       = "correct horse battery staple"
+	)
+	start, err := store.Identity().StartPasswordSignup(
+		ctx,
+		identitystore.PasswordSignupStartInput{Email: unicodeEmail},
+	)
+	if err != nil {
+		t.Fatalf("start signup: %v", err)
+	}
+	if start.Email.NormalizedEmail != canonicalEmail {
+		t.Fatalf("normalized email = %q, want %q", start.Email.NormalizedEmail, canonicalEmail)
+	}
+	passwordHash, err := authn.HashPassword(password)
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	completed, err := store.Identity().CompletePasswordSignup(
+		ctx,
+		identitystore.CompletePasswordSignupInput{Token: start.Token, PasswordHash: passwordHash},
+	)
+	if err != nil || !completed.Verified {
+		t.Fatalf("complete signup: record=%+v err=%v", completed, err)
+	}
+	user, err := authenticatePasswordForTest(t, ctx, store, "user@bu\u0308cher.example", password)
+	if err != nil {
+		t.Fatalf("authenticate with decomposed spelling: %v", err)
+	}
+	if user.ID != completed.User.ID {
+		t.Fatalf("authenticated user = %s, want %s", user.ID, completed.User.ID)
+	}
+	replay, err := store.Identity().StartPasswordSignup(
+		ctx,
+		identitystore.PasswordSignupStartInput{Email: canonicalEmail},
+	)
+	if err != nil {
+		t.Fatalf("repeat signup with punycode spelling: %v", err)
+	}
+	if !replay.EmailAlreadyVerified {
+		t.Fatalf("repeat signup = %+v, want existing verified identity", replay)
+	}
+}
+
 func TestPasswordSignupConcurrentVerificationFirstCommitWins(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	pool := openIntegrationDB(t, ctx)
 	store := newIntegrationStore(pool)
 
-	first, err := store.Identity().StartPasswordSignup(ctx, identitystore.PasswordSignupStartInput{Email: "race-signup@example.com"})
+	first, err := store.Identity().StartPasswordSignup(ctx, identitystore.PasswordSignupStartInput{Email: "race-signup@bu\u0308cher.example"})
 	if err != nil {
 		t.Fatalf("start first signup: %v", err)
 	}
 	second, err := store.Identity().StartPasswordSignup(
 		ctx,
-		identitystore.PasswordSignupStartInput{Email: "race-signup@example.com"},
+		identitystore.PasswordSignupStartInput{Email: "race-signup@xn--bcher-kva.example"},
 	)
 	if err != nil {
 		t.Fatalf("start second signup: %v", err)
@@ -5167,7 +5253,7 @@ func TestPasswordSignupConcurrentVerificationFirstCommitWins(t *testing.T) {
 		t,
 		ctx,
 		store,
-		"race-signup@example.com",
+		"race-signup@bücher.example",
 		winningPassword,
 	); err != nil {
 		t.Fatalf("authenticate winning password: %v", err)
@@ -5347,7 +5433,7 @@ WHERE user_id = $1 AND purpose = 'password_reset' AND consumed_at IS NULL`,
 	}
 	usable := 0
 	for _, record := range records {
-		if _, err := store.Identity().ActiveAuthTokenNormalizedEmail(
+		if _, err := store.Identity().ActiveAuthTokenEmail(
 			ctx,
 			record.Token,
 			identitystore.UserAuthTokenPurposePasswordReset,
@@ -5445,7 +5531,7 @@ func TestPasswordResetRequestAndCompletionSerialize(t *testing.T) {
 	if !request.record.Found || request.record.Token == "" {
 		t.Fatalf("password reset race request = %+v", request.record)
 	}
-	if _, err := store.Identity().ActiveAuthTokenNormalizedEmail(
+	if _, err := store.Identity().ActiveAuthTokenEmail(
 		ctx,
 		request.record.Token,
 		identitystore.UserAuthTokenPurposePasswordReset,

--- a/internal/storage/identitystore/identity_records.go
+++ b/internal/storage/identitystore/identity_records.go
@@ -97,11 +97,10 @@ type UserRecord struct {
 }
 
 type CreateUserEmailInput struct {
-	UserID          ID
-	Email           string
-	NormalizedEmail string
-	Verified        bool
-	IsPrimary       bool
+	UserID    ID
+	Email     string
+	Verified  bool
+	IsPrimary bool
 }
 
 type UserEmailRecord struct {

--- a/internal/storage/identitystore/org_invitations_store.go
+++ b/internal/storage/identitystore/org_invitations_store.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/omnara-ai/omnara/internal/authz"
+	"github.com/omnara-ai/omnara/internal/emailaddr"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
 	"github.com/omnara-ai/omnara/internal/storage/internal/resourceguard"
 	"github.com/omnara-ai/omnara/internal/storage/internal/storeutil"
@@ -30,7 +31,7 @@ func (s *Store) CreateOrgInvitation(
 	if input.Role != authz.OrgRoleAdmin && input.Role != authz.OrgRoleMember {
 		return OrgInvitationRecord{}, storeerr.InvalidRequest(errors.New("role must be admin or member"))
 	}
-	normalizedEmail := NormalizeEmail(input.Email)
+	normalizedEmail := emailaddr.Normalize(input.Email)
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return OrgInvitationRecord{}, fmt.Errorf("begin create org invitation: %w", err)

--- a/internal/storage/identitystore/password_auth_store.go
+++ b/internal/storage/identitystore/password_auth_store.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/omnara-ai/omnara/internal/authn"
+	"github.com/omnara-ai/omnara/internal/emailaddr"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
 	"github.com/omnara-ai/omnara/internal/storage/internal/storeutil"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
@@ -38,7 +39,7 @@ func (s *Store) StartPasswordSignup(
 	if input.Email == "" {
 		return PasswordSignupStartRecord{}, errors.New("email is required")
 	}
-	normalizedEmail := NormalizeEmail(input.Email)
+	normalizedEmail := emailaddr.Normalize(input.Email)
 	if _, err := s.q.GetVerifiedUserEmailByNormalizedEmail(
 		ctx,
 		dbsqlc.GetVerifiedUserEmailByNormalizedEmailParams{NormalizedEmail: normalizedEmail},
@@ -133,7 +134,7 @@ func (s *Store) CleanupInactiveAuthState(ctx context.Context) (AuthStateCleanupR
 	}, nil
 }
 
-func (s *Store) ActiveAuthTokenNormalizedEmail(
+func (s *Store) ActiveAuthTokenEmail(
 	ctx context.Context,
 	token, purpose string,
 ) (string, error) {
@@ -150,8 +151,8 @@ func (s *Store) ActiveAuthTokenNormalizedEmail(
 	if err != nil {
 		return "", fmt.Errorf("load active auth token: %w", err)
 	}
-	if row.NormalizedEmail != nil {
-		return *row.NormalizedEmail, nil
+	if row.Email != nil {
+		return *row.Email, nil
 	}
 	emails, err := s.q.ListVerifiedUserEmailsByUser(ctx, dbsqlc.ListVerifiedUserEmailsByUserParams{UserID: row.UserID})
 	if err != nil {
@@ -160,7 +161,7 @@ func (s *Store) ActiveAuthTokenNormalizedEmail(
 	if len(emails) == 0 {
 		return "", nil
 	}
-	return emails[0].NormalizedEmail, nil
+	return emails[0].Email, nil
 }
 
 func (s *Store) CompletePasswordSignup(
@@ -289,7 +290,7 @@ func (s *Store) AuthenticatePasswordAndCreateSession(
 	ctx context.Context,
 	input PasswordLoginSessionInput,
 ) (UserRecord, error) {
-	normalizedEmail := NormalizeEmail(input.Email)
+	normalizedEmail := emailaddr.Normalize(input.Email)
 	if normalizedEmail == "" || input.Password == "" {
 		authn.EqualizePasswordVerifyTiming(input.Password)
 		return UserRecord{}, storeerr.ErrUnauthorized
@@ -387,7 +388,7 @@ func (s *Store) StartPasswordReset(
 	ctx context.Context,
 	input PasswordResetStartInput,
 ) (PasswordResetStartRecord, error) {
-	normalizedEmail := NormalizeEmail(input.Email)
+	normalizedEmail := emailaddr.Normalize(input.Email)
 	if normalizedEmail == "" {
 		return PasswordResetStartRecord{}, nil
 	}

--- a/internal/storage/identitystore/users_memberships_store.go
+++ b/internal/storage/identitystore/users_memberships_store.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/omnara-ai/omnara/internal/authz"
+	"github.com/omnara-ai/omnara/internal/emailaddr"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
 	"github.com/omnara-ai/omnara/internal/storage/internal/skillops"
 	"github.com/omnara-ai/omnara/internal/storage/internal/storeutil"
@@ -34,13 +35,14 @@ func (s *Store) CreateUserEmail(
 	if input.Email == "" {
 		return UserEmailRecord{}, errors.New("email is required")
 	}
-	if input.NormalizedEmail == "" {
+	normalizedEmail := emailaddr.Normalize(input.Email)
+	if normalizedEmail == "" {
 		return UserEmailRecord{}, errors.New("normalized email is required")
 	}
 	row, err := s.q.CreateUserEmail(ctx, dbsqlc.CreateUserEmailParams{
 		UserID:          input.UserID,
 		Email:           input.Email,
-		NormalizedEmail: input.NormalizedEmail,
+		NormalizedEmail: normalizedEmail,
 		Verified:        input.Verified,
 		IsPrimary:       input.IsPrimary,
 	})
@@ -51,10 +53,6 @@ func (s *Store) CreateUserEmail(
 		return UserEmailRecord{}, fmt.Errorf("create user email: %w", err)
 	}
 	return userEmailRecordFromSQLC(row), nil
-}
-
-func NormalizeEmail(email string) string {
-	return strings.ToLower(strings.TrimSpace(email))
 }
 
 func isValidProjectRole(role string) bool {
@@ -155,7 +153,7 @@ func (s *Store) resolveAuthIdentityUser(
 	) {
 		return UserRecord{}, fmt.Errorf("load auth identity: %w", err)
 	}
-	normalizedEmail := NormalizeEmail(input.Email)
+	normalizedEmail := emailaddr.Normalize(input.Email)
 	if !input.EmailVerified || normalizedEmail == "" {
 		return UserRecord{}, storeerr.ErrUnauthorized
 	}

--- a/internal/storage/user_profile_integration_test.go
+++ b/internal/storage/user_profile_integration_test.go
@@ -132,19 +132,17 @@ func TestGetUserAndPrimaryVerifiedUserEmail(t *testing.T) {
 		t.Fatalf("create split user: %v", err)
 	}
 	if _, err := store.Identity().CreateUserEmail(ctx, identitystore.CreateUserEmailInput{
-		UserID:          splitUser.ID,
-		Email:           "unverified-primary@example.com",
-		NormalizedEmail: identitystore.NormalizeEmail("unverified-primary@example.com"),
-		IsPrimary:       true,
+		UserID:    splitUser.ID,
+		Email:     "unverified-primary@example.com",
+		IsPrimary: true,
 	}); err != nil {
 		t.Fatalf("create unverified primary email: %v", err)
 	}
 	if _, err := store.Identity().CreateUserEmail(ctx, identitystore.CreateUserEmailInput{
-		UserID:          splitUser.ID,
-		Email:           "verified-secondary@example.com",
-		NormalizedEmail: identitystore.NormalizeEmail("verified-secondary@example.com"),
-		Verified:        true,
-		IsPrimary:       false,
+		UserID:    splitUser.ID,
+		Email:     "verified-secondary@example.com",
+		Verified:  true,
+		IsPrimary: false,
 	}); err != nil {
 		t.Fatalf("create verified secondary email: %v", err)
 	}

--- a/internal/storage/verified_user_test_helper_test.go
+++ b/internal/storage/verified_user_test_helper_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/omnara-ai/omnara/internal/emailaddr"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
 	"github.com/omnara-ai/omnara/internal/storage/internal/storeutil"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
@@ -25,7 +26,7 @@ func (s *Store) CreateVerifiedUser(
 		return identitystore.UserRecord{}, errors.New("store is required")
 	}
 	email := strings.TrimSpace(input.Email)
-	normalizedEmail := identitystore.NormalizeEmail(email)
+	normalizedEmail := emailaddr.Normalize(email)
 	if normalizedEmail == "" {
 		return identitystore.UserRecord{}, errors.New("email is required")
 	}

--- a/internal/testutil/storagetest/users.go
+++ b/internal/testutil/storagetest/users.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/omnara-ai/omnara/internal/emailaddr"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
 )
 
@@ -23,7 +24,7 @@ func CreateVerifiedUser(
 		return identitystore.UserRecord{}, errors.New("pool is required")
 	}
 	email := strings.TrimSpace(input.Email)
-	normalizedEmail := identitystore.NormalizeEmail(email)
+	normalizedEmail := emailaddr.Normalize(email)
 	if normalizedEmail == "" {
 		return identitystore.UserRecord{}, errors.New("email is required")
 	}


### PR DESCRIPTION
## Summary

Email identity keys were `lower(trim(email))`, so the composed (`bücher.example`), decomposed (`bücher.example`) and Punycode (`xn--bcher-kva.example`) spellings of one internationalized address were **three different identities**: login and password reset with another spelling failed, invitations missed the invitee, and a second account could be verified for the same mailbox.

This PR makes the identity key canonical and derives it in exactly one place:

- **`internal/emailaddr.Normalize`** — domain: [UTS #46](https://www.unicode.org/reports/tr46/) non-transitional `ToASCII`, i.e. the A-label DNS resolves, lowercased — the comparison form [RFC 9598 §5.5](https://www.rfc-editor.org/rfc/rfc9598.html) prescribes for internationalized addresses. Local part: **lowercased and otherwise untouched.** RFC 9598 §5.7 says the local part "MUST NOT be transformed in any way, such as by doing case folding or normalization of any kind"; lowercasing is the pre-existing industry deviation this codebase already relied on and keeps, and nothing new (no NFC) is added — two spellings of a local part that a mail server *might* treat as different mailboxes must not be merged into one identity, because the OIDC link path would attach a login to the wrong account.
- **`emailaddr.Equal`** — same identity iff the canonical forms are byte-identical.
- **`CreateUserEmail` derives the key itself**; `CreateUserEmailInput.NormalizedEmail` is gone, so no caller can store a differently derived key.
- **Lookups stay single-key. No SQL, no generated code, no locking changes, no migration.**
- **One definition of "same address".** `emailaddr.Equal` replaces the `strings.EqualFold` comparison between OIDC id-token and userinfo emails. The password policy now receives the stored address (`ActiveAuthTokenNormalizedEmail` → `ActiveAuthTokenEmail`) and rejects a password containing either that address or its identity key, comparing both sides as lowercased text and as NFC-normalized text, so it never accepts a password the previous check rejected — strictly stronger than before.
- **Hostname rules.** The domain profile is `idna.Lookup` plus `VerifyDNSLength`, so a label that is only `xn--` is rejected (falls back) instead of decoding to an empty label and rewriting ASCII input. The domain is handed to UTS #46 unmodified so its own case mapping applies (`STRAẞE.de` → `strasse.de`, both spellings of `İstanbul.com` → one key), and an invalid domain keeps its spelling with only ASCII case folded, which makes `Normalize` idempotent by construction.

## Why no migration

Every pure-ASCII address is a fixed point of the new rule — its key is exactly `lower(trim(email))`. `TestNormalizeASCIIIsFixedPoint` checks 50k random LDH domains plus edge cases (trailing dot, leading/trailing hyphen, `ab--cd`, `_`, over-long labels, invalid `xn--`). A read-only audit of production found **0 of 1,072** `user_emails` and **0 of 6** `org_invitations` with a non-ASCII or Punycode key, and 0 rows whose stored key differs from `lower(trim(email))`. Every existing key is therefore unchanged, and every key written from now on is canonical. Re-run the audit immediately before release.

Supersedes #409, which reached the same key but kept a multi-key compatibility layer (4-key lookup fan-out, multi-key advisory locks, fail-closed ambiguity branches) for legacy rows that do not exist.

## Out of scope

Provider-level mailbox equivalence (Gmail dot/plus aliases) and signup abuse controls are policy, not identity canonicalization, and are deliberately not in this PR.

## Testing

- Static gates: fmt, go-modules, sqlc-check, sql-rules, migration-check, integration-packages-check, tagged-packages-check, golangci-lint — green
- Unit: `internal/emailaddr` (table incl. U+0130/U+1E9E/`xn--` cases and decomposed fixtures written as explicit `\u0308`/`\u0307` escapes; properties: 50k-input ASCII fixed point over varied local parts and domains incl. `xn--` labels, idempotency, domain profile only adds failures to `idna.Lookup`; `Equal` incl. decomposed-vs-composed domain equal, decomposed-vs-composed local part not equal), `internal/authn` (password may not contain the address as typed, decomposed, as its Punycode key, or followed by a combining mark — the last pins that nothing the old check rejected is now accepted), `internal/httpapi/auth`
- Integration (PostgreSQL 18.6): `make test-integration-storage`, `make test-integration-httpapi`
  - new: `TestPasswordSignupCanonicalizesInternationalizedDomain`, `TestOrgInvitationCanonicalizesInternationalizedDomain`
  - the two concurrency races (`…ConcurrentVerificationFirstCommitWins`, `…ConcurrentFirstLinkSerializesEmailOwner`) and the OIDC link test now use mixed Unicode/Punycode spellings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
