### PR TITLE
fix(auth): onboard users without an organization before CLI approval

### DIFF
--- a/frontend/apps/web/src/lib/require-organization.test.ts
+++ b/frontend/apps/web/src/lib/require-organization.test.ts
@@ -1,0 +1,40 @@
+import type { CurrentUser } from '@omnara/sdk'
+import { isRedirect } from '@tanstack/react-router'
+import { describe, expect, it } from 'vitest'
+
+import { requireOrganization } from '@/lib/require-organization'
+
+function user(orgCount: number): CurrentUser {
+  return {
+    orgs: Array.from({ length: orgCount }, (_, index) => ({
+      id: `org_${index}`,
+      name: `Org ${index}`,
+    })),
+  } as unknown as CurrentUser
+}
+
+function redirectHref(run: () => void): string {
+  try {
+    run()
+  } catch (error) {
+    if (isRedirect(error)) return (error as { options: { href: string } }).options.href
+    throw error
+  }
+  throw new Error('expected a redirect')
+}
+
+describe('requireOrganization', () => {
+  it('lets organization members through', () => {
+    expect(() => {
+      requireOrganization(user(1), '/device?user_code=ABCDE-F1234')
+    }).not.toThrow()
+  })
+
+  it('sends users without an organization to onboarding and preserves their destination', () => {
+    expect(
+      redirectHref(() => {
+        requireOrganization(user(0), '/device?user_code=ABCDE-F1234')
+      }),
+    ).toBe('/onboarding?return_to=%2Fdevice%3Fuser_code%3DABCDE-F1234')
+  })
+})

--- a/frontend/apps/web/src/lib/require-organization.ts
+++ b/frontend/apps/web/src/lib/require-organization.ts
@@ -1,0 +1,9 @@
+import type { CurrentUser } from '@omnara/sdk'
+import { redirect } from '@tanstack/react-router'
+
+export function requireOrganization(me: CurrentUser, returnTo: string): void {
+  if (me.orgs.length > 0) return
+  const search = returnTo === '/' ? '' : `?return_to=${encodeURIComponent(returnTo)}`
+  // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router throws redirects.
+  throw redirect({ href: `/onboarding${search}` })
+}

