### PR TITLE
fix: Ignore macOS metadata entries in skill archives

### DIFF
--- a/internal/skills/archive.go
+++ b/internal/skills/archive.go
@@ -259,6 +259,9 @@ func ReplaceSkillMd(format ArchiveFormat, raw []byte, skillMd string) ([]byte, e
 			if err != nil {
 				return nil, err
 			}
+			if isMacOSMetadata(cleaned) {
+				continue
+			}
 			if err := budget.accountEntry(cleaned); err != nil {
 				return nil, err
 			}
@@ -296,6 +299,9 @@ func ReplaceSkillMd(format ArchiveFormat, raw []byte, skillMd string) ([]byte, e
 			cleaned, err := cleanEntryPath(header.Name)
 			if err != nil {
 				return nil, err
+			}
+			if isMacOSMetadata(cleaned) {
+				continue
 			}
 			if err := budget.accountEntry(cleaned); err != nil {
 				return nil, err
@@ -353,6 +359,9 @@ func readZipEntries(raw []byte) ([]archiveEntry, error) {
 		cleaned, err := cleanEntryPath(file.Name)
 		if err != nil {
 			return nil, err
+		}
+		if isMacOSMetadata(cleaned) {
+			continue
 		}
 		entry := archiveEntry{Path: cleaned}
 		switch {
@@ -438,6 +447,9 @@ func readTarGzEntries(raw []byte) ([]archiveEntry, error) {
 		default:
 			return nil, fmt.Errorf("unsupported tar entry type %q for %q", string(header.Typeflag), header.Name)
 		}
+		if isMacOSMetadata(cleaned) {
+			continue
+		}
 		entries = append(entries, entry)
 	}
 	return entries, nil
@@ -461,6 +473,15 @@ func cleanEntryPath(raw string) (string, error) {
 		}
 	}
 	return cleaned, nil
+}
+
+func isMacOSMetadata(cleaned string) bool {
+	segments := strings.Split(cleaned, "/")
+	if segments[0] == "__MACOSX" {
+		return true
+	}
+	last := segments[len(segments)-1]
+	return last == ".DS_Store" || strings.HasPrefix(last, "._")
 }
 
 func validateAndExtract(format ArchiveFormat, entries []archiveEntry) (Metadata, error) {
@@ -657,6 +678,9 @@ func extractZip(raw []byte, absDst string) error {
 		if err != nil {
 			return err
 		}
+		if isMacOSMetadata(cleaned) {
+			continue
+		}
 		if err := budget.accountEntry(cleaned); err != nil {
 			return err
 		}
@@ -702,6 +726,9 @@ func extractTarGz(raw []byte, absDst string) error {
 		cleaned, err := cleanEntryPath(header.Name)
 		if err != nil {
 			return err
+		}
+		if isMacOSMetadata(cleaned) {
+			continue
 		}
 		if err := budget.accountEntry(cleaned); err != nil {
 			return err

--- a/internal/skills/archive.go
+++ b/internal/skills/archive.go
@@ -300,11 +300,14 @@ func ReplaceSkillMd(format ArchiveFormat, raw []byte, skillMd string) ([]byte, e
 			if err != nil {
 				return nil, err
 			}
-			if isMacOSMetadata(cleaned) {
-				continue
-			}
 			if err := budget.accountEntry(cleaned); err != nil {
 				return nil, err
+			}
+			if isMacOSMetadata(cleaned) {
+				if err := skipTarEntry(budget, cleaned, header); err != nil {
+					return nil, err
+				}
+				continue
 			}
 			switch header.Typeflag {
 			case tar.TypeDir:
@@ -473,6 +476,13 @@ func cleanEntryPath(raw string) (string, error) {
 		}
 	}
 	return cleaned, nil
+}
+
+func skipTarEntry(budget *extractionBudget, cleaned string, header *tar.Header) error {
+	if header.Typeflag != tar.TypeReg {
+		return nil
+	}
+	return budget.accountFileSize(cleaned, header.Size)
 }
 
 func isMacOSMetadata(cleaned string) bool {
@@ -727,11 +737,14 @@ func extractTarGz(raw []byte, absDst string) error {
 		if err != nil {
 			return err
 		}
-		if isMacOSMetadata(cleaned) {
-			continue
-		}
 		if err := budget.accountEntry(cleaned); err != nil {
 			return err
+		}
+		if isMacOSMetadata(cleaned) {
+			if err := skipTarEntry(budget, cleaned, header); err != nil {
+				return err
+			}
+			continue
 		}
 		segments := strings.SplitN(cleaned, "/", 2)
 		if root == "" {

--- a/internal/skills/archive_test.go
+++ b/internal/skills/archive_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -484,4 +485,72 @@ func (zeroReader) Read(p []byte) (int, error) {
 		p[i] = 0
 	}
 	return len(p), nil
+}
+
+func TestExtractMetadataIgnoresMacOSMetadata(t *testing.T) {
+	raw := buildZip(t, map[string]string{
+		"pdf-tools/SKILL.md":                      sampleSkillMd,
+		"pdf-tools/.DS_Store":                     "junk",
+		"pdf-tools/scripts/extract.py":            "print('hi')\n",
+		"__MACOSX/._pdf-tools":                    "junk",
+		"__MACOSX/pdf-tools/._SKILL.md":           "junk",
+		"__MACOSX/pdf-tools/scripts/._extract.py": "junk",
+	})
+	meta, err := ExtractMetadata(FormatZip, raw)
+	if err != nil {
+		t.Fatalf("ExtractMetadata: %v", err)
+	}
+	if meta.RootDir != "pdf-tools" {
+		t.Fatalf("RootDir = %q", meta.RootDir)
+	}
+	files, err := ListFiles(FormatZip, raw)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	var paths []string
+	for _, f := range files {
+		paths = append(paths, f.Path)
+	}
+	if want := []string{"SKILL.md", "scripts/extract.py"}; !slices.Equal(paths, want) {
+		t.Fatalf("ListFiles = %v, want %v", paths, want)
+	}
+	dst := filepath.Join(t.TempDir(), "skill")
+	if err := ExtractInto(FormatZip, raw, dst); err != nil {
+		t.Fatalf("ExtractInto: %v", err)
+	}
+	for _, rel := range []string{".DS_Store", "../__MACOSX"} {
+		if _, err := os.Stat(filepath.Join(dst, rel)); !os.IsNotExist(err) {
+			t.Fatalf("%s should not be extracted: %v", rel, err)
+		}
+	}
+	rewritten, err := ReplaceSkillMd(FormatZip, raw, sampleSkillMd)
+	if err != nil {
+		t.Fatalf("ReplaceSkillMd: %v", err)
+	}
+	entries, err := readZipEntries(rewritten)
+	if err != nil {
+		t.Fatalf("readZipEntries: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("rewritten archive has %d entries, want 2", len(entries))
+	}
+}
+
+func TestExtractMetadataTarGzIgnoresMacOSMetadata(t *testing.T) {
+	raw := buildTarGz(t, map[string]string{
+		"pdf-tools/SKILL.md":            sampleSkillMd,
+		"pdf-tools/._SKILL.md":          "junk",
+		"pdf-tools/.DS_Store":           "junk",
+		"__MACOSX/pdf-tools/._SKILL.md": "junk",
+	})
+	if _, err := ExtractMetadata(FormatTarGz, raw); err != nil {
+		t.Fatalf("ExtractMetadata: %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "skill")
+	if err := ExtractInto(FormatTarGz, raw, dst); err != nil {
+		t.Fatalf("ExtractInto: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "._SKILL.md")); !os.IsNotExist(err) {
+		t.Fatalf("._SKILL.md should not be extracted: %v", err)
+	}
 }

--- a/internal/skills/archive_test.go
+++ b/internal/skills/archive_test.go
@@ -554,3 +554,39 @@ func TestExtractMetadataTarGzIgnoresMacOSMetadata(t *testing.T) {
 		t.Fatalf("._SKILL.md should not be extracted: %v", err)
 	}
 }
+
+func buildTarGzBomb(t *testing.T, name string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	payloadSize := int64(MaxExtractedBytes) + 1024
+	hdr := &tar.Header{Name: name, Mode: 0o644, Size: payloadSize, Typeflag: tar.TypeReg}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("bomb tar header: %v", err)
+	}
+	if _, err := io.CopyN(tw, &zeroReader{}, payloadSize); err != nil {
+		t.Fatalf("bomb tar write: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("bomb tar close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("bomb gz close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestTarGzMacOSMetadataBombIsRejected(t *testing.T) {
+	raw := buildTarGzBomb(t, "__MACOSX/pdf-tools/._SKILL.md")
+	if _, err := ExtractMetadata(FormatTarGz, raw); !errors.Is(err, errExtractionLimitExceeded) {
+		t.Fatalf("ExtractMetadata: expected extraction-limit error, got %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "skill")
+	if err := ExtractInto(FormatTarGz, raw, dst); !errors.Is(err, errExtractionLimitExceeded) {
+		t.Fatalf("ExtractInto: expected extraction-limit error, got %v", err)
+	}
+	if _, err := ReplaceSkillMd(FormatTarGz, raw, sampleSkillMd); !errors.Is(err, errExtractionLimitExceeded) {
+		t.Fatalf("ReplaceSkillMd: expected extraction-limit error, got %v", err)
+	}
+}


### PR DESCRIPTION
Finder-compressed zips carry a __MACOSX/ resource-fork directory alongside the skill directory, which tripped the single-top-level-directory check. Skip __MACOSX/, .DS_Store, and AppleDouble ._ entries when reading, extracting, listing, or rewriting a skill archive.