### PR TITLE
fix: explain MCP tool names that exceed the model limit

### DIFF
--- a/frontend/apps/web/src/components/agents/AgentConfigMcpServerTools.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigMcpServerTools.tsx
@@ -10,10 +10,13 @@ import {
 import { useState } from 'react'
 
 import { mcpServerToolsRequest } from '@/components/agents/mcpServerToolsRequest'
-import type {
-  BasicMcpServer,
-  BasicMcpTool,
-  McpAuthType,
+import {
+  type BasicMcpServer,
+  type BasicMcpTool,
+  type McpAuthType,
+  mcpRuntimeToolName,
+  mcpRuntimeToolNameError,
+  mcpRuntimeToolNameMaxLength,
 } from '@/components/agents/useAgentBuilderForm'
 import { SearchIcon, Trash2Icon, TriangleAlert } from '@/components/icons'
 import { Button } from '@/components/ui/button'
@@ -72,8 +75,13 @@ export function AgentConfigMcpServerTools({
   const typedName = query.trim()
   const typedNameAddable =
     mcpToolNamePattern.test(typedName) &&
+    mcpRuntimeToolNameError(server.name, typedName) === undefined &&
     !overriddenNames.has(typedName) &&
     !discoveredByName.has(typedName)
+  const unexposableTools = discovered.flatMap((tool) => {
+    const error = mcpRuntimeToolNameError(server.name, tool.name)
+    return error === undefined ? [] : [{ name: tool.name, error }]
+  })
 
   function addOverride(name: string) {
     if (overriddenNames.has(name)) return
@@ -297,6 +305,9 @@ export function AgentConfigMcpServerTools({
           </div>
         )}
       </div>
+      {unexposableTools.length > 0 && (
+        <UnexposableTools serverName={server.name} tools={unexposableTools} />
+      )}
       {discovery.isError && (authType !== 'none' || detectedAuthType(discovery.error) == null) && (
         <DiscoveryFailure
           error={discovery.error}
@@ -351,6 +362,44 @@ function DiscoveryFailure({
       >
         {switchable ? (detected === 'oauth' ? 'Use OAuth' : 'Use bearer secret') : 'Retry'}
       </Button>
+    </div>
+  )
+}
+
+function UnexposableTools({
+  serverName,
+  tools,
+}: {
+  serverName: string
+  tools: { name: string; error: string }[]
+}) {
+  const longestToolName = Math.max(...tools.map((tool) => tool.name.length))
+  const maxServerNameLength =
+    mcpRuntimeToolNameMaxLength - mcpRuntimeToolName('', '').length - longestToolName
+  return (
+    <div role="alert" className="text-destructive flex items-start gap-2 text-sm">
+      <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+      <div className="min-w-0 flex-1 space-y-1">
+        <p className="font-medium">
+          {tools.length === 1
+            ? 'One tool cannot be exposed to the model, so the agent will fail to connect to this server.'
+            : `${tools.length} tools cannot be exposed to the model, so the agent will fail to connect to this server.`}
+        </p>
+        <p className="text-muted-foreground">
+          Omnara names MCP tools <code className="font-mono">mcp__{serverName}__&lt;tool&gt;</code>,
+          and the full name must be {mcpRuntimeToolNameMaxLength} characters or fewer.{' '}
+          {maxServerNameLength >= 1
+            ? `Shorten the server name to ${maxServerNameLength} characters or fewer.`
+            : 'Some tool names are too long to expose under any server name.'}
+        </p>
+        <ul className="text-muted-foreground list-disc space-y-0.5 pl-5">
+          {tools.map((tool) => (
+            <li key={tool.name} className="break-all font-mono text-xs">
+              {tool.name}
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   )
 }

--- a/frontend/apps/web/src/components/agents/AgentConfigMcpServerTools.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigMcpServerTools.tsx
@@ -9,6 +9,7 @@ import {
 } from '@omnara/sdk'
 import { useState } from 'react'
 
+import { AgentConfigMcpToolOverrideList } from '@/components/agents/AgentConfigMcpToolOverrideList'
 import { mcpServerToolsRequest } from '@/components/agents/mcpServerToolsRequest'
 import {
   type BasicMcpServer,
@@ -17,8 +18,9 @@ import {
   mcpRuntimeToolName,
   mcpRuntimeToolNameError,
   mcpRuntimeToolNameMaxLength,
+  mcpToolEnabled,
 } from '@/components/agents/useAgentBuilderForm'
-import { SearchIcon, Trash2Icon, TriangleAlert } from '@/components/icons'
+import { SearchIcon, TriangleAlert } from '@/components/icons'
 import { Button } from '@/components/ui/button'
 import {
   Combobox,
@@ -29,17 +31,8 @@ import {
   ComboboxLoading,
 } from '@/components/ui/combobox'
 import { Field, FieldLabel } from '@/components/ui/field'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useDebouncedValue } from '@/hooks/use-resource-list'
 
-const inheritValue = 'inherit'
 const mcpToolNamePattern = /^[a-zA-Z][a-zA-Z0-9_-]{0,63}$/
 
 export function AgentConfigMcpServerTools({
@@ -57,45 +50,25 @@ export function AgentConfigMcpServerTools({
   onToolsChange: (tools: BasicMcpTool[]) => void
   onAuthTypeChange: (authType: McpAuthType) => void
 }) {
-  const { authType } = server
   const request = parseRequestKey(useDebouncedValue(JSON.stringify(mcpServerToolsRequest(server))))
   const discovery = useMcpServerTools(orgId, projectId, request, {
     onError: (error) => {
       const detected = detectedAuthType(error)
-      if (authType === 'none' && detected != null) onAuthTypeChange(detected)
+      if (server.authType === 'none' && detected != null) onAuthTypeChange(detected)
     },
   })
-  const [query, setQuery] = useState('')
-  const [openDescription, setOpenDescription] = useState<string | null>(null)
-
   const discovered = discovery.data?.tools ?? []
-  const discoveredByName = new Map(discovered.map((tool) => [tool.name, tool]))
   const overriddenNames = new Set(server.tools.map((tool) => tool.name))
-  const candidates = discovered.filter((tool) => !overriddenNames.has(tool.name))
-  const typedName = query.trim()
-  const typedNameAddable =
-    mcpToolNamePattern.test(typedName) &&
-    mcpRuntimeToolNameError(server.name, typedName) === undefined &&
-    !overriddenNames.has(typedName) &&
-    !discoveredByName.has(typedName)
   const unexposableTools = discovered.flatMap((tool) => {
+    if (!mcpToolEnabled(server, tool.name)) return []
     const error = mcpRuntimeToolNameError(server.name, tool.name)
     return error === undefined ? [] : [{ name: tool.name, error }]
   })
-
-  function addOverride(name: string) {
-    if (overriddenNames.has(name)) return
-    onToolsChange([...server.tools, { name, enabled: null, permission: null }])
-    setQuery('')
-  }
-
-  function updateOverride(name: string, patch: Partial<Omit<BasicMcpTool, 'name'>>) {
-    onToolsChange(server.tools.map((tool) => (tool.name === name ? { ...tool, ...patch } : tool)))
-  }
-
   const toolCountLabel = discovery.isSuccess
     ? `${discovered.length} ${discovered.length === 1 ? 'tool' : 'tools'}`
     : null
+  const discoveryFailure = visibleDiscoveryFailure(discovery, server.authType)
+
   return (
     <Field>
       <FieldLabel htmlFor={`${server.id}-tool-override`}>
@@ -106,211 +79,30 @@ export function AgentConfigMcpServerTools({
         </span>
       </FieldLabel>
       <div className="rounded-md border">
-        <Combobox
-          items={candidates}
-          inputValue={query}
-          onInputValueChange={(value, details) => {
-            if (details.reason === 'input-change' || details.reason === 'input-clear') {
-              setQuery(value)
-            }
+        <ToolOverridePicker
+          inputId={`${server.id}-tool-override`}
+          discovered={discovered}
+          overriddenNames={overriddenNames}
+          discovering={discovery.isPending && request != null}
+          toolCountLabel={toolCountLabel}
+          onAdd={(name) => {
+            onToolsChange([...server.tools, { name, enabled: null, permission: null }])
           }}
-          value={null}
-          onValueChange={(tool: McpServerTool | null) => {
-            if (tool) addOverride(tool.name)
-          }}
-          itemToStringLabel={(tool: McpServerTool) => tool.name}
-          itemToStringValue={(tool: McpServerTool) => tool.name}
-          isItemEqualToValue={(tool: McpServerTool, other: McpServerTool) =>
-            tool.name === other.name
-          }
-          filter={(tool: McpServerTool, search: string) => {
-            const needle = search.trim().toLowerCase()
-            return (
-              needle === '' ||
-              tool.name.toLowerCase().includes(needle) ||
-              (tool.title?.toLowerCase().includes(needle) ?? false) ||
-              (tool.description?.toLowerCase().includes(needle) ?? false)
-            )
-          }}
-        >
-          <div className="bg-muted/40 relative border-b">
-            <SearchIcon className="text-muted-foreground pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2" />
-            <ComboboxPrimitive.Input
-              id={`${server.id}-tool-override`}
-              className="placeholder:text-muted-foreground pointer-coarse:text-base h-11 w-full bg-transparent pl-10 pr-3 text-base outline-none md:text-sm"
-              placeholder={
-                toolCountLabel == null
-                  ? 'Add a tool override'
-                  : `Add a tool override — search ${toolCountLabel}`
-              }
-              onKeyDown={(event) => {
-                if (event.key === 'Enter' && typedNameAddable) {
-                  event.preventDefault()
-                  addOverride(typedName)
-                }
-              }}
-            />
-          </div>
-          <ComboboxContent>
-            <ComboboxEmpty>
-              {discovery.isPending && request != null
-                ? null
-                : typedNameAddable
-                  ? `Press Enter to add "${typedName}"`
-                  : candidates.length === 0 && discovered.length > 0
-                    ? 'Every discovered tool already has an override.'
-                    : 'No tools match.'}
-            </ComboboxEmpty>
-            <ComboboxList>
-              {(tool: McpServerTool) => (
-                <ComboboxItem key={tool.name} value={tool}>
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate font-mono text-xs">{tool.name}</div>
-                    {tool.description && (
-                      <div className="text-muted-foreground line-clamp-2 text-xs">
-                        {tool.description}
-                      </div>
-                    )}
-                  </div>
-                </ComboboxItem>
-              )}
-            </ComboboxList>
-            {discovery.isPending && request != null && (
-              <ComboboxLoading label="Discovering tools…" />
-            )}
-          </ComboboxContent>
-        </Combobox>
-        {server.tools.length === 0 ? (
-          <p className="text-muted-foreground px-4 py-3 text-sm">
-            {toolCountLabel == null
-              ? 'No overrides.'
-              : `No overrides — all ${toolCountLabel} follow the settings above.`}
-          </p>
-        ) : (
-          <div className="divide-y">
-            {server.tools.map((tool) => {
-              const description = discoveredByName.get(tool.name)?.description
-              return (
-                <div
-                  key={tool.name}
-                  className="flex flex-wrap items-center gap-2 px-3 py-2 sm:flex-nowrap sm:gap-3"
-                >
-                  <div
-                    className="-my-2 flex min-w-0 flex-1 basis-full items-center self-stretch py-2 sm:basis-auto"
-                    onPointerEnter={() => {
-                      setOpenDescription(tool.name)
-                    }}
-                    onPointerLeave={() => {
-                      setOpenDescription(null)
-                    }}
-                  >
-                    {description ? (
-                      <Tooltip open={openDescription === tool.name}>
-                        <TooltipTrigger asChild>
-                          <button
-                            type="button"
-                            className="bg-muted block max-w-full cursor-default truncate rounded-md px-2 py-1 text-left font-mono text-xs outline-none focus-visible:ring-2"
-                            aria-label={`About ${tool.name}`}
-                            onFocus={() => {
-                              setOpenDescription(tool.name)
-                            }}
-                            onBlur={() => {
-                              setOpenDescription(null)
-                            }}
-                          >
-                            {tool.name}
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent
-                          side="right"
-                          className="max-w-sm px-4 py-2 text-sm leading-relaxed"
-                        >
-                          {description}
-                        </TooltipContent>
-                      </Tooltip>
-                    ) : (
-                      <span className="bg-muted truncate rounded-md px-2 py-1 font-mono text-xs">
-                        {tool.name}
-                      </span>
-                    )}
-                  </div>
-                  <Select
-                    value={tool.enabled == null ? inheritValue : String(tool.enabled)}
-                    onValueChange={(value) => {
-                      updateOverride(tool.name, {
-                        enabled: value === inheritValue ? null : value === 'true',
-                      })
-                    }}
-                  >
-                    <SelectTrigger
-                      size="sm"
-                      className="min-w-0 flex-1 sm:w-36 sm:flex-none"
-                      aria-label={`${tool.name} enabled`}
-                    >
-                      <SelectValue>
-                        {tool.enabled == null ? 'Default' : tool.enabled ? 'Enabled' : 'Disabled'}
-                      </SelectValue>
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={inheritValue}>Default</SelectItem>
-                      <SelectItem value="true">Enabled</SelectItem>
-                      <SelectItem value="false">Disabled</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <Select
-                    value={tool.permission?.mode ?? inheritValue}
-                    disabled={permissionProfile == null}
-                    onValueChange={(mode) => {
-                      updateOverride(tool.name, {
-                        permission: mode === inheritValue ? null : { mode, parameters: {} },
-                      })
-                    }}
-                  >
-                    <SelectTrigger
-                      size="sm"
-                      className="min-w-0 flex-1 sm:w-40 sm:flex-none"
-                      aria-label={`${tool.name} permission`}
-                    >
-                      <SelectValue>
-                        {tool.permission == null
-                          ? 'Default'
-                          : permissionModeLabel(permissionProfile, tool.permission.mode)}
-                      </SelectValue>
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={inheritValue}>Default</SelectItem>
-                      {permissionProfile?.permission_modes.map((mode) => (
-                        <SelectItem key={mode.name} value={mode.name}>
-                          {mode.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="ghost"
-                    aria-label={`Remove ${tool.name} override`}
-                    onClick={() => {
-                      onToolsChange(
-                        server.tools.filter((candidate) => candidate.name !== tool.name),
-                      )
-                    }}
-                  >
-                    <Trash2Icon />
-                  </Button>
-                </div>
-              )
-            })}
-          </div>
-        )}
+        />
+        <AgentConfigMcpToolOverrideList
+          tools={server.tools}
+          discovered={discovered}
+          permissionProfile={permissionProfile}
+          toolCountLabel={toolCountLabel}
+          onToolsChange={onToolsChange}
+        />
       </div>
       {unexposableTools.length > 0 && (
         <UnexposableTools serverName={server.name} tools={unexposableTools} />
       )}
-      {discovery.isError && (authType !== 'none' || detectedAuthType(discovery.error) == null) && (
+      {discoveryFailure && (
         <DiscoveryFailure
-          error={discovery.error}
+          error={discoveryFailure}
           server={server}
           onRetry={() => {
             void discovery.refetch()
@@ -320,6 +112,136 @@ export function AgentConfigMcpServerTools({
       )}
     </Field>
   )
+}
+
+function ToolOverridePicker({
+  inputId,
+  discovered,
+  overriddenNames,
+  discovering,
+  toolCountLabel,
+  onAdd,
+}: {
+  inputId: string
+  discovered: McpServerTool[]
+  overriddenNames: Set<string>
+  discovering: boolean
+  toolCountLabel: string | null
+  onAdd: (name: string) => void
+}) {
+  const [query, setQuery] = useState('')
+  const candidates = discovered.filter((tool) => !overriddenNames.has(tool.name))
+  const typedName = query.trim()
+  const typedNameAddable =
+    mcpToolNamePattern.test(typedName) &&
+    !overriddenNames.has(typedName) &&
+    !discovered.some((tool) => tool.name === typedName)
+
+  function addOverride(name: string) {
+    if (overriddenNames.has(name)) return
+    onAdd(name)
+    setQuery('')
+  }
+
+  return (
+    <Combobox
+      items={candidates}
+      inputValue={query}
+      onInputValueChange={(value, details) => {
+        if (details.reason === 'input-change' || details.reason === 'input-clear') {
+          setQuery(value)
+        }
+      }}
+      value={null}
+      onValueChange={(tool: McpServerTool | null) => {
+        if (tool) addOverride(tool.name)
+      }}
+      itemToStringLabel={(tool: McpServerTool) => tool.name}
+      itemToStringValue={(tool: McpServerTool) => tool.name}
+      isItemEqualToValue={(tool: McpServerTool, other: McpServerTool) => tool.name === other.name}
+      filter={matchesToolSearch}
+    >
+      <div className="bg-muted/40 relative border-b">
+        <SearchIcon className="text-muted-foreground pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2" />
+        <ComboboxPrimitive.Input
+          id={inputId}
+          className="placeholder:text-muted-foreground pointer-coarse:text-base h-11 w-full bg-transparent pl-10 pr-3 text-base outline-none md:text-sm"
+          placeholder={
+            toolCountLabel == null
+              ? 'Add a tool override'
+              : `Add a tool override — search ${toolCountLabel}`
+          }
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && typedNameAddable) {
+              event.preventDefault()
+              addOverride(typedName)
+            }
+          }}
+        />
+      </div>
+      <ComboboxContent>
+        <ComboboxEmpty>
+          {discovering
+            ? null
+            : emptyMessage({
+                typedName: typedNameAddable ? typedName : null,
+                candidates,
+                discovered,
+              })}
+        </ComboboxEmpty>
+        <ComboboxList>
+          {(tool: McpServerTool) => (
+            <ComboboxItem key={tool.name} value={tool}>
+              <div className="min-w-0 flex-1">
+                <div className="truncate font-mono text-xs">{tool.name}</div>
+                {tool.description && (
+                  <div className="text-muted-foreground line-clamp-2 text-xs">
+                    {tool.description}
+                  </div>
+                )}
+              </div>
+            </ComboboxItem>
+          )}
+        </ComboboxList>
+        {discovering && <ComboboxLoading label="Discovering tools…" />}
+      </ComboboxContent>
+    </Combobox>
+  )
+}
+
+function matchesToolSearch(tool: McpServerTool, search: string) {
+  const needle = search.trim().toLowerCase()
+  return (
+    needle === '' ||
+    tool.name.toLowerCase().includes(needle) ||
+    (tool.title?.toLowerCase().includes(needle) ?? false) ||
+    (tool.description?.toLowerCase().includes(needle) ?? false)
+  )
+}
+
+function emptyMessage({
+  typedName,
+  candidates,
+  discovered,
+}: {
+  typedName: string | null
+  candidates: McpServerTool[]
+  discovered: McpServerTool[]
+}) {
+  if (typedName != null) return `Press Enter to add "${typedName}"`
+  if (candidates.length === 0 && discovered.length > 0) {
+    return 'Every discovered tool already has an override.'
+  }
+  return 'No tools match.'
+}
+
+function visibleDiscoveryFailure(
+  discovery: ReturnType<typeof useMcpServerTools>,
+  authType: McpAuthType,
+) {
+  if (!discovery.isError) return null
+  if (authType !== 'none') return discovery.error
+  return detectedAuthType(discovery.error) == null ? discovery.error : null
 }
 
 function parseRequestKey(key: string): McpServerToolsRequest | null {
@@ -389,8 +311,8 @@ function UnexposableTools({
           Omnara names MCP tools <code className="font-mono">mcp__{serverName}__&lt;tool&gt;</code>,
           and the full name must be {mcpRuntimeToolNameMaxLength} characters or fewer.{' '}
           {maxServerNameLength >= 1
-            ? `Shorten the server name to ${maxServerNameLength} characters or fewer.`
-            : 'Some tool names are too long to expose under any server name.'}
+            ? `Shorten the server name to ${maxServerNameLength} characters or fewer, or disable these tools.`
+            : 'Some tool names are too long to expose under any server name, so disable them.'}
         </p>
         <ul className="text-muted-foreground list-disc space-y-0.5 pl-5">
           {tools.map((tool) => (
@@ -432,8 +354,4 @@ function discoveryFailureTitle(
     return 'The selected secret is not available to this project.'
   }
   return 'Could not discover tools.'
-}
-
-function permissionModeLabel(profile: ToolPermissionProfile | undefined, value: string) {
-  return profile?.permission_modes.find((mode) => mode.name === value)?.label ?? value
 }

--- a/frontend/apps/web/src/components/agents/AgentConfigMcpServerTools.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigMcpServerTools.tsx
@@ -15,10 +15,9 @@ import {
   type BasicMcpServer,
   type BasicMcpTool,
   type McpAuthType,
-  mcpRuntimeToolName,
-  mcpRuntimeToolNameError,
-  mcpRuntimeToolNameMaxLength,
-  mcpToolEnabled,
+  mcpToolNameAddable,
+  type UnexposableMcpTool,
+  unexposableMcpTools,
 } from '@/components/agents/useAgentBuilderForm'
 import { SearchIcon, TriangleAlert } from '@/components/icons'
 import { Button } from '@/components/ui/button'
@@ -32,8 +31,6 @@ import {
 } from '@/components/ui/combobox'
 import { Field, FieldLabel } from '@/components/ui/field'
 import { useDebouncedValue } from '@/hooks/use-resource-list'
-
-const mcpToolNamePattern = /^[a-zA-Z][a-zA-Z0-9_-]{0,63}$/
 
 export function AgentConfigMcpServerTools({
   orgId,
@@ -59,11 +56,10 @@ export function AgentConfigMcpServerTools({
   })
   const discovered = discovery.data?.tools ?? []
   const overriddenNames = new Set(server.tools.map((tool) => tool.name))
-  const unexposableTools = discovered.flatMap((tool) => {
-    if (!mcpToolEnabled(server, tool.name)) return []
-    const error = mcpRuntimeToolNameError(server.name, tool.name)
-    return error === undefined ? [] : [{ name: tool.name, error }]
-  })
+  const unexposableTools = unexposableMcpTools(
+    server,
+    discovered.map((tool) => tool.name),
+  )
   const toolCountLabel = discovery.isSuccess
     ? `${discovered.length} ${discovered.length === 1 ? 'tool' : 'tools'}`
     : null
@@ -97,9 +93,7 @@ export function AgentConfigMcpServerTools({
           onToolsChange={onToolsChange}
         />
       </div>
-      {unexposableTools.length > 0 && (
-        <UnexposableTools serverName={server.name} tools={unexposableTools} />
-      )}
+      {unexposableTools.length > 0 && <UnexposableTools tools={unexposableTools} />}
       {discoveryFailure && (
         <DiscoveryFailure
           error={discoveryFailure}
@@ -133,7 +127,7 @@ function ToolOverridePicker({
   const candidates = discovered.filter((tool) => !overriddenNames.has(tool.name))
   const typedName = query.trim()
   const typedNameAddable =
-    mcpToolNamePattern.test(typedName) &&
+    mcpToolNameAddable(typedName) &&
     !overriddenNames.has(typedName) &&
     !discovered.some((tool) => tool.name === typedName)
 
@@ -288,36 +282,20 @@ function DiscoveryFailure({
   )
 }
 
-function UnexposableTools({
-  serverName,
-  tools,
-}: {
-  serverName: string
-  tools: { name: string; error: string }[]
-}) {
-  const longestToolName = Math.max(...tools.map((tool) => tool.name.length))
-  const maxServerNameLength =
-    mcpRuntimeToolNameMaxLength - mcpRuntimeToolName('', '').length - longestToolName
+function UnexposableTools({ tools }: { tools: UnexposableMcpTool[] }) {
   return (
     <div role="alert" className="text-destructive flex items-start gap-2 text-sm">
       <TriangleAlert className="mt-0.5 size-4 shrink-0" />
       <div className="min-w-0 flex-1 space-y-1">
         <p className="font-medium">
           {tools.length === 1
-            ? 'One tool cannot be exposed to the model, so the agent will fail to connect to this server.'
-            : `${tools.length} tools cannot be exposed to the model, so the agent will fail to connect to this server.`}
-        </p>
-        <p className="text-muted-foreground">
-          Omnara names MCP tools <code className="font-mono">mcp__{serverName}__&lt;tool&gt;</code>,
-          and the full name must be {mcpRuntimeToolNameMaxLength} characters or fewer.{' '}
-          {maxServerNameLength >= 1
-            ? `Shorten the server name to ${maxServerNameLength} characters or fewer, or disable these tools.`
-            : 'Some tool names are too long to expose under any server name, so disable them.'}
+            ? 'One tool cannot be exposed to the model, so the agent will fail to connect to this server. Fix the name or disable the tool.'
+            : `${tools.length} tools cannot be exposed to the model, so the agent will fail to connect to this server. Fix the names or disable the tools.`}
         </p>
         <ul className="text-muted-foreground list-disc space-y-0.5 pl-5">
           {tools.map((tool) => (
-            <li key={tool.name} className="break-all font-mono text-xs">
-              {tool.name}
+            <li key={tool.name} className="break-words">
+              {tool.error}
             </li>
           ))}
         </ul>

--- a/frontend/apps/web/src/components/agents/AgentConfigMcpToolOverrideList.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigMcpToolOverrideList.tsx
@@ -1,0 +1,188 @@
+import type { McpServerTool, ToolPermissionProfile } from '@omnara/sdk'
+import { useState } from 'react'
+
+import type { BasicMcpTool } from '@/components/agents/useAgentBuilderForm'
+import { Trash2Icon } from '@/components/icons'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+const inheritValue = 'inherit'
+
+export function AgentConfigMcpToolOverrideList({
+  tools,
+  discovered,
+  permissionProfile,
+  toolCountLabel,
+  onToolsChange,
+}: {
+  tools: BasicMcpTool[]
+  discovered: McpServerTool[]
+  permissionProfile?: ToolPermissionProfile
+  toolCountLabel: string | null
+  onToolsChange: (tools: BasicMcpTool[]) => void
+}) {
+  const [openDescription, setOpenDescription] = useState<string | null>(null)
+  if (tools.length === 0) {
+    return (
+      <p className="text-muted-foreground px-4 py-3 text-sm">
+        {toolCountLabel == null
+          ? 'No overrides.'
+          : `No overrides — all ${toolCountLabel} follow the settings above.`}
+      </p>
+    )
+  }
+  const discoveredByName = new Map(discovered.map((tool) => [tool.name, tool]))
+  return (
+    <div className="divide-y">
+      {tools.map((tool) => (
+        <ToolOverrideRow
+          key={tool.name}
+          tool={tool}
+          description={discoveredByName.get(tool.name)?.description}
+          permissionProfile={permissionProfile}
+          descriptionOpen={openDescription === tool.name}
+          onDescriptionOpenChange={(open) => {
+            setOpenDescription(open ? tool.name : null)
+          }}
+          onChange={(patch) => {
+            onToolsChange(
+              tools.map((candidate) =>
+                candidate.name === tool.name ? { ...candidate, ...patch } : candidate,
+              ),
+            )
+          }}
+          onRemove={() => {
+            onToolsChange(tools.filter((candidate) => candidate.name !== tool.name))
+          }}
+        />
+      ))}
+    </div>
+  )
+}
+
+function ToolOverrideRow({
+  tool,
+  description,
+  permissionProfile,
+  descriptionOpen,
+  onDescriptionOpenChange,
+  onChange,
+  onRemove,
+}: {
+  tool: BasicMcpTool
+  description: string | undefined
+  permissionProfile?: ToolPermissionProfile
+  descriptionOpen: boolean
+  onDescriptionOpenChange: (open: boolean) => void
+  onChange: (patch: Partial<Omit<BasicMcpTool, 'name'>>) => void
+  onRemove: () => void
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 px-3 py-2 sm:flex-nowrap sm:gap-3">
+      <div
+        className="-my-2 flex min-w-0 flex-1 basis-full items-center self-stretch py-2 sm:basis-auto"
+        onPointerEnter={() => {
+          onDescriptionOpenChange(true)
+        }}
+        onPointerLeave={() => {
+          onDescriptionOpenChange(false)
+        }}
+      >
+        {description ? (
+          <Tooltip open={descriptionOpen}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="bg-muted block max-w-full cursor-default truncate rounded-md px-2 py-1 text-left font-mono text-xs outline-none focus-visible:ring-2"
+                aria-label={`About ${tool.name}`}
+                onFocus={() => {
+                  onDescriptionOpenChange(true)
+                }}
+                onBlur={() => {
+                  onDescriptionOpenChange(false)
+                }}
+              >
+                {tool.name}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right" className="max-w-sm px-4 py-2 text-sm leading-relaxed">
+              {description}
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          <span className="bg-muted truncate rounded-md px-2 py-1 font-mono text-xs">
+            {tool.name}
+          </span>
+        )}
+      </div>
+      <Select
+        value={tool.enabled == null ? inheritValue : String(tool.enabled)}
+        onValueChange={(value) => {
+          onChange({ enabled: value === inheritValue ? null : value === 'true' })
+        }}
+      >
+        <SelectTrigger
+          size="sm"
+          className="min-w-0 flex-1 sm:w-36 sm:flex-none"
+          aria-label={`${tool.name} enabled`}
+        >
+          <SelectValue>
+            {tool.enabled == null ? 'Default' : tool.enabled ? 'Enabled' : 'Disabled'}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={inheritValue}>Default</SelectItem>
+          <SelectItem value="true">Enabled</SelectItem>
+          <SelectItem value="false">Disabled</SelectItem>
+        </SelectContent>
+      </Select>
+      <Select
+        value={tool.permission?.mode ?? inheritValue}
+        disabled={permissionProfile == null}
+        onValueChange={(mode) => {
+          onChange({ permission: mode === inheritValue ? null : { mode, parameters: {} } })
+        }}
+      >
+        <SelectTrigger
+          size="sm"
+          className="min-w-0 flex-1 sm:w-40 sm:flex-none"
+          aria-label={`${tool.name} permission`}
+        >
+          <SelectValue>
+            {tool.permission == null
+              ? 'Default'
+              : permissionModeLabel(permissionProfile, tool.permission.mode)}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={inheritValue}>Default</SelectItem>
+          {permissionProfile?.permission_modes.map((mode) => (
+            <SelectItem key={mode.name} value={mode.name}>
+              {mode.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button
+        type="button"
+        size="icon"
+        variant="ghost"
+        aria-label={`Remove ${tool.name} override`}
+        onClick={onRemove}
+      >
+        <Trash2Icon />
+      </Button>
+    </div>
+  )
+}
+
+function permissionModeLabel(profile: ToolPermissionProfile | undefined, value: string) {
+  return profile?.permission_modes.find((mode) => mode.name === value)?.label ?? value
+}

--- a/frontend/apps/web/src/components/agents/AgentSidebar.tsx
+++ b/frontend/apps/web/src/components/agents/AgentSidebar.tsx
@@ -231,7 +231,9 @@ function AgentMcpConnectionItem({ connection }: { connection: AgentMcpConnection
       ? 'Connected'
       : connection.state === 'initializing'
         ? 'Connecting'
-        : 'Disconnected'
+        : connection.state === 'failed'
+          ? 'Failed'
+          : 'Disconnected'
 
   return (
     <SidebarMenuItem className="py-1.5 text-sm">
@@ -242,7 +244,9 @@ function AgentMcpConnectionItem({ connection }: { connection: AgentMcpConnection
               <McpServerIcon server={server} url={connection.endpoint_url} />
               <span className="truncate">{connection.server_key}</span>
             </span>
-            <Badge variant="outline">{stateLabel}</Badge>
+            <Badge variant={connection.state === 'failed' ? 'destructive' : 'outline'}>
+              {stateLabel}
+            </Badge>
           </div>
         </TooltipTrigger>
         <TooltipContent side="left" className="max-w-xs space-y-1 text-left">
@@ -260,10 +264,15 @@ function AgentMcpConnectionItem({ connection }: { connection: AgentMcpConnection
             {connection.protocol_version ? ` · MCP ${connection.protocol_version}` : ''}
           </div>
           {connection.initialize_error && (
-            <div className="text-destructive">{connection.initialize_error}</div>
+            <div className="text-destructive break-words">{connection.initialize_error}</div>
           )}
         </TooltipContent>
       </Tooltip>
+      {connection.state === 'failed' && connection.initialize_error && (
+        <p role="alert" className="text-destructive mt-1 line-clamp-4 break-words text-xs">
+          {connection.initialize_error}
+        </p>
+      )}
     </SidebarMenuItem>
   )
 }

--- a/frontend/apps/web/src/components/agents/useAgentBuilderForm.test.ts
+++ b/frontend/apps/web/src/components/agents/useAgentBuilderForm.test.ts
@@ -9,6 +9,7 @@ import {
   createBasicConfigSession,
   mcpRuntimeToolNameError,
   mcpServerNameError,
+  mcpToolEnabled,
 } from './useAgentBuilderForm'
 
 const fullConfig: BasicConfig = {
@@ -649,6 +650,26 @@ describe('basic agent config names', () => {
         'but the model only accepts tool names of 64 characters or fewer. ' +
         'The tool name itself is too long to expose under any server name.',
     )
+  })
+
+  it('resolves whether an MCP tool is enabled from its override or the server default', () => {
+    const [enabledByDefault, disabledByDefault] = fullConfig.mcpServers
+    if (!enabledByDefault || !disabledByDefault) throw new Error('fixture needs two servers')
+    const overrides = [
+      { name: 'on', enabled: true, permission: null },
+      { name: 'off', enabled: false, permission: null },
+      { name: 'inherit', enabled: null, permission: null },
+    ]
+    const enabled = { ...enabledByDefault, tools: overrides }
+    const disabled = { ...disabledByDefault, tools: overrides }
+    expect(mcpToolEnabled(enabled, 'on')).toBe(true)
+    expect(mcpToolEnabled(enabled, 'off')).toBe(false)
+    expect(mcpToolEnabled(enabled, 'inherit')).toBe(true)
+    expect(mcpToolEnabled(enabled, 'unknown')).toBe(true)
+    expect(mcpToolEnabled(disabled, 'on')).toBe(true)
+    expect(mcpToolEnabled(disabled, 'off')).toBe(false)
+    expect(mcpToolEnabled(disabled, 'inherit')).toBe(false)
+    expect(mcpToolEnabled(disabled, 'unknown')).toBe(false)
   })
 
   it('rejects duplicate MCP server keys', () => {

--- a/frontend/apps/web/src/components/agents/useAgentBuilderForm.test.ts
+++ b/frontend/apps/web/src/components/agents/useAgentBuilderForm.test.ts
@@ -7,6 +7,7 @@ import {
   type BasicConfig,
   basicConfigValid,
   createBasicConfigSession,
+  mcpRuntimeToolNameError,
   mcpServerNameError,
 } from './useAgentBuilderForm'
 
@@ -633,6 +634,21 @@ describe('basic agent config names', () => {
     ['GitHub-2', undefined],
   ])('reports the MCP server key rule for %j', (name, expected) => {
     expect(mcpServerNameError(name)).toBe(expected)
+  })
+
+  it('explains when the prefixed MCP tool name exceeds the model limit', () => {
+    const tool = 'provider__search-call-recordings-by-metadata'
+    expect(mcpRuntimeToolNameError('cust-read', tool)).toBeUndefined()
+    expect(mcpRuntimeToolNameError('customer-user-read', tool)).toBe(
+      `"${tool}" becomes "mcp__customer-user-read__${tool}" (69 characters) once the server name is prefixed, ` +
+        'but the model only accepts tool names of 64 characters or fewer. ' +
+        'Shorten the server name to 13 characters or fewer.',
+    )
+    expect(mcpRuntimeToolNameError('a', 'b'.repeat(64))).toBe(
+      `"${'b'.repeat(64)}" becomes "mcp__a__${'b'.repeat(64)}" (72 characters) once the server name is prefixed, ` +
+        'but the model only accepts tool names of 64 characters or fewer. ' +
+        'The tool name itself is too long to expose under any server name.',
+    )
   })
 
   it('rejects duplicate MCP server keys', () => {

--- a/frontend/apps/web/src/components/agents/useAgentBuilderForm.test.ts
+++ b/frontend/apps/web/src/components/agents/useAgentBuilderForm.test.ts
@@ -6,10 +6,12 @@ import { emptyProviderOptions } from '@/components/machines/machineOverrides'
 import {
   type BasicConfig,
   basicConfigValid,
+  type BasicMcpServer,
   createBasicConfigSession,
   mcpRuntimeToolNameError,
   mcpServerNameError,
   mcpToolEnabled,
+  unexposableMcpTools,
 } from './useAgentBuilderForm'
 
 const fullConfig: BasicConfig = {
@@ -650,6 +652,53 @@ describe('basic agent config names', () => {
         'but the model only accepts tool names of 64 characters or fewer. ' +
         'The tool name itself is too long to expose under any server name.',
     )
+  })
+
+  it.each([
+    ['', 'Tool name is required.'],
+    [
+      '1search',
+      '"1search" must start with a letter, but the model only accepts tool names that begin with a letter.',
+    ],
+    [
+      'search.issues',
+      '"search.issues" contains characters other than letters, numbers, underscores, and hyphens, which the model does not accept in tool names.',
+    ],
+    [
+      'search issues',
+      '"search issues" contains characters other than letters, numbers, underscores, and hyphens, which the model does not accept in tool names.',
+    ],
+    ['search_issues-v2', undefined],
+  ])('explains when the MCP tool name %j has characters the model rejects', (name, expected) => {
+    expect(mcpRuntimeToolNameError('github', name)).toBe(expected)
+  })
+
+  it('lists enabled discovered and configured MCP tools the model cannot accept', () => {
+    const [server] = fullConfig.mcpServers
+    if (!server) throw new Error('fixture needs a server')
+    const longName = 'b'.repeat(64)
+    const configured: BasicMcpServer = {
+      ...server,
+      name: 'github',
+      defaultEnabled: true,
+      tools: [
+        { name: longName, enabled: null, permission: null },
+        { name: 'c'.repeat(64), enabled: false, permission: null },
+        { name: 'search.issues', enabled: true, permission: null },
+      ],
+    }
+    expect(
+      unexposableMcpTools(configured, ['list-issues', 'get.issue', 'search.issues']).map(
+        (tool) => tool.name,
+      ),
+    ).toEqual(['get.issue', 'search.issues', longName])
+    expect(unexposableMcpTools({ ...configured, defaultEnabled: false }, ['get.issue'])).toEqual([
+      {
+        name: 'search.issues',
+        error:
+          '"search.issues" contains characters other than letters, numbers, underscores, and hyphens, which the model does not accept in tool names.',
+      },
+    ])
   })
 
   it('resolves whether an MCP tool is enabled from its override or the server default', () => {

--- a/frontend/apps/web/src/components/agents/useAgentBuilderForm.ts
+++ b/frontend/apps/web/src/components/agents/useAgentBuilderForm.ts
@@ -245,6 +245,10 @@ export function mcpRuntimeToolName(serverName: string, toolName: string) {
   return `mcp__${serverName}__${toolName}`
 }
 
+export function mcpToolEnabled(server: BasicMcpServer, toolName: string) {
+  return server.tools.find((tool) => tool.name === toolName)?.enabled ?? server.defaultEnabled
+}
+
 export function mcpRuntimeToolNameError(serverName: string, toolName: string): string | undefined {
   const runtimeName = mcpRuntimeToolName(serverName, toolName)
   if (runtimeName.length <= mcpRuntimeToolNameMaxLength) return undefined

--- a/frontend/apps/web/src/components/agents/useAgentBuilderForm.ts
+++ b/frontend/apps/web/src/components/agents/useAgentBuilderForm.ts
@@ -239,6 +239,22 @@ export function mcpServerNameError(name: string): string | undefined {
   return undefined
 }
 
+export const mcpRuntimeToolNameMaxLength = 64
+
+export function mcpRuntimeToolName(serverName: string, toolName: string) {
+  return `mcp__${serverName}__${toolName}`
+}
+
+export function mcpRuntimeToolNameError(serverName: string, toolName: string): string | undefined {
+  const runtimeName = mcpRuntimeToolName(serverName, toolName)
+  if (runtimeName.length <= mcpRuntimeToolNameMaxLength) return undefined
+  const maxServerNameLength = mcpRuntimeToolNameMaxLength - mcpRuntimeToolName('', toolName).length
+  const prefixed = `"${toolName}" becomes "${runtimeName}" (${runtimeName.length} characters) once the server name is prefixed, but the model only accepts tool names of ${mcpRuntimeToolNameMaxLength} characters or fewer.`
+  return maxServerNameLength >= 1
+    ? `${prefixed} Shorten the server name to ${maxServerNameLength} characters or fewer.`
+    : `${prefixed} The tool name itself is too long to expose under any server name.`
+}
+
 function mcpServerValid(server: BasicMcpServer) {
   return (
     mcpServerNameError(server.name) === undefined &&

--- a/frontend/apps/web/src/components/agents/useAgentBuilderForm.ts
+++ b/frontend/apps/web/src/components/agents/useAgentBuilderForm.ts
@@ -249,7 +249,20 @@ export function mcpToolEnabled(server: BasicMcpServer, toolName: string) {
   return server.tools.find((tool) => tool.name === toolName)?.enabled ?? server.defaultEnabled
 }
 
+const mcpToolNamePattern = /^[a-zA-Z][a-zA-Z0-9_-]{0,63}$/
+
+export function mcpToolNameAddable(toolName: string) {
+  return mcpToolNamePattern.test(toolName)
+}
+
 export function mcpRuntimeToolNameError(serverName: string, toolName: string): string | undefined {
+  if (toolName === '') return 'Tool name is required.'
+  if (!/^[a-zA-Z]/.test(toolName)) {
+    return `"${toolName}" must start with a letter, but the model only accepts tool names that begin with a letter.`
+  }
+  if (!/^[a-zA-Z0-9_-]*$/.test(toolName)) {
+    return `"${toolName}" contains characters other than letters, numbers, underscores, and hyphens, which the model does not accept in tool names.`
+  }
   const runtimeName = mcpRuntimeToolName(serverName, toolName)
   if (runtimeName.length <= mcpRuntimeToolNameMaxLength) return undefined
   const maxServerNameLength = mcpRuntimeToolNameMaxLength - mcpRuntimeToolName('', toolName).length
@@ -257,6 +270,23 @@ export function mcpRuntimeToolNameError(serverName: string, toolName: string): s
   return maxServerNameLength >= 1
     ? `${prefixed} Shorten the server name to ${maxServerNameLength} characters or fewer.`
     : `${prefixed} The tool name itself is too long to expose under any server name.`
+}
+
+export interface UnexposableMcpTool {
+  name: string
+  error: string
+}
+
+export function unexposableMcpTools(
+  server: BasicMcpServer,
+  discoveredNames: string[],
+): UnexposableMcpTool[] {
+  const names = new Set([...discoveredNames, ...server.tools.map((tool) => tool.name)])
+  return [...names].flatMap((name) => {
+    if (!mcpToolEnabled(server, name)) return []
+    const error = mcpRuntimeToolNameError(server.name, name)
+    return error === undefined ? [] : [{ name, error }]
+  })
 }
 
 function mcpServerValid(server: BasicMcpServer) {

--- a/internal/agentconfig/compiler_test.go
+++ b/internal/agentconfig/compiler_test.go
@@ -317,6 +317,56 @@ mcp:
 	}
 }
 
+func TestCompileYAMLAllowsTooLongRuntimeToolNameWhenDisabled(t *testing.T) {
+	serverKey := strings.Repeat("a", 32)
+	remoteName := strings.Repeat("b", 32)
+	for name, source := range map[string]string{
+		"disabled_by_override": `
+mcp:
+  ` + serverKey + `:
+    url: https://example.com/mcp
+    tools:
+      ` + remoteName + `:
+        enabled: false
+`,
+		"disabled_by_server_default": `
+mcp:
+  ` + serverKey + `:
+    url: https://example.com/mcp
+    default_enabled: false
+    tools:
+      ` + remoteName + `:
+        permission:
+          mode: always_ask
+          parameters: {}
+`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			compiled, err := Compile(SourceFormatYAML, []byte(validAgentSource(source)), CompileOptions{})
+			if err != nil {
+				t.Fatalf("compile mcp config: %v", err)
+			}
+			contract, err := RuntimeContractFromCompiled(compiled.CanonicalJSON, CompilerVersion, compiled.Hash)
+			if err != nil {
+				t.Fatalf("runtime contract: %v", err)
+			}
+			if _, ok := contract.MCPServers[0].ResolveTool(remoteName); ok {
+				t.Fatal("tool with too-long runtime name should stay disabled")
+			}
+		})
+	}
+	if _, err := Compile(SourceFormatYAML, []byte(validAgentSource(`
+mcp:
+  `+serverKey+`:
+    url: https://example.com/mcp
+    tools:
+      "bad name":
+        enabled: false
+`)), CompileOptions{}); err == nil {
+		t.Fatal("disabled tool with malformed name should still be rejected")
+	}
+}
+
 func TestCompileYAMLRejectsInvalidMCPConfig(t *testing.T) {
 	for name, source := range map[string]string{
 		"server_key_underscore": `
@@ -336,6 +386,16 @@ mcp:
     tools:
       ` + strings.Repeat("b", 32) + `:
         enabled: true
+        permission:
+          mode: always_ask
+          parameters: {}
+`,
+		"runtime_tool_name_too_long_by_server_default": `
+mcp:
+  ` + strings.Repeat("a", 32) + `:
+    url: https://example.com/mcp
+    tools:
+      ` + strings.Repeat("b", 32) + `:
         permission:
           mode: always_ask
           parameters: {}

--- a/internal/agentconfig/mcp.go
+++ b/internal/agentconfig/mcp.go
@@ -76,9 +76,10 @@ func compileMCPServers(
 		if err != nil {
 			return nil, issueAt(jsonPointer("mcp", serverKey, "url"), err)
 		}
+		defaultEnabled := server.DefaultEnabled == nil || *server.DefaultEnabled
 		var tools map[string]MCPToolCompiled
 		if len(server.Tools) > 0 {
-			tools, err = compileMCPTools(serverKey, server.Tools)
+			tools, err = compileMCPTools(serverKey, defaultEnabled, server.Tools)
 			if err != nil {
 				return nil, issueAt(jsonPointer("mcp", serverKey, "tools"), err)
 			}
@@ -103,7 +104,7 @@ func compileMCPServers(
 		compiled[serverKey] = MCPServerCompiled{
 			URL:            endpoint,
 			Auth:           auth,
-			DefaultEnabled: server.DefaultEnabled == nil || *server.DefaultEnabled,
+			DefaultEnabled: defaultEnabled,
 			Permission:     permission,
 			Tools:          tools,
 		}
@@ -212,10 +213,18 @@ func classifyMCPURLHost(host string) mcpURLHost {
 	}
 }
 
-func compileMCPTools(serverKey string, source map[string]AgentConfigMCPToolSource) (map[string]MCPToolCompiled, error) {
+func compileMCPTools(
+	serverKey string,
+	defaultEnabled bool,
+	source map[string]AgentConfigMCPToolSource,
+) (map[string]MCPToolCompiled, error) {
 	compiled := make(map[string]MCPToolCompiled, len(source))
 	for remoteName, tool := range source {
-		if err := toolcatalog.ValidateMCPRuntimeToolName(serverKey, remoteName); err != nil {
+		enabled := defaultEnabled
+		if tool.Enabled != nil {
+			enabled = *tool.Enabled
+		}
+		if err := validateMCPToolName(serverKey, remoteName, enabled); err != nil {
 			return nil, issueAt(jsonPointer(remoteName), err)
 		}
 		var permission *toolpermission.Selection
@@ -235,6 +244,15 @@ func compileMCPTools(serverKey string, source map[string]AgentConfigMCPToolSourc
 		}
 	}
 	return compiled, nil
+}
+
+func validateMCPToolName(serverKey, remoteName string, enabled bool) error {
+	err := toolcatalog.ValidateMCPRuntimeToolName(serverKey, remoteName)
+	var tooLong *toolcatalog.MCPRuntimeToolNameTooLongError
+	if !enabled && errors.As(err, &tooLong) {
+		return nil
+	}
+	return err
 }
 
 func runtimeMCPServers(compiled map[string]MCPServerCompiled) ([]RuntimeMCPServer, error) {

--- a/internal/mcp/connection_manager.go
+++ b/internal/mcp/connection_manager.go
@@ -285,7 +285,7 @@ func (m Manager) initialize(
 	if err != nil {
 		return executionstore.MCPConnectionRecord{}, fmt.Errorf("list mcp tools for %q: %w", conn.ServerKey, err)
 	}
-	if err := validateDiscoveredTools(conn.ServerKey, tools); err != nil {
+	if err := validateDiscoveredTools(server, tools); err != nil {
 		return executionstore.MCPConnectionRecord{}, fmt.Errorf(
 			"validate mcp tools for %q: %w",
 			conn.ServerKey,
@@ -313,14 +313,16 @@ func (m Manager) initialize(
 	return ready, nil
 }
 
-func validateDiscoveredTools(serverKey string, tools []*sdkmcp.Tool) error {
+func validateDiscoveredTools(server agentconfig.RuntimeMCPServer, tools []*sdkmcp.Tool) error {
 	seen := make(map[string]struct{}, len(tools))
 	for index, tool := range tools {
 		if tool == nil {
 			return fmt.Errorf("tool at index %d is null", index)
 		}
-		if err := toolcatalog.ValidateMCPRuntimeToolName(serverKey, tool.Name); err != nil {
-			return fmt.Errorf("tool name %q cannot be exposed to the model: %w", tool.Name, err)
+		if _, enabled := server.ResolveTool(tool.Name); enabled {
+			if err := toolcatalog.ValidateMCPRuntimeToolName(server.ServerKey, tool.Name); err != nil {
+				return fmt.Errorf("tool name %q cannot be exposed to the model: %w", tool.Name, err)
+			}
 		}
 		if _, duplicate := seen[tool.Name]; duplicate {
 			return fmt.Errorf("duplicate tool name %q", tool.Name)

--- a/internal/mcp/connection_manager.go
+++ b/internal/mcp/connection_manager.go
@@ -319,9 +319,8 @@ func validateDiscoveredTools(serverKey string, tools []*sdkmcp.Tool) error {
 		if tool == nil {
 			return fmt.Errorf("tool at index %d is null", index)
 		}
-		runtimeName := toolcatalog.MCPRuntimeToolName(serverKey, tool.Name)
-		if !toolcatalog.IsMCPRuntimeToolName(runtimeName) {
-			return fmt.Errorf("tool name %q cannot be exposed to the model", tool.Name)
+		if err := toolcatalog.ValidateMCPRuntimeToolName(serverKey, tool.Name); err != nil {
+			return fmt.Errorf("tool name %q cannot be exposed to the model: %w", tool.Name, err)
 		}
 		if _, duplicate := seen[tool.Name]; duplicate {
 			return fmt.Errorf("duplicate tool name %q", tool.Name)

--- a/internal/mcp/connection_manager_internal_test.go
+++ b/internal/mcp/connection_manager_internal_test.go
@@ -43,7 +43,15 @@ func TestValidateDiscoveredTools(t *testing.T) {
 		{
 			name:  "unsupported name",
 			tools: []*sdkmcp.Tool{{Name: "search docs"}},
-			want:  `tool name "search docs" cannot be exposed to the model`,
+			want:  `tool name "search docs" cannot be exposed to the model: mcp tool name "search docs" must match`,
+		},
+		{
+			name:  "prefixed name too long",
+			tools: []*sdkmcp.Tool{{Name: strings.Repeat("a", 60)}},
+			want: `tool name "` + strings.Repeat("a", 60) + `" cannot be exposed to the model: tool "` +
+				strings.Repeat("a", 60) + `" becomes "mcp__docs__` + strings.Repeat("a", 60) +
+				`" (71 characters) once the server name is prefixed, but the model only accepts tool names of 64 characters or fewer; ` +
+				`the tool name itself is too long to expose under any server name`,
 		},
 		{
 			name: "duplicate name",

--- a/internal/mcp/connection_manager_internal_test.go
+++ b/internal/mcp/connection_manager_internal_test.go
@@ -6,6 +6,8 @@ import (
 	"unicode/utf8"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/omnara-ai/omnara/internal/agentconfig"
 )
 
 func TestSanitizeInitializationError(t *testing.T) {
@@ -19,10 +21,15 @@ func TestSanitizeInitializationError(t *testing.T) {
 }
 
 func TestValidateDiscoveredTools(t *testing.T) {
+	disabledTool := map[string]agentconfig.RuntimeMCPTool{
+		strings.Repeat("a", 60): {RemoteName: strings.Repeat("a", 60), Enabled: boolPtr(false)},
+		"search docs":           {RemoteName: "search docs", Enabled: boolPtr(false)},
+	}
 	tests := []struct {
-		name  string
-		tools []*sdkmcp.Tool
-		want  string
+		name   string
+		tools  []*sdkmcp.Tool
+		server agentconfig.RuntimeMCPServer
+		want   string
 	}{
 		{
 			name: "valid",
@@ -61,10 +68,43 @@ func TestValidateDiscoveredTools(t *testing.T) {
 			},
 			want: `duplicate tool name "search"`,
 		},
+		{
+			name: "unexposable names skipped when disabled by override",
+			tools: []*sdkmcp.Tool{
+				{Name: "search"},
+				{Name: strings.Repeat("a", 60)},
+				{Name: "search docs"},
+			},
+			server: agentconfig.RuntimeMCPServer{ServerKey: "docs", DefaultEnabled: true, Tools: disabledTool},
+		},
+		{
+			name: "unexposable names skipped when server disables tools by default",
+			tools: []*sdkmcp.Tool{
+				{Name: "search"},
+				{Name: strings.Repeat("a", 60)},
+			},
+			server: agentconfig.RuntimeMCPServer{
+				ServerKey: "docs",
+				Tools:     map[string]agentconfig.RuntimeMCPTool{"search": {RemoteName: "search", Enabled: boolPtr(true)}},
+			},
+		},
+		{
+			name: "duplicate disabled names still rejected",
+			tools: []*sdkmcp.Tool{
+				{Name: "search docs"},
+				{Name: "search docs"},
+			},
+			server: agentconfig.RuntimeMCPServer{ServerKey: "docs", DefaultEnabled: true, Tools: disabledTool},
+			want:   `duplicate tool name "search docs"`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := validateDiscoveredTools("docs", test.tools)
+			server := test.server
+			if server.ServerKey == "" {
+				server = agentconfig.RuntimeMCPServer{ServerKey: "docs", DefaultEnabled: true}
+			}
+			err := validateDiscoveredTools(server, test.tools)
 			if test.want == "" {
 				if err != nil {
 					t.Fatalf("validate discovered tools: %v", err)
@@ -76,4 +116,8 @@ func TestValidateDiscoveredTools(t *testing.T) {
 			}
 		})
 	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }

--- a/internal/toolcatalog/mcp_names.go
+++ b/internal/toolcatalog/mcp_names.go
@@ -48,6 +48,34 @@ func SplitMCPRuntimeToolName(name string) (serverKey string, remoteName string, 
 	return serverKey, remoteName, true
 }
 
+type MCPRuntimeToolNameTooLongError struct {
+	ServerKey  string
+	RemoteName string
+}
+
+func (e *MCPRuntimeToolNameTooLongError) RuntimeName() string {
+	return MCPRuntimeToolName(e.ServerKey, e.RemoteName)
+}
+
+func (e *MCPRuntimeToolNameTooLongError) MaxServerKeyLength() int {
+	return MaxMCPRuntimeToolNameLength - len(MCPRuntimeToolPrefix) - len(MCPToolNameSeparator) - len(e.RemoteName)
+}
+
+func (e *MCPRuntimeToolNameTooLongError) Error() string {
+	name := e.RuntimeName()
+	message := fmt.Sprintf(
+		"tool %q becomes %q (%d characters) once the server name is prefixed, but the model only accepts tool names of %d characters or fewer",
+		e.RemoteName,
+		name,
+		len(name),
+		MaxMCPRuntimeToolNameLength,
+	)
+	if maxKey := e.MaxServerKeyLength(); maxKey >= 1 {
+		return fmt.Sprintf("%s; shorten the server name %q to %d characters or fewer", message, e.ServerKey, maxKey)
+	}
+	return message + "; the tool name itself is too long to expose under any server name"
+}
+
 func ValidateMCPRuntimeToolName(serverKey, remoteName string) error {
 	if serverKey == "" {
 		return errors.New("mcp server key is required")
@@ -61,9 +89,8 @@ func ValidateMCPRuntimeToolName(serverKey, remoteName string) error {
 	if !mcpRemoteToolNamePattern.MatchString(remoteName) {
 		return fmt.Errorf("mcp tool name %q must match %s", remoteName, MCPRemoteToolNamePattern)
 	}
-	name := MCPRuntimeToolName(serverKey, remoteName)
-	if len(name) > MaxMCPRuntimeToolNameLength {
-		return fmt.Errorf("mcp runtime tool name %q must be %d characters or fewer", name, MaxMCPRuntimeToolNameLength)
+	if len(MCPRuntimeToolName(serverKey, remoteName)) > MaxMCPRuntimeToolNameLength {
+		return &MCPRuntimeToolNameTooLongError{ServerKey: serverKey, RemoteName: remoteName}
 	}
 	return nil
 }

--- a/internal/toolcatalog/mcp_names_test.go
+++ b/internal/toolcatalog/mcp_names_test.go
@@ -1,6 +1,10 @@
 package toolcatalog
 
-import "testing"
+import (
+	"errors"
+	"strings"
+	"testing"
+)
 
 func TestMCPRuntimeToolNamesUseExplicitNamespace(t *testing.T) {
 	name := MCPRuntimeToolName("docs", "search")
@@ -23,5 +27,37 @@ func TestMCPRuntimeToolNamesUseExplicitNamespace(t *testing.T) {
 	serverKey, remoteName, ok = SplitMCPRuntimeToolName(awsName)
 	if !ok || serverKey != "aws" || remoteName != "aws___call_aws" {
 		t.Fatalf("split AWS runtime name = (%q, %q, %t)", serverKey, remoteName, ok)
+	}
+}
+
+func TestValidateMCPRuntimeToolNameExplainsPrefixedLength(t *testing.T) {
+	serverKey := "customer-user-read"
+	remoteName := "provider__search-call-recordings-by-metadata"
+	err := ValidateMCPRuntimeToolName(serverKey, remoteName)
+	var tooLong *MCPRuntimeToolNameTooLongError
+	if !errors.As(err, &tooLong) {
+		t.Fatalf("error = %v, want MCPRuntimeToolNameTooLongError", err)
+	}
+	if tooLong.RuntimeName() != "mcp__customer-user-read__provider__search-call-recordings-by-metadata" {
+		t.Fatalf("runtime name = %q", tooLong.RuntimeName())
+	}
+	if tooLong.MaxServerKeyLength() != 13 {
+		t.Fatalf("max server key length = %d, want 13", tooLong.MaxServerKeyLength())
+	}
+	for _, want := range []string{
+		"(69 characters)",
+		"64 characters or fewer",
+		`shorten the server name "customer-user-read" to 13 characters or fewer`,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not contain %q", err.Error(), want)
+		}
+	}
+	if err := ValidateMCPRuntimeToolName("cust-read", remoteName); err != nil {
+		t.Fatalf("shortened server key unexpectedly rejected: %v", err)
+	}
+	if err := ValidateMCPRuntimeToolName("a", strings.Repeat("b", 64)); err == nil ||
+		!strings.Contains(err.Error(), "too long to expose under any server name") {
+		t.Fatalf("error = %v, want unexposable tool name message", err)
 	}
 }


### PR DESCRIPTION
`toolcatalog.ValidateMCPRuntimeToolName` returns a typed `MCPRuntimeToolNameTooLongError` whose message shows the prefixed name, its length, the 64-character limit, and the maximum server name length that would make it fit (or that the tool name is too long under any server name).
`validateDiscoveredTools` wraps that validation error, so the connection's `initialize_error` explains the length problem instead of the generic message.

Frontend: mcp connection panel shows an error for tools whose prefixed name is too long
Frontend: Failed MCP connections in the agent sidebar show a `Failed` badge with the error inline