--- a/frontend/apps/web/src/router.tsx
+++ b/frontend/apps/web/src/router.tsx
@@ -12,6 +12,8 @@ import {
 import { Suspense } from 'react'
 
 import { FullPageSpinner } from '@/components/ui/spinner'
+import { safeReturnTo } from '@/lib/auth-return-to'
+import { requireOrganization } from '@/lib/require-organization'
 import { RootError } from '@/routes/RootError'
 
 export interface RouterContext {
@@ -57,12 +59,8 @@ const authenticatedRoute = createRoute({
 const onboardedRoute = createRoute({
   getParentRoute: () => authenticatedRoute,
   id: 'onboarded',
-  beforeLoad: ({ context }) => {
-    const { me } = context
-    if (me.orgs.length === 0) {
-      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router throws redirects.
-      throw redirect({ href: '/onboarding' })
-    }
+  beforeLoad: ({ context, location }) => {
+    requireOrganization(context.me, location.href)
   },
   component: lazyRouteComponent(() => import('@/routes/AuthedLayout'), 'AuthedLayout'),
 })
@@ -172,17 +170,20 @@ const agentRoute = createRoute({
 const deviceAuthRoute = createRoute({
   getParentRoute: () => authenticatedRoute,
   path: '/device',
+  beforeLoad: ({ context, location }) => {
+    requireOrganization(context.me, location.href)
+  },
   component: lazyRouteComponent(() => import('@/routes/DeviceAuth'), 'DeviceAuth'),
 })
 
 const onboardingRoute = createRoute({
   getParentRoute: () => authenticatedRoute,
   path: '/onboarding',
-  beforeLoad: ({ context }) => {
-    const { me } = context
-    if (me.orgs.length > 0) {
+  beforeLoad: ({ context, location }) => {
+    if (context.me.orgs.length > 0) {
+      const returnTo = new URL(location.href, window.location.origin).searchParams.get('return_to')
       // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router throws redirects.
-      throw redirect({ href: '/' })
+      throw redirect({ href: safeReturnTo(returnTo) })
     }
   },
   component: lazyRouteComponent(() => import('@/routes/Onboarding'), 'Onboarding'),

--- a/frontend/apps/web/src/routes/Onboarding.test.tsx
+++ b/frontend/apps/web/src/routes/Onboarding.test.tsx
@@ -11,6 +11,7 @@ const hooks = vi.hoisted(() => ({
   createOrganization: vi.fn(),
   declineInvitation: vi.fn(),
   refetchInvitations: vi.fn(),
+  pendingInvitations: [] as unknown[],
 }))
 
 vi.mock('@omnara/react', () => ({
@@ -18,7 +19,7 @@ vi.mock('@omnara/react', () => ({
   useCreateOrganization: () => ({ mutateAsync: hooks.createOrganization }),
   useDeclineInvitation: () => ({ mutateAsync: hooks.declineInvitation }),
   usePendingInvitations: () => ({
-    data: { data: [] },
+    data: { data: hooks.pendingInvitations },
     refetch: hooks.refetchInvitations,
   }),
 }))
@@ -79,6 +80,7 @@ beforeEach(() => {
   hooks.createOrganization.mockReset()
   hooks.declineInvitation.mockReset()
   hooks.refetchInvitations.mockReset()
+  hooks.pendingInvitations.length = 0
   hooks.createOrganization.mockImplementation(() => new Promise(() => undefined))
   window.history.replaceState(null, '', '/onboarding')
 
@@ -103,6 +105,76 @@ describe('Onboarding organization creation', () => {
     await submitOrganization()
 
     expect(hooks.createOrganization).toHaveBeenCalledOnce()
+    expect(window.location.pathname).toBe('/')
+  })
+
+  it('returns to the device approval page it was sent from after creating the organization', async () => {
+    window.history.replaceState(
+      null,
+      '',
+      '/onboarding?return_to=%2Fdevice%3Fuser_code%3DABCDE-F1234',
+    )
+    hooks.createOrganization.mockResolvedValueOnce(undefined)
+    renderOnboarding()
+
+    expect(container.textContent).toContain(
+      'Create your organization, then we will bring you back to approve the CLI login.',
+    )
+
+    setOrganizationName('Acme Inc.')
+    await submitOrganization()
+
+    expect(window.location.pathname).toBe('/device')
+    expect(window.location.search).toBe('?user_code=ABCDE-F1234')
+  })
+
+  it('returns to the device approval page after accepting an invitation', async () => {
+    window.history.replaceState(
+      null,
+      '',
+      '/onboarding?return_to=%2Fdevice%3Fuser_code%3DABCDE-F1234',
+    )
+    const invitation = {
+      id: 'inv_1',
+      org_id: 'org_1',
+      org_name: 'Acme Inc.',
+      email: 'person@example.com',
+      org_role: 'member',
+      created_at: '2026-01-01T00:00:00Z',
+    }
+    hooks.pendingInvitations.push(invitation)
+    hooks.acceptInvitation.mockResolvedValueOnce(invitation)
+    renderOnboarding()
+
+    const accept = Array.from(container.querySelectorAll('button')).find(
+      (candidate) => candidate.textContent.trim() === 'Accept',
+    )
+    if (!accept) throw new Error('Missing Accept button')
+    await act(async () => {
+      accept.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(hooks.acceptInvitation).toHaveBeenCalledWith('inv_1')
+    expect(window.location.pathname).toBe('/device')
+    expect(window.location.search).toBe('?user_code=ABCDE-F1234')
+  })
+
+  it('ignores an unsafe return destination', async () => {
+    const host = window.location.host
+    window.history.replaceState(
+      null,
+      '',
+      '/onboarding?return_to=https%3A%2F%2Fevil.example%2Fsteal',
+    )
+    hooks.createOrganization.mockResolvedValueOnce(undefined)
+    renderOnboarding()
+    setOrganizationName('Acme Inc.')
+
+    await submitOrganization()
+
+    expect(window.location.host).toBe(host)
     expect(window.location.pathname).toBe('/')
   })
 

--- a/frontend/apps/web/src/routes/Onboarding.tsx
+++ b/frontend/apps/web/src/routes/Onboarding.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Field, FieldGroup, FieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import { ResourceNameFieldError } from '@/components/ui/resource-name-error'
+import { isDeviceApprovalReturnTo, safeReturnTo } from '@/lib/auth-return-to'
 import { resourceNameValid } from '@/lib/resource-name'
 import { errorMessage } from '@/lib/submit-status'
 
@@ -28,6 +29,8 @@ export function Onboarding() {
   const { data } = usePendingInvitations()
   const pending = data.data
   const createOrganization = useCreateOrganization()
+  const returnTo = safeReturnTo(new URLSearchParams(window.location.search).get('return_to'))
+  const approvingDevice = isDeviceApprovalReturnTo(returnTo)
 
   const [state, setState] = useState<OnboardingState>(initialOnboardingState)
   const creating = state.action.kind === 'creating'
@@ -41,7 +44,7 @@ export function Onboarding() {
         body: { name: state.name },
         idempotencyKey: state.idempotencyKey,
       })
-      window.location.assign('/')
+      window.location.assign(returnTo)
     } catch (err) {
       setState((prev) => ({
         ...prev,
@@ -62,8 +65,11 @@ export function Onboarding() {
           <h1 className="text-2xl font-semibold tracking-tight">Welcome to Omnara</h1>
           <p className="text-muted-foreground text-sm">
             {pending.length > 0
-              ? 'Accept an invitation or create your own organization to get started.'
-              : 'Create your organization to get started.'}
+              ? 'Accept an invitation or create your own organization'
+              : 'Create your organization'}
+            {approvingDevice
+              ? ', then we will bring you back to approve the CLI login.'
+              : ' to get started.'}
           </p>
         </div>
 
@@ -73,7 +79,7 @@ export function Onboarding() {
           <PendingInvitationList
             invitations={pending}
             onAccepted={() => {
-              window.location.assign('/')
+              window.location.assign(returnTo)
             }}
           />
         )}

--- a/frontend/packages/cli/src/config.ts
+++ b/frontend/packages/cli/src/config.ts
@@ -183,7 +183,7 @@ export function registerConfigCommand(program: Command, cli: CliConfig): void {
           throw new CliInputError('interactive selection needs a terminal')
         }
         await cli.ensureLoggedIn()
-        const orgId = await promptOrgSelection(cli.client)
+        const orgId = await promptOrgSelection(cli.client, cli.issuerUrl)
         const projectId = await promptProjectSelection(cli.client, orgId)
         updateConfigFile({ org_id: orgId, project_id: projectId })
         printConfig()

--- a/frontend/packages/cli/src/device-login.ts
+++ b/frontend/packages/cli/src/device-login.ts
@@ -131,6 +131,7 @@ export interface DeviceLoginResult {
   token: string
   orgId?: string
   projectId?: string
+  hasOrganizations?: boolean
 }
 
 export async function loginWithDevice(options: DeviceLoginOptions): Promise<DeviceLoginResult> {
@@ -169,11 +170,13 @@ export async function loginWithDevice(options: DeviceLoginOptions): Promise<Devi
   const client = createOmnaraClient({ baseUrl: options.apiUrl, auth: bearerToken(token) })
   let orgId = saved.org_id
   let projectId = saved.project_id
+  let hasOrganizations: boolean | undefined
   let loginMessage = 'Logged in'
   let validationWarning: string | undefined
   try {
     const { data: me } = await sdk.getCurrentUser({ client })
     loginMessage = `Logged in as ${me.user.email || me.user.display_name}`
+    hasOrganizations = me.orgs.length > 0
     if (orgId !== undefined && !me.orgs.some((org) => org.id === orgId)) {
       updateConfigFile({ org_id: undefined, project_id: undefined })
       orgId = undefined
@@ -199,5 +202,5 @@ export async function loginWithDevice(options: DeviceLoginOptions): Promise<Devi
   if (process.env.OMNARA_API_KEY !== undefined) {
     report.warn('OMNARA_API_KEY is set and takes precedence over the saved token')
   }
-  return { token, orgId, projectId }
+  return { token, orgId, projectId, hasOrganizations }
 }

--- a/frontend/packages/cli/src/factory.ts
+++ b/frontend/packages/cli/src/factory.ts
@@ -114,7 +114,7 @@ interface ConfigParam {
   configKey: 'org_id' | 'project_id'
   describe: string
   resolve: (config: CliConfig, path: Record<string, unknown>) => string | undefined
-  prompt: (client: OmnaraClient, path: Record<string, unknown>) => Promise<string>
+  prompt: (config: CliConfig, path: Record<string, unknown>) => Promise<string>
 }
 
 const CONFIG_PARAMS: ConfigParam[] = [
@@ -125,7 +125,7 @@ const CONFIG_PARAMS: ConfigParam[] = [
     configKey: 'org_id',
     describe: 'pass --org or set OMNARA_ORG_ID',
     resolve: (config) => config.defaultOrgId,
-    prompt: (client) => promptOrgSelection(client),
+    prompt: (config) => promptOrgSelection(config.client, config.issuerUrl),
   },
   {
     key: 'projectID',
@@ -137,12 +137,12 @@ const CONFIG_PARAMS: ConfigParam[] = [
       path.orgID === undefined || path.orgID === config.defaultOrgId
         ? config.defaultProjectId
         : undefined,
-    prompt: (client, path) => {
+    prompt: (config, path) => {
       const orgId = path.orgID
       if (typeof orgId !== 'string') {
         throw new CliInputError('cannot select a project before an organization is set')
       }
-      return promptProjectSelection(client, orgId)
+      return promptProjectSelection(config.client, orgId)
     },
   },
 ]
@@ -315,7 +315,7 @@ async function resolvePathValues(
     usedExplicitOverride = usedExplicitOverride || explicit !== undefined
     let value = explicit ?? param.resolve(config, path)
     if (value === undefined && canPromptInteractively()) {
-      value = await param.prompt(config.client, path)
+      value = await param.prompt(config, path)
       if (!usedExplicitOverride) saveConfigDefault(param.configKey, value)
     }
     if (value === undefined) {

--- a/frontend/packages/cli/src/interactive.ts
+++ b/frontend/packages/cli/src/interactive.ts
@@ -26,10 +26,12 @@ async function selectFrom(message: string, choices: Choice[]): Promise<string> {
   return picked
 }
 
-export async function promptOrgSelection(client: OmnaraClient): Promise<string> {
+export async function promptOrgSelection(client: OmnaraClient, issuerUrl: string): Promise<string> {
   const { data } = await sdk.getCurrentUser({ client })
   if (data.orgs.length === 0) {
-    throw new CliInputError('this account has no organizations')
+    throw new CliInputError(
+      `this account has no organizations; create one at ${new URL('/onboarding', issuerUrl).toString()}`,
+    )
   }
   return selectFrom(
     'Select an organization',

--- a/frontend/packages/cli/src/login.test.ts
+++ b/frontend/packages/cli/src/login.test.ts
@@ -13,7 +13,7 @@ const mocks = vi.hoisted(() => ({
     Promise.resolve({
       data: {
         user: { email: 'person@example.com', display_name: 'Person' },
-        orgs: [],
+        orgs: [] as { id: string; name: string }[],
       },
     }),
   ),
@@ -121,7 +121,12 @@ describe('loginWithDevice', () => {
       },
     })
 
-    expect(result).toEqual({ token: 'omnara_pat_v1_test', orgId: undefined, projectId: undefined })
+    expect(result).toEqual({
+      token: 'omnara_pat_v1_test',
+      orgId: undefined,
+      projectId: undefined,
+      hasOrganizations: false,
+    })
     expect(mocks.updateConfigFile).toHaveBeenCalledWith({
       org_id: undefined,
       project_id: undefined,
@@ -182,6 +187,36 @@ describe('login', () => {
 
     expect(mocks.startDeviceAuth).not.toHaveBeenCalled()
     expect(mocks.pollDeviceAuthToken).not.toHaveBeenCalled()
+  })
+
+  it('points an account without organizations to browser onboarding', async () => {
+    const program = new Command()
+    const cli = testConfig('https://self-hosted.example/api/v1', 'https://self-hosted.example')
+    registerLoginCommand(program, cli)
+
+    await program.parseAsync(['node', 'omnara', 'login', '--no-browser'])
+
+    expect(console.log).toHaveBeenCalledWith(
+      "This account has no organization yet. Create one at https://self-hosted.example/onboarding, then run 'omnara config select'.",
+    )
+  })
+
+  it('asks an account with organizations but no default to run config select', async () => {
+    const program = new Command()
+    const cli = testConfig('https://self-hosted.example/api/v1', 'https://self-hosted.example')
+    mocks.getCurrentUser.mockResolvedValueOnce({
+      data: {
+        user: { email: 'person@example.com', display_name: 'Person' },
+        orgs: [{ id: 'org_00000000000000000000000001', name: 'Acme' }],
+      },
+    })
+    registerLoginCommand(program, cli)
+
+    await program.parseAsync(['node', 'omnara', 'login', '--no-browser'])
+
+    expect(console.log).toHaveBeenCalledWith(
+      "Run 'omnara config select' to choose a default organization and project.",
+    )
   })
 
   it('keeps the login successful when account validation fails', async () => {

--- a/frontend/packages/cli/src/login.ts
+++ b/frontend/packages/cli/src/login.ts
@@ -19,14 +19,18 @@ export function registerLoginCommand(program: Command, cli: CliConfig): void {
     .action(async (options: LoginOptions) => {
       await runCliAction(async () => {
         const report = createLoginReporter(`Log in to ${cli.issuerUrl}`)
-        const { orgId } = await loginWithDevice({
+        const { orgId, hasOrganizations } = await loginWithDevice({
           apiUrl: cli.apiUrl,
           issuerUrl: cli.issuerUrl,
           browser: options.browser,
           tokenName: options.tokenName,
           report,
         })
-        if ((process.env.OMNARA_ORG_ID ?? orgId) === undefined) {
+        if (hasOrganizations === false) {
+          report.finish(
+            `This account has no organization yet. Create one at ${new URL('/onboarding', cli.issuerUrl).toString()}, then run 'omnara config select'.`,
+          )
+        } else if ((process.env.OMNARA_ORG_ID ?? orgId) === undefined) {
           report.finish("Run 'omnara config select' to choose a default organization and project.")
         } else {
           report.finish()


### PR DESCRIPTION
## Summary

`npx omnara login` for a user with no organization ended in a dead end: the browser approved the CLI, the CLI saved a token, and every subsequent command failed with `this account has no organizations`. In production, 86 of the 99 org-less users signed up in the last 14 days and 61 of them already hold a CLI token — this is the CLI-first onboarding path.

**Cause.** `/device` is an authenticated route but was not behind the organization gate (`onboardedRoute`), so it was the one page a brand-new user could reach without ever being sent to `/onboarding`. The gate also dropped context (`/onboarding` with no `return_to`), and onboarding always finished at `/`.

**Fix — browser onboarding, then device approval.**
- `requireOrganization(me, returnTo)` (new, unit-tested) redirects org-less users to `/onboarding?return_to=…`, mirroring the existing login gate. It is used by the app shell **and** by `/device`.
- `/onboarding` reads `return_to` through the existing `safeReturnTo` (same-origin relative paths only) and returns there after creating an organization **or** accepting an invitation; its "already has an org" guard also honors it. Copy explains the round-trip when a device approval is pending.
- CLI: `login` tells an org-less account to create one at `<issuer>/onboarding` and then run `config select`; `config select` says the same instead of the bare error. Defense in depth only — the browser gate is the fix.

**What does not change.** No server code. The device grant carries no organization; the CLI keeps the `device_code`; the browser carries only the short-lived `user_code` that is designed to travel in `verification_uri_complete`. Organization membership stays application state. Users who already have an organization see no change.

## Testing

- `pnpm run typecheck`, `lint`, `format:check`, `build` — green
- `apps/web`: 187 tests (new: `require-organization.test.ts`; `Onboarding.test.tsx` covers return after create, return after accept, unsafe `return_to` ignored, device-aware copy)
- `packages/cli`: 35 tests (new: no-organization guidance; has-organization message unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
