### PR TITLE
refactor(web): centralize the frontend design system

### DIFF
--- a/frontend/apps/web/package.json
+++ b/frontend/apps/web/package.json
@@ -38,7 +38,7 @@
     "shadcn": "^4.13.0",
     "shiki": "4.4.3",
     "streamdown": "^2.5.0",
-    "tailwind-merge": "^2.5.0",
+    "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"

--- a/frontend/apps/web/src/components/agents/AgentChatMessage.tsx
+++ b/frontend/apps/web/src/components/agents/AgentChatMessage.tsx
@@ -41,7 +41,7 @@ function ActorLabel({
 
 function JsonValue({ value }: { value: unknown }) {
   return (
-    <pre className="bg-background/60 max-h-72 overflow-auto rounded-md border p-3 font-mono text-xs leading-relaxed">
+    <pre className="bg-background/60 type-code max-h-72 overflow-auto rounded-md border p-3">
       {JSON.stringify(value, null, 2)}
     </pre>
   )
@@ -50,7 +50,7 @@ function JsonValue({ value }: { value: unknown }) {
 function AssistantMarkdown({ children }: { children: string }) {
   return (
     <Streamdown
-      className="max-w-3xl text-pretty py-0.5 text-sm leading-7"
+      className="type-body-small leading-prose max-w-3xl text-pretty py-0.5"
       components={{
         a: ({ children: linkChildren, ...props }) => (
           <a {...props} target="_blank" rel="noreferrer">
@@ -70,7 +70,7 @@ function AgentConfigDivider({ action }: { action: 'initialized' | 'changed' }) {
   return (
     <div className="flex w-full items-center gap-3 py-1" role="separator" aria-label={label}>
       <span className="bg-border h-px flex-1" aria-hidden="true" />
-      <span className="text-muted-foreground text-[11px] font-medium tracking-wide">{label}</span>
+      <span className="text-muted-foreground tracking-eyebrow text-xs font-medium">{label}</span>
       <span className="bg-border h-px flex-1" aria-hidden="true" />
     </div>
   )
@@ -90,16 +90,16 @@ function ToolPart({
         {complete ? (
           <Check className="text-muted-foreground size-3.5" />
         ) : (
-          <CircleDashed className="text-primary size-3.5 animate-spin" />
+          <CircleDashed className="text-primary size-3.5 motion-safe:animate-spin" />
         )}
         <ChevronRight className="text-muted-foreground size-3.5 transition-transform group-data-[state=open]/tool:rotate-90" />
       </CollapsibleTrigger>
       <CollapsibleContent className="space-y-2 border-t p-2">
-        <p className="text-muted-foreground px-1 text-[11px] font-medium">Input</p>
+        <p className="text-muted-foreground px-1 text-xs font-medium">Input</p>
         <JsonValue value={part.input} />
         {part.state === 'output-available' && (
           <>
-            <p className="text-muted-foreground px-1 pt-1 text-[11px] font-medium">Output</p>
+            <p className="text-muted-foreground px-1 pt-1 text-xs font-medium">Output</p>
             <JsonValue value={part.output} />
           </>
         )}
@@ -179,7 +179,7 @@ export function AgentChatMessage({
                 className="text-muted-foreground flex items-center gap-2 py-0.5 text-xs"
                 role="status"
               >
-                <CircleDashed className="size-3.5 animate-spin" />
+                <CircleDashed className="size-3.5 motion-safe:animate-spin" />
                 Thinking…
               </div>
             )

--- a/frontend/apps/web/src/components/agents/AgentComposer.tsx
+++ b/frontend/apps/web/src/components/agents/AgentComposer.tsx
@@ -226,7 +226,10 @@ export function AgentComposer({
   }
 
   return (
-    <form onSubmit={onSubmit} className="bg-background relative rounded-2xl border p-2 shadow-sm">
+    <form
+      onSubmit={onSubmit}
+      className="control-focus-within bg-background relative rounded-2xl border p-2 shadow-sm"
+    >
       {dragging && (
         <div className="bg-background/95 border-primary pointer-events-none absolute inset-0 z-10 flex items-center justify-center gap-2 rounded-2xl border-2 text-sm font-medium shadow-sm">
           <Upload className="size-5" /> Drop files to attach
@@ -258,9 +261,10 @@ export function AgentComposer({
           onClick={() => inputRef.current?.click()}
         />
         <Textarea
+          variant="embedded"
           value={text}
           placeholder={composerPlaceholder(canOperate, chat.historyStatus)}
-          className="max-h-40 min-h-9 min-w-0 flex-1 resize-none border-0 bg-transparent px-2 py-2 shadow-none focus-visible:ring-0 dark:bg-transparent"
+          className="max-h-40 min-h-9 min-w-0 flex-1 resize-none px-2 py-2"
           disabled={!ready}
           readOnly={submitting}
           onChange={(event) => {

--- a/frontend/apps/web/src/components/agents/AgentComposer.tsx
+++ b/frontend/apps/web/src/components/agents/AgentComposer.tsx
@@ -100,7 +100,7 @@ function SelectedAttachment({
       )}
       <span className="min-w-0 flex-1">
         <span className="block truncate text-xs font-medium">{attachment.file.name}</span>
-        <span className="text-muted-foreground block text-[11px]">
+        <span className="text-muted-foreground block text-xs">
           {attachmentSize(attachment.file.size)}
         </span>
       </span>

--- a/frontend/apps/web/src/components/agents/AgentConfigMcpSecretCombobox.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigMcpSecretCombobox.tsx
@@ -108,9 +108,7 @@ export function AgentConfigMcpSecretCombobox({
                 <span className="flex min-w-0 flex-col items-start">
                   <span className="truncate">{action.label}</span>
                   {action.warning && (
-                    <span className="truncate text-xs text-amber-600 dark:text-amber-500">
-                      {action.warning}
-                    </span>
+                    <span className="text-warning truncate text-xs">{action.warning}</span>
                   )}
                 </span>
               </button>

--- a/frontend/apps/web/src/components/agents/AgentConfigMcpServerTools.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigMcpServerTools.tsx
@@ -331,7 +331,7 @@ function DiscoveryFailure({
   const detected = detectedAuthType(error)
   const switchable = detected != null && detected !== server.authType
   return (
-    <div role="alert" className="flex items-start gap-2 text-sm text-amber-600 dark:text-amber-500">
+    <div role="alert" className="text-warning flex items-start gap-2 text-sm">
       <TriangleAlert className="mt-0.5 size-4 shrink-0" />
       <div className="min-w-0 flex-1 space-y-1">
         <p className="font-medium">{discoveryFailureTitle(error, server, detected)}</p>

--- a/frontend/apps/web/src/components/agents/AgentConfigPanel.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigPanel.tsx
@@ -58,12 +58,12 @@ export function AgentConfigPanel({
         />
       ) : configQuery.isPending ? (
         <>
-          <h2 className="text-lg font-semibold tracking-tight">Agent configuration</h2>
+          <h2 className="type-card-title">Agent configuration</h2>
           <Spinner className="mx-auto my-8" />
         </>
       ) : (
         <>
-          <h2 className="text-lg font-semibold tracking-tight">Agent configuration</h2>
+          <h2 className="type-card-title">Agent configuration</h2>
           <div className="flex items-center gap-3">
             <p className="text-muted-foreground text-sm">Couldn&rsquo;t load the agent config.</p>
             <Button
@@ -158,7 +158,7 @@ function AgentConfigPanelEditor({
           editor={editor}
           orgId={orgId}
           projectId={projectId}
-          header={<h2 className="text-lg font-semibold tracking-tight">Agent configuration</h2>}
+          header={<h2 className="type-card-title">Agent configuration</h2>}
           yamlFieldId="agent-config-panel-yaml"
           yamlFieldClassName="h-[24rem]"
           issues={error.issues}

--- a/frontend/apps/web/src/components/agents/AgentConfigSectionCard.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigSectionCard.tsx
@@ -12,7 +12,7 @@ export function AgentConfigSectionCard({
   return (
     <section className="bg-card rounded-xl border">
       <div className="flex items-center justify-between gap-3 px-4 py-3 sm:px-5">
-        <h3 className="text-sm font-semibold">{title}</h3>
+        <h3 className="type-label">{title}</h3>
         {action}
       </div>
       {children ? <div className="border-t">{children}</div> : null}

--- a/frontend/apps/web/src/components/agents/AgentConfigYamlEditor.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigYamlEditor.tsx
@@ -10,6 +10,7 @@ import { z } from 'zod'
 import { AgentConfigIssueList } from '@/components/agents/AgentConfigIssueList'
 import { issueMarkers } from '@/lib/agent-config-issues'
 import { cn } from '@/lib/utils'
+import { editorAppearance } from '@/styles/editor'
 
 import agentConfigSchemaSource from '../../../../../../internal/agentconfig/generated/agent_config.schema.json?raw'
 
@@ -17,10 +18,6 @@ const agentConfigSchema = z.record(z.string(), z.json()).parse(JSON.parse(agentC
 const agentConfigSchemaUri = 'https://omnara.local/schemas/agent-config.schema.json'
 const agentConfigYamlFileMatches = ['*.yaml', '*.yml']
 let yamlConfiguration: MonacoYaml | undefined
-
-function monacoThemeFromDocument() {
-  return document.documentElement.classList.contains('dark') ? 'vs-dark' : 'vs'
-}
 
 function yamlOptions(): MonacoYamlOptions {
   return {
@@ -138,9 +135,7 @@ export function AgentConfigYamlEditor({
       ariaLabel: agentConfigYamlAriaLabel(initialReadOnlyRef.current),
       ariaRequired: !initialReadOnlyRef.current,
       automaticLayout: true,
-      fontFamily: 'var(--font-mono)',
-      fontSize: 12,
-      lineHeight: 18,
+      ...editorAppearance(monaco, editorElementRef.current),
       minimap: { enabled: false },
       padding: { top: 12, bottom: 12 },
       placeholder: agentConfigYamlPlaceholder,
@@ -149,13 +144,14 @@ export function AgentConfigYamlEditor({
       scrollBeyondLastLine: false,
       stickyScroll: { enabled: false },
       tabSize: 2,
-      theme: monacoThemeFromDocument(),
       wordWrap: 'on',
       wrappingIndent: 'same',
     })
 
     const themeObserver = new MutationObserver(() => {
-      editorRef.current?.updateOptions({ theme: monacoThemeFromDocument() })
+      if (editorElementRef.current) {
+        editorRef.current?.updateOptions(editorAppearance(monaco, editorElementRef.current))
+      }
     })
     themeObserver.observe(document.documentElement, {
       attributeFilter: ['class'],
@@ -224,7 +220,7 @@ export function AgentConfigYamlEditor({
         id={id}
         ref={editorElementRef}
         className={cn(
-          'border-input bg-background h-[28rem] overflow-hidden rounded-md border text-xs',
+          'border-input bg-card type-code rounded-control h-[28rem] overflow-hidden border',
           className,
         )}
       />

--- a/frontend/apps/web/src/components/agents/AgentConfigYamlField.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigYamlField.tsx
@@ -25,7 +25,7 @@ function AgentConfigYamlEditorFallback({
     <div
       id={id}
       className={cn(
-        'border-input bg-background flex h-[28rem] items-center justify-center overflow-hidden rounded-md border text-xs',
+        'border-input bg-card type-code rounded-control flex h-[28rem] items-center justify-center overflow-hidden border',
         className,
       )}
       role="status"

--- a/frontend/apps/web/src/components/agents/AgentConfigYamlField.tsx
+++ b/frontend/apps/web/src/components/agents/AgentConfigYamlField.tsx
@@ -31,7 +31,7 @@ function AgentConfigYamlEditorFallback({
       role="status"
       aria-live="polite"
     >
-      <Spinner className="text-muted-foreground h-6 w-6" />
+      <Spinner className="text-muted-foreground size-6" />
       <span className="sr-only">Loading YAML editor</span>
     </div>
   )

--- a/frontend/apps/web/src/components/agents/AgentInteractions.tsx
+++ b/frontend/apps/web/src/components/agents/AgentInteractions.tsx
@@ -86,7 +86,7 @@ function InteractionFormCard({
     <Card className="border-primary/35 bg-primary/[0.04] min-w-0 gap-3 shadow-none">
       <CardHeader className="min-w-0 gap-1">
         {isPermission ? (
-          <CardTitle className="wrap-anywhere flex flex-wrap items-center gap-2 text-sm text-blue-600 dark:text-blue-400">
+          <CardTitle className="wrap-anywhere text-link flex flex-wrap items-center gap-2 text-sm">
             <KeyRound className="size-4 shrink-0" />
             {toolName == null ? (
               interaction.request.title

--- a/frontend/apps/web/src/components/agents/AgentProfileNameHeading.tsx
+++ b/frontend/apps/web/src/components/agents/AgentProfileNameHeading.tsx
@@ -60,7 +60,7 @@ export function AgentProfileNameHeading({
               aria-label="Profile name"
               required
               value={nameDraft}
-              className="border-border focus-visible:border-border -mx-1 h-auto w-full min-w-0 max-w-96 rounded-none border-0 border-b px-1 py-0 text-2xl font-bold tracking-tight shadow-none focus-visible:ring-0 sm:h-auto md:text-2xl dark:bg-transparent"
+              className="border-border focus-visible:border-border type-title -mx-1 h-auto w-full min-w-0 max-w-96 rounded-none border-0 border-b px-1 py-0 text-2xl shadow-none focus-visible:ring-0 sm:h-auto md:text-2xl dark:bg-transparent"
               onChange={(event) => {
                 setNameDraft(event.target.value)
               }}
@@ -92,7 +92,7 @@ export function AgentProfileNameHeading({
         </div>
       ) : (
         <div className="flex items-center gap-1">
-          <h1 className="text-2xl font-bold tracking-tight">{profile.name}</h1>
+          <h1 className="type-title">{profile.name}</h1>
           {canManage && (
             <Button
               size="icon"

--- a/frontend/apps/web/src/components/agents/AgentProfileNameHeading.tsx
+++ b/frontend/apps/web/src/components/agents/AgentProfileNameHeading.tsx
@@ -59,8 +59,9 @@ export function AgentProfileNameHeading({
               autoFocus
               aria-label="Profile name"
               required
+              variant="embedded"
               value={nameDraft}
-              className="border-border focus-visible:border-border type-title -mx-1 h-auto w-full min-w-0 max-w-96 rounded-none border-0 border-b px-1 py-0 text-2xl shadow-none focus-visible:ring-0 sm:h-auto md:text-2xl dark:bg-transparent"
+              className="border-border focus-visible:border-ring type-title -mx-1 h-auto w-full min-w-0 max-w-96 rounded-none border-b px-1 py-0 text-2xl sm:h-auto md:text-2xl"
               onChange={(event) => {
                 setNameDraft(event.target.value)
               }}

--- a/frontend/apps/web/src/components/agents/AgentProfilesSection.tsx
+++ b/frontend/apps/web/src/components/agents/AgentProfilesSection.tsx
@@ -77,7 +77,7 @@ export function AgentProfilesSection({
           </div>
         )}
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <h2 className="text-2xl font-bold tracking-tight">Agent profiles</h2>
+          <h2 className="type-title">Agent profiles</h2>
           {canManage && (
             <Button asChild size="sm">
               <Link to="/projects/$projectId/agents/new" params={{ projectId }}>

--- a/frontend/apps/web/src/components/agents/AgentSidebar.tsx
+++ b/frontend/apps/web/src/components/agents/AgentSidebar.tsx
@@ -26,7 +26,7 @@ import { formatDateTime } from '@/lib/format'
 import { cn } from '@/lib/utils'
 
 export const sidebarToggleActiveClass =
-  'bg-blue-500/10 text-blue-600 hover:bg-blue-500/15 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-400'
+  'bg-accent text-link hover:bg-primary/15 hover:text-link-hover'
 
 export function AgentSidebarToggle() {
   const { isMobile, open, openMobile, toggleSidebar } = useSidebar()

--- a/frontend/apps/web/src/components/agents/AgentsSection.tsx
+++ b/frontend/apps/web/src/components/agents/AgentsSection.tsx
@@ -19,7 +19,7 @@ export function AgentsSection({
 }) {
   return (
     <div className="flex flex-col gap-3">
-      <h2 className="text-2xl font-bold tracking-tight">Agents</h2>
+      <h2 className="type-title">Agents</h2>
       <AgentsTable
         orgId={orgId}
         projectId={projectId}

--- a/frontend/apps/web/src/components/agents/CreateAgentActions.tsx
+++ b/frontend/apps/web/src/components/agents/CreateAgentActions.tsx
@@ -1,0 +1,72 @@
+import type { ApiError } from '@omnara/sdk'
+import { useNavigate } from '@tanstack/react-router'
+
+import { InsufficientCreditsMessage } from '@/components/agents/InsufficientCreditsMessage'
+import type { SubmitAction } from '@/components/agents/useCreateAgentSubmission'
+import { Button } from '@/components/ui/button'
+import { statusError, type SubmitStatus } from '@/lib/submit-status'
+import { useWebConfig } from '@/lib/web-config'
+
+export function CreateAgentActions({
+  projectId,
+  status,
+  pendingAction,
+  launchError,
+  canSubmit,
+  onCreateProfile,
+}: {
+  projectId: string
+  status: SubmitStatus
+  pendingAction: SubmitAction | null
+  launchError?: ApiError
+  canSubmit: boolean
+  onCreateProfile: () => void
+}) {
+  const navigate = useNavigate()
+  const { data: webConfig } = useWebConfig()
+  const isSubmitting = status.phase === 'submitting'
+  const errorMessage = statusError(status)
+
+  return (
+    <div className="bg-sidebar -mx-4 -mb-4 flex flex-col gap-3 border-t px-4 py-3.5 sm:-mx-6 sm:-mb-6 sm:flex-row sm:items-center sm:justify-between sm:gap-4 sm:px-8">
+      <Button
+        type="button"
+        variant="ghost"
+        disabled={isSubmitting}
+        className="w-full sm:w-auto"
+        onClick={() => {
+          void navigate({ to: '/projects/$projectId/agents', params: { projectId } })
+        }}
+      >
+        Cancel
+      </Button>
+      <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center sm:gap-4">
+        {launchError && webConfig?.billingURL ? (
+          <p className="text-destructive whitespace-pre-wrap text-sm" role="alert">
+            <InsufficientCreditsMessage billingHref={webConfig.billingHref} />
+          </p>
+        ) : errorMessage ? (
+          <p className="text-destructive whitespace-pre-wrap text-sm">{errorMessage}</p>
+        ) : null}
+        <Button
+          type="button"
+          variant="outline"
+          disabled={!canSubmit}
+          loading={pendingAction === 'profile'}
+          className="w-full sm:w-auto"
+          onClick={onCreateProfile}
+        >
+          Create profile
+        </Button>
+        <Button
+          type="submit"
+          disabled={!canSubmit}
+          loading={pendingAction === 'launch'}
+          className="w-full sm:w-auto"
+        >
+          Create & launch agent
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/apps/web/src/components/agents/CreateAgentFormView.tsx
+++ b/frontend/apps/web/src/components/agents/CreateAgentFormView.tsx
@@ -1,67 +1,28 @@
-import {
-  useCreateAgent,
-  useCreateAgentConfig,
-  useCreateAgentProfile,
-  useUpdateAgentProfile,
-} from '@omnara/react'
-import type { AgentConfigErrorIssue, ApiError } from '@omnara/sdk'
 import { type ConfiguredModelSummary, type MachinePoolSummary, type ToolCatalog } from '@omnara/sdk'
-import { useNavigate } from '@tanstack/react-router'
-import { type SyntheticEvent, useReducer, useRef, useState } from 'react'
+import type { SyntheticEvent } from 'react'
 
 import { AgentConfigBasicForm } from '@/components/agents/AgentConfigBasicForm'
 import { AgentConfigIssueList } from '@/components/agents/AgentConfigIssueList'
 import { AgentConfigModelField } from '@/components/agents/AgentConfigModelField'
-import {
-  type AgentConfigMode,
-  agentConfigModeReducer,
-  initialAgentConfigModeState,
-  yamlDiverged,
-} from '@/components/agents/agentConfigModeMachine'
+import { yamlDiverged } from '@/components/agents/agentConfigModeMachine'
 import { AgentConfigYamlField } from '@/components/agents/AgentConfigYamlField'
 import { AgentTemplateMenu } from '@/components/agents/AgentTemplateMenu'
-import {
-  type AgentTemplate,
-  agentTemplateBasicConfig,
-  agentTemplateName,
-  defaultAgentTools,
-} from '@/components/agents/agentTemplates'
+import type { AgentTemplate } from '@/components/agents/agentTemplates'
 import { ConfirmDiscardYamlDialog } from '@/components/agents/ConfirmDiscardYamlDialog'
-import { InsufficientCreditsMessage } from '@/components/agents/InsufficientCreditsMessage'
-import { takeMcpBuilderOAuthRestore } from '@/components/agents/pendingMcpBuilderOAuth'
+import { CreateAgentActions } from '@/components/agents/CreateAgentActions'
 import { PillTabs } from '@/components/agents/PillTabs'
+import { useAgentDraft } from '@/components/agents/useAgentDraft'
 import {
-  createBasicConfigSession,
-  emptyBasicConfig,
-  useAgentBuilderForm,
-} from '@/components/agents/useAgentBuilderForm'
+  type SubmitAction,
+  useCreateAgentSubmission,
+} from '@/components/agents/useCreateAgentSubmission'
 import { PageBreadcrumb } from '@/components/layout/PageBreadcrumb'
-import { Button } from '@/components/ui/button'
 import { Field, FieldGroup, RequiredFieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import { ResourceNameFieldError } from '@/components/ui/resource-name-error'
-import { configSubmitError } from '@/lib/agent-config-issues'
-import { isInsufficientCreditsError } from '@/lib/insufficient-credits'
 import { resourceNameValid } from '@/lib/resource-name'
-import type { SubmitStatus } from '@/lib/submit-status'
-import { idle, settleSubmission, statusError, submitting } from '@/lib/submit-status'
 import { useProjectPage } from '@/lib/use-project-page'
 import { cn } from '@/lib/utils'
-import { useWebConfig } from '@/lib/web-config'
-
-type SubmitAction = 'profile' | 'launch'
-
-interface CreateAgentDraft {
-  name: string
-  status: SubmitStatus
-}
-
-interface SavedProfile {
-  name: string
-  yaml: string
-  profileId: string
-  configId: string
-}
 
 export function CreateAgentFormView({
   catalog,
@@ -77,129 +38,34 @@ export function CreateAgentFormView({
   initialTemplate?: AgentTemplate
 }) {
   const { activeOrg, project, projectId } = useProjectPage()
-  const createAgentConfig = useCreateAgentConfig(activeOrg.id, projectId)
-  const createAgentProfile = useCreateAgentProfile(activeOrg.id, projectId)
-  const updateAgentProfile = useUpdateAgentProfile(activeOrg.id, projectId)
-  const createAgent = useCreateAgent(activeOrg.id, projectId)
-  const { data: webConfig } = useWebConfig()
-  const navigate = useNavigate()
-  const [mode, dispatchMode] = useReducer(
-    agentConfigModeReducer,
-    initialAgentConfigModeState('builder'),
+  const {
+    submit: submitAgent,
+    status,
+    pendingAction,
+    launchError,
+    issues,
+  } = useCreateAgentSubmission(activeOrg.id, projectId)
+  const { name, setName, mode, dispatchMode, form, switchMode, applyTemplate } = useAgentDraft(
+    catalog,
+    defaultPool,
+    defaultModel,
+    initialTemplate,
   )
-  const [restored] = useState(takeMcpBuilderOAuthRestore)
-  const [draft, setDraft] = useState<CreateAgentDraft>(() => ({
-    name: restored?.agentName ?? initialTemplate?.name ?? '',
-    status: idle,
-  }))
-  const [pendingAction, setPendingAction] = useState<SubmitAction | null>(null)
-  const [launchError, setLaunchError] = useState<ApiError>()
-  const savedProfile = useRef<SavedProfile | null>(null)
-  const [session, setSession] = useState(() => createBasicConfigSession(''))
-  const form = useAgentBuilderForm(
-    session,
-    restored?.draft ??
-      (initialTemplate
-        ? agentTemplateBasicConfig(initialTemplate, catalog, defaultPool, defaultModel)
-        : { ...emptyBasicConfig, tools: defaultAgentTools(catalog) }),
-  )
-  const switchMode = (nextMode: AgentConfigMode) => {
-    if (nextMode === 'builder' && mode.editorYaml !== null) {
-      const adopted = createBasicConfigSession(mode.editorYaml)
-      if (adopted.initialDraft != null) {
-        setSession(adopted)
-        form.reset(adopted.initialDraft)
-        dispatchMode({ type: 'adopt-yaml-edits' })
-        return
-      }
-    }
-    dispatchMode({ type: 'switch-mode', mode: nextMode })
-  }
-
-  function applyTemplate(template: AgentTemplate) {
-    const next = agentTemplateBasicConfig(template, catalog, defaultPool, defaultModel)
-    // Keep a model the user already picked; templates only fill the gap.
-    if (form.model.providerConfig !== '' && form.model.modelName !== '') {
-      next.providerConfig = form.model.providerConfig
-      next.modelName = form.model.modelName
-    }
-    form.reset(next)
-    setDraft((prev) => ({ ...prev, name: agentTemplateName(prev.name, template) }))
-  }
-
-  const [issues, setIssues] = useState<AgentConfigErrorIssue[]>([])
 
   if (project == null) return null
 
   const showBuilder = mode.mode === 'builder'
-  const isSubmitting = draft.status.phase === 'submitting'
-  const errorMessage = statusError(draft.status)
+  const isSubmitting = status.phase === 'submitting'
   const yaml = mode.editorYaml ?? form.yaml
   const canSubmit =
     !isSubmitting &&
-    resourceNameValid(draft.name) &&
+    resourceNameValid(name) &&
     yaml.trim() !== '' &&
     !(form.blocked && (showBuilder || !yamlDiverged(mode)))
 
   async function submit(action: SubmitAction) {
     if (!canSubmit) return
-    setLaunchError(undefined)
-    setIssues([])
-    setDraft((prev) => ({ ...prev, status: submitting }))
-    setPendingAction(action)
-    const name = draft.name
-    const result = await settleSubmission(async () => {
-      let profile = savedProfile.current
-      if (profile?.name !== name || profile.yaml !== yaml) {
-        const config = await createAgentConfig.mutateAsync({ source: yaml, source_format: 'yaml' })
-        if (profile?.name === name) {
-          await updateAgentProfile.mutateAsync({
-            agentProfileID: profile.profileId,
-            config: config.id,
-            expected_current_config_id: profile.configId,
-          })
-          profile = { ...profile, yaml, configId: config.id }
-        } else {
-          const created = await createAgentProfile.mutateAsync({ name, config: config.id })
-          profile = { name, yaml, profileId: created.id, configId: config.id }
-        }
-        savedProfile.current = profile
-      }
-      if (action === 'launch') {
-        const launch = await createAgent.mutateAsync({
-          profile: profile.profileId,
-          config: profile.configId,
-        })
-        await navigate({
-          to: '/projects/$projectId/agents/$agentId',
-          params: { projectId, agentId: launch.agent.id },
-        })
-      } else {
-        await navigate({
-          to: '/projects/$projectId/agent-profiles/$profileId',
-          params: { projectId, profileId: profile.profileId },
-        })
-      }
-    }).finally(() => {
-      setPendingAction(null)
-    })
-
-    if (result.ok) {
-      setDraft((prev) => ({ ...prev, status: idle }))
-    } else {
-      if (action === 'launch' && isInsufficientCreditsError(result.error)) {
-        setLaunchError(result.error)
-      }
-      const failure = configSubmitError(
-        result.error,
-        action === 'launch' ? 'Could not create agent' : 'Could not create profile',
-      )
-      setIssues(failure.issues)
-      setDraft((prev) => ({
-        ...prev,
-        status: { phase: 'error', message: failure.message },
-      }))
-    }
+    await submitAgent(name, yaml, action)
   }
 
   return (
@@ -256,14 +122,14 @@ export function CreateAgentFormView({
                 <Input
                   id="agent-config-name"
                   required
-                  value={draft.name}
+                  value={name}
                   placeholder="Demo research agent"
                   className={cn(!showBuilder && 'max-w-md')}
                   onChange={(event) => {
-                    setDraft((prev) => ({ ...prev, name: event.target.value }))
+                    setName(event.target.value)
                   }}
                 />
-                <ResourceNameFieldError value={draft.name} />
+                <ResourceNameFieldError value={name} />
               </Field>
               {showBuilder && (
                 <AgentConfigModelField
@@ -280,7 +146,7 @@ export function CreateAgentFormView({
                 orgId={activeOrg.id}
                 projectId={projectId}
                 form={form}
-                agentName={draft.name}
+                agentName={name}
               />
               <AgentConfigIssueList issues={issues} />
             </div>
@@ -298,48 +164,16 @@ export function CreateAgentFormView({
           </FieldGroup>
         </div>
       </div>
-      <div className="bg-sidebar -mx-4 -mb-4 flex flex-col gap-3 border-t px-4 py-3.5 sm:-mx-6 sm:-mb-6 sm:flex-row sm:items-center sm:justify-between sm:gap-4 sm:px-8">
-        <Button
-          type="button"
-          variant="ghost"
-          disabled={isSubmitting}
-          className="w-full sm:w-auto"
-          onClick={() => {
-            void navigate({ to: '/projects/$projectId/agents', params: { projectId } })
-          }}
-        >
-          Cancel
-        </Button>
-        <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center sm:gap-4">
-          {launchError && webConfig?.billingURL ? (
-            <p className="text-destructive whitespace-pre-wrap text-sm" role="alert">
-              <InsufficientCreditsMessage billingHref={webConfig.billingHref} />
-            </p>
-          ) : errorMessage ? (
-            <p className="text-destructive whitespace-pre-wrap text-sm">{errorMessage}</p>
-          ) : null}
-          <Button
-            type="button"
-            variant="outline"
-            disabled={!canSubmit}
-            loading={pendingAction === 'profile'}
-            className="w-full sm:w-auto"
-            onClick={() => {
-              void submit('profile')
-            }}
-          >
-            Create profile
-          </Button>
-          <Button
-            type="submit"
-            disabled={!canSubmit}
-            loading={pendingAction === 'launch'}
-            className="w-full sm:w-auto"
-          >
-            Create & launch agent
-          </Button>
-        </div>
-      </div>
+      <CreateAgentActions
+        projectId={projectId}
+        status={status}
+        pendingAction={pendingAction}
+        launchError={launchError}
+        canSubmit={canSubmit}
+        onCreateProfile={() => {
+          void submit('profile')
+        }}
+      />
       <ConfirmDiscardYamlDialog
         open={mode.confirmDiscard}
         onOpenChange={(open) => {

--- a/frontend/apps/web/src/components/agents/CreateAgentFormView.tsx
+++ b/frontend/apps/web/src/components/agents/CreateAgentFormView.tsx
@@ -229,7 +229,7 @@ export function CreateAgentFormView({
           />
           <div className="mx-auto flex w-full max-w-3xl flex-wrap items-center justify-between gap-2">
             <div>
-              <h1 className="text-2xl font-bold tracking-tight">New agent</h1>
+              <h1 className="type-title">New agent</h1>
               <p className="text-muted-foreground mt-0.5 text-sm">
                 Define a reusable agent profile for this project.
               </p>

--- a/frontend/apps/web/src/components/agents/DeployAgentProfileDialog.tsx
+++ b/frontend/apps/web/src/components/agents/DeployAgentProfileDialog.tsx
@@ -140,7 +140,7 @@ export function DeployAgentProfileDialog({
                   <FieldLabel htmlFor="slack-app-configuration-token">
                     App configuration token
                   </FieldLabel>
-                  <FieldDescription className="text-[13px] leading-snug">
+                  <FieldDescription className="text-caption leading-snug">
                     This token lets Omnara create and configure the Slack app automatically.
                     Generate one in{' '}
                     <a

--- a/frontend/apps/web/src/components/agents/useAgentDraft.ts
+++ b/frontend/apps/web/src/components/agents/useAgentDraft.ts
@@ -1,0 +1,67 @@
+import type { ConfiguredModelSummary, MachinePoolSummary, ToolCatalog } from '@omnara/sdk'
+import { useReducer, useState } from 'react'
+
+import {
+  type AgentConfigMode,
+  agentConfigModeReducer,
+  initialAgentConfigModeState,
+} from '@/components/agents/agentConfigModeMachine'
+import {
+  type AgentTemplate,
+  agentTemplateBasicConfig,
+  agentTemplateName,
+  defaultAgentTools,
+} from '@/components/agents/agentTemplates'
+import { takeMcpBuilderOAuthRestore } from '@/components/agents/pendingMcpBuilderOAuth'
+import {
+  createBasicConfigSession,
+  emptyBasicConfig,
+  useAgentBuilderForm,
+} from '@/components/agents/useAgentBuilderForm'
+
+export function useAgentDraft(
+  catalog: ToolCatalog | undefined,
+  defaultPool: MachinePoolSummary | undefined,
+  defaultModel: ConfiguredModelSummary | undefined,
+  initialTemplate: AgentTemplate | undefined,
+) {
+  const [mode, dispatchMode] = useReducer(
+    agentConfigModeReducer,
+    initialAgentConfigModeState('builder'),
+  )
+  const [restored] = useState(takeMcpBuilderOAuthRestore)
+  const [name, setName] = useState(restored?.agentName ?? initialTemplate?.name ?? '')
+  const [session, setSession] = useState(() => createBasicConfigSession(''))
+  const form = useAgentBuilderForm(
+    session,
+    restored?.draft ??
+      (initialTemplate
+        ? agentTemplateBasicConfig(initialTemplate, catalog, defaultPool, defaultModel)
+        : { ...emptyBasicConfig, tools: defaultAgentTools(catalog) }),
+  )
+  const switchMode = (nextMode: AgentConfigMode) => {
+    if (nextMode === 'builder' && mode.editorYaml !== null) {
+      const adopted = createBasicConfigSession(mode.editorYaml)
+      if (adopted.initialDraft != null) {
+        setSession(adopted)
+        form.reset(adopted.initialDraft)
+        dispatchMode({ type: 'adopt-yaml-edits' })
+        return
+      }
+    }
+    dispatchMode({ type: 'switch-mode', mode: nextMode })
+  }
+
+  function applyTemplate(template: AgentTemplate) {
+    const next = agentTemplateBasicConfig(template, catalog, defaultPool, defaultModel)
+    // Keep a model the user already picked; templates only fill the gap.
+    if (form.model.providerConfig !== '' && form.model.modelName !== '') {
+      next.providerConfig = form.model.providerConfig
+      next.modelName = form.model.modelName
+    }
+    form.reset(next)
+    setName((prev) => agentTemplateName(prev, template))
+  }
+
+  return { name, setName, mode, dispatchMode, form, switchMode, applyTemplate }
+}

--- a/frontend/apps/web/src/components/agents/useAgentDraft.ts
+++ b/frontend/apps/web/src/components/agents/useAgentDraft.ts
@@ -54,7 +54,6 @@ export function useAgentDraft(
 
   function applyTemplate(template: AgentTemplate) {
     const next = agentTemplateBasicConfig(template, catalog, defaultPool, defaultModel)
-    // Keep a model the user already picked; templates only fill the gap.
     if (form.model.providerConfig !== '' && form.model.modelName !== '') {
       next.providerConfig = form.model.providerConfig
       next.modelName = form.model.modelName

--- a/frontend/apps/web/src/components/agents/useCreateAgentSubmission.ts
+++ b/frontend/apps/web/src/components/agents/useCreateAgentSubmission.ts
@@ -1,0 +1,94 @@
+import {
+  useCreateAgent,
+  useCreateAgentConfig,
+  useCreateAgentProfile,
+  useUpdateAgentProfile,
+} from '@omnara/react'
+import type { AgentConfigErrorIssue, ApiError } from '@omnara/sdk'
+import { useNavigate } from '@tanstack/react-router'
+import { useRef, useState } from 'react'
+
+import { configSubmitError } from '@/lib/agent-config-issues'
+import { isInsufficientCreditsError } from '@/lib/insufficient-credits'
+import type { SubmitStatus } from '@/lib/submit-status'
+import { idle, settleSubmission, submitting } from '@/lib/submit-status'
+
+export type SubmitAction = 'profile' | 'launch'
+
+interface SavedProfile {
+  name: string
+  yaml: string
+  profileId: string
+  configId: string
+}
+
+export function useCreateAgentSubmission(orgId: string, projectId: string) {
+  const createAgentConfig = useCreateAgentConfig(orgId, projectId)
+  const createAgentProfile = useCreateAgentProfile(orgId, projectId)
+  const updateAgentProfile = useUpdateAgentProfile(orgId, projectId)
+  const createAgent = useCreateAgent(orgId, projectId)
+  const navigate = useNavigate()
+  const [status, setStatus] = useState<SubmitStatus>(idle)
+  const [pendingAction, setPendingAction] = useState<SubmitAction | null>(null)
+  const [launchError, setLaunchError] = useState<ApiError>()
+  const [issues, setIssues] = useState<AgentConfigErrorIssue[]>([])
+  const savedProfile = useRef<SavedProfile | null>(null)
+
+  async function submit(name: string, yaml: string, action: SubmitAction) {
+    setLaunchError(undefined)
+    setIssues([])
+    setStatus(submitting)
+    setPendingAction(action)
+    const result = await settleSubmission(async () => {
+      let profile = savedProfile.current
+      if (profile?.name !== name || profile.yaml !== yaml) {
+        const config = await createAgentConfig.mutateAsync({ source: yaml, source_format: 'yaml' })
+        if (profile?.name === name) {
+          await updateAgentProfile.mutateAsync({
+            agentProfileID: profile.profileId,
+            config: config.id,
+            expected_current_config_id: profile.configId,
+          })
+          profile = { ...profile, yaml, configId: config.id }
+        } else {
+          const created = await createAgentProfile.mutateAsync({ name, config: config.id })
+          profile = { name, yaml, profileId: created.id, configId: config.id }
+        }
+        savedProfile.current = profile
+      }
+      if (action === 'launch') {
+        const launch = await createAgent.mutateAsync({
+          profile: profile.profileId,
+          config: profile.configId,
+        })
+        await navigate({
+          to: '/projects/$projectId/agents/$agentId',
+          params: { projectId, agentId: launch.agent.id },
+        })
+      } else {
+        await navigate({
+          to: '/projects/$projectId/agent-profiles/$profileId',
+          params: { projectId, profileId: profile.profileId },
+        })
+      }
+    }).finally(() => {
+      setPendingAction(null)
+    })
+
+    if (result.ok) {
+      setStatus(idle)
+    } else {
+      if (action === 'launch' && isInsufficientCreditsError(result.error)) {
+        setLaunchError(result.error)
+      }
+      const failure = configSubmitError(
+        result.error,
+        action === 'launch' ? 'Could not create agent' : 'Could not create profile',
+      )
+      setIssues(failure.issues)
+      setStatus({ phase: 'error', message: failure.message })
+    }
+  }
+
+  return { submit, status, pendingAction, launchError, issues }
+}

--- a/frontend/apps/web/src/components/api-tokens/OrgApiKeysSection.tsx
+++ b/frontend/apps/web/src/components/api-tokens/OrgApiKeysSection.tsx
@@ -16,7 +16,7 @@ export function OrgApiKeysSection({ orgId }: { orgId: string }) {
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <h2 className="text-2xl font-bold tracking-tight">Organization API tokens</h2>
+        <h2 className="type-title">Organization API tokens</h2>
         <Button
           size="sm"
           onClick={() => {

--- a/frontend/apps/web/src/components/api-tokens/PersonalAccessTokensSection.tsx
+++ b/frontend/apps/web/src/components/api-tokens/PersonalAccessTokensSection.tsx
@@ -16,7 +16,7 @@ export function PersonalAccessTokensSection() {
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <h2 className="text-2xl font-bold tracking-tight">Personal access tokens</h2>
+        <h2 className="type-title">Personal access tokens</h2>
         <Button
           size="sm"
           onClick={() => {

--- a/frontend/apps/web/src/components/auth/AuthLayout.tsx
+++ b/frontend/apps/web/src/components/auth/AuthLayout.tsx
@@ -37,7 +37,7 @@ export function AuthLayout({ children }: { children: ReactNode }) {
           <Wordmark />
         </div>
         <div className="relative z-10 space-y-3">
-          <p className="text-foreground type-page-title">The API for production-grade agents.</p>
+          <p className="text-foreground type-title">The API for production-grade agents.</p>
           <p className="text-muted-foreground text-base">Omnara console</p>
         </div>
       </aside>

--- a/frontend/apps/web/src/components/auth/AuthLayout.tsx
+++ b/frontend/apps/web/src/components/auth/AuthLayout.tsx
@@ -26,7 +26,7 @@ export function AuthLayout({ children }: { children: ReactNode }) {
   return (
     <div className="grid min-h-svh lg:grid-cols-2">
       <aside className="relative hidden flex-col justify-between overflow-hidden p-10 lg:flex">
-        <div className="from-primary/10 via-card to-card absolute inset-0 bg-gradient-to-br" />
+        <div className="from-primary/10 via-card to-card bg-linear-to-br absolute inset-0" />
         <div aria-hidden className="absolute inset-0 opacity-40" style={dotGrid} />
         <div
           aria-hidden

--- a/frontend/apps/web/src/components/auth/AuthLayout.tsx
+++ b/frontend/apps/web/src/components/auth/AuthLayout.tsx
@@ -4,7 +4,7 @@ import { BrandMark } from '@/components/brand/OmnaraMark'
 
 function Wordmark() {
   return (
-    <div className="flex items-center gap-2 text-base font-semibold tracking-tight">
+    <div className="type-card-title flex items-center gap-2 text-base">
       <BrandMark className="size-5" />
       Omnara
     </div>
@@ -37,9 +37,7 @@ export function AuthLayout({ children }: { children: ReactNode }) {
           <Wordmark />
         </div>
         <div className="relative z-10 space-y-3">
-          <p className="text-foreground text-3xl font-semibold tracking-tight">
-            The API for production-grade agents.
-          </p>
+          <p className="text-foreground type-page-title">The API for production-grade agents.</p>
           <p className="text-muted-foreground text-base">Omnara console</p>
         </div>
       </aside>
@@ -59,7 +57,7 @@ export function AuthLayout({ children }: { children: ReactNode }) {
 export function AuthHeading({ title, subtitle }: { title: string; subtitle: string }) {
   return (
     <div className="flex flex-col gap-2">
-      <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+      <h1 className="type-title">{title}</h1>
       <p className="text-muted-foreground text-pretty text-sm">{subtitle}</p>
     </div>
   )

--- a/frontend/apps/web/src/components/auth/LastUsedBadge.tsx
+++ b/frontend/apps/web/src/components/auth/LastUsedBadge.tsx
@@ -4,7 +4,7 @@ export function LastUsedBadge({ className }: { className?: string }) {
   return (
     <span
       className={cn(
-        'bg-muted text-muted-foreground rounded px-1.5 py-0.5 text-[10px] font-medium leading-none',
+        'bg-muted text-muted-foreground rounded px-1.5 py-0.5 text-xs font-medium leading-none',
         className,
       )}
     >

--- a/frontend/apps/web/src/components/auth/PasswordRequirements.tsx
+++ b/frontend/apps/web/src/components/auth/PasswordRequirements.tsx
@@ -20,7 +20,7 @@ export function PasswordRequirements({ id, password }: { id: string; password: s
           key={requirement.label}
           className={
             requirement.met
-              ? 'flex items-center gap-1.5 text-emerald-700 dark:text-emerald-400'
+              ? 'text-success flex items-center gap-1.5'
               : 'text-muted-foreground flex items-center gap-1.5'
           }
         >

--- a/frontend/apps/web/src/components/invitations/PendingInvitationList.tsx
+++ b/frontend/apps/web/src/components/invitations/PendingInvitationList.tsx
@@ -121,7 +121,7 @@ export function PendingInvitationList({
                     title={copiedInvitationID === invitation.id ? 'Copied' : 'Copy organization ID'}
                     onClick={() => void copyOrganizationID(invitation)}
                   >
-                    <code className="truncate font-mono text-[11px] font-normal">
+                    <code className="truncate font-mono text-xs font-normal">
                       {invitation.org_id}
                     </code>
                     {copiedInvitationID === invitation.id ? (

--- a/frontend/apps/web/src/components/layout/SearchHeader.tsx
+++ b/frontend/apps/web/src/components/layout/SearchHeader.tsx
@@ -26,7 +26,7 @@ export function SearchHeader({
   const showToolbar = toolbar !== undefined || onChange !== undefined || children !== undefined
   return (
     <div className="flex flex-col gap-3">
-      <h2 className="text-2xl font-bold tracking-tight">{title}</h2>
+      <h2 className="type-title">{title}</h2>
       {showToolbar && (
         <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:flex-wrap sm:items-center">
           {toolbar}

--- a/frontend/apps/web/src/components/org/ModelDiscoveryFailureStep.tsx
+++ b/frontend/apps/web/src/components/org/ModelDiscoveryFailureStep.tsx
@@ -36,7 +36,7 @@ export function ModelDiscoveryFailureStep({
             : 'The model provider already exists, but its available models could not be fetched.'}
         </DialogDescription>
       </DialogHeader>
-      <div role="alert" className="text-sm text-amber-600 dark:text-amber-500">
+      <div role="alert" className="text-warning text-sm">
         <p className="font-medium">Warning: unable to fetch available models. This might mean:</p>
         <ul className="mt-2 list-disc space-y-1 pl-5">
           <li>Your API token is expired or invalid</li>

--- a/frontend/apps/web/src/components/org/useMembersPage.ts
+++ b/frontend/apps/web/src/components/org/useMembersPage.ts
@@ -1,0 +1,93 @@
+import { useOrgInvitations, useOrgMembers } from '@omnara/react'
+import type { OrgInvitation, OrgMember } from '@omnara/sdk'
+import { useState } from 'react'
+
+import type { PaginationControls } from '@/hooks/use-paged-query'
+
+type MembershipRow =
+  | { kind: 'invitation'; id: string; invitation: OrgInvitation }
+  | { kind: 'member'; id: string; member: OrgMember }
+
+const PAGE_SIZE = 15
+
+export function useMembersPage(orgId: string, canManage: boolean) {
+  const [page, setPage] = useState(0)
+  const [paginationOwner, setPaginationOwner] = useState({
+    orgID: orgId,
+    canManage,
+  })
+  if (paginationOwner.orgID !== orgId || paginationOwner.canManage !== canManage) {
+    setPaginationOwner({ orgID: orgId, canManage })
+    setPage(0)
+  }
+
+  const invitationsQuery = useOrgInvitations(orgId, {
+    pageSize: PAGE_SIZE,
+    enabled: canManage,
+  })
+  const invitationsExhausted =
+    !canManage ||
+    invitationsQuery.isError ||
+    (invitationsQuery.isSuccess && !invitationsQuery.hasNextPage)
+  const membersQuery = useOrgMembers(orgId, {
+    sort: 'name',
+    pageSize: PAGE_SIZE,
+    enabled: invitationsExhausted,
+  })
+
+  const loadedRows: MembershipRow[] = []
+  for (const loadedPage of invitationsQuery.data?.pages ?? []) {
+    for (const invitation of loadedPage.data) {
+      loadedRows.push({ kind: 'invitation', id: invitation.id, invitation })
+    }
+  }
+  for (const loadedPage of membersQuery.data?.pages ?? []) {
+    for (const member of loadedPage.data) {
+      loadedRows.push({ kind: 'member', id: member.user_id, member })
+    }
+  }
+  const pageStart = page * PAGE_SIZE
+  const rows = loadedRows.slice(pageStart, pageStart + PAGE_SIZE)
+  const nextPageStart = pageStart + PAGE_SIZE
+  const nextPageEnd = nextPageStart + PAGE_SIZE
+  const hasLoadedNextPage = loadedRows.length > nextPageStart
+  const pagination: PaginationControls = {
+    page,
+    canPrev: page > 0,
+    canNext:
+      hasLoadedNextPage ||
+      invitationsQuery.hasNextPage ||
+      (invitationsExhausted && membersQuery.hasNextPage),
+    onPrev: () => {
+      setPage((current) => Math.max(current - 1, 0))
+    },
+    onNext: () => {
+      if (
+        loadedRows.length < nextPageEnd &&
+        invitationsQuery.hasNextPage &&
+        !invitationsQuery.isFetchingNextPage
+      ) {
+        void invitationsQuery.fetchNextPage().then(() => {
+          setPage((current) => current + 1)
+        })
+        return
+      }
+      if (
+        loadedRows.length < nextPageEnd &&
+        invitationsExhausted &&
+        membersQuery.hasNextPage &&
+        !membersQuery.isFetchingNextPage
+      ) {
+        void membersQuery.fetchNextPage().then(() => {
+          setPage((current) => current + 1)
+        })
+        return
+      }
+      if (hasLoadedNextPage) {
+        setPage((current) => current + 1)
+      }
+    },
+  }
+
+  return { invitationsQuery, membersQuery, invitationsExhausted, rows, pagination, setPage }
+}

--- a/frontend/apps/web/src/components/overview/AgentOnboarding.tsx
+++ b/frontend/apps/web/src/components/overview/AgentOnboarding.tsx
@@ -37,7 +37,7 @@ export function AgentOnboarding({ orgId, project }: { orgId: string; project: Vi
       >
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="flex flex-col gap-2">
-            <h2 className="text-2xl font-semibold tracking-tight">Launch your first agent</h2>
+            <h2 className="type-title">Launch your first agent</h2>
             <p className="text-muted-foreground text-sm">
               Follow the steps to create an agent profile and start a chat.
             </p>

--- a/frontend/apps/web/src/components/overview/CodeBlock.tsx
+++ b/frontend/apps/web/src/components/overview/CodeBlock.tsx
@@ -119,7 +119,7 @@ function Code({
   return (
     <pre
       className={cn(
-        'code-highlight overflow-x-auto whitespace-pre-wrap break-words px-4 py-4 font-mono text-sm leading-6 sm:px-6 sm:py-5',
+        'code-highlight type-code overflow-x-auto whitespace-pre-wrap break-words px-4 py-4 sm:px-6 sm:py-5',
         emphasis ? 'text-foreground font-medium' : 'text-muted-foreground',
         className,
       )}

--- a/frontend/apps/web/src/components/overview/OnboardingProfileDraft.tsx
+++ b/frontend/apps/web/src/components/overview/OnboardingProfileDraft.tsx
@@ -106,7 +106,7 @@ export function ProfileDraftStep({
                 'flex flex-col gap-2 rounded-xl border p-4 text-left transition-all sm:min-h-36 sm:p-6',
                 'focus-visible:ring-ring/50 focus-visible:outline-none focus-visible:ring-[3px]',
                 selected
-                  ? 'border-blue-500/40 bg-gradient-to-br from-blue-500/[0.06] via-blue-500/[0.02] to-transparent'
+                  ? 'border-primary/40 from-primary/[0.06] via-primary/[0.02] bg-gradient-to-br to-transparent'
                   : 'border-border bg-card hover:bg-muted/50',
               )}
               onClick={() => {
@@ -114,7 +114,7 @@ export function ProfileDraftStep({
                 setCustomDraft(null)
               }}
             >
-              <span className="text-sm font-semibold">{candidate.name}</span>
+              <span className="type-label">{candidate.name}</span>
               <span className="text-muted-foreground text-xs leading-snug">
                 {candidate.description}
               </span>

--- a/frontend/apps/web/src/components/overview/OnboardingProfileDraft.tsx
+++ b/frontend/apps/web/src/components/overview/OnboardingProfileDraft.tsx
@@ -106,7 +106,7 @@ export function ProfileDraftStep({
                 'flex flex-col gap-2 rounded-xl border p-4 text-left transition-all sm:min-h-36 sm:p-6',
                 'focus-visible:ring-ring/50 focus-visible:outline-none focus-visible:ring-[3px]',
                 selected
-                  ? 'border-primary/40 from-primary/[0.06] via-primary/[0.02] bg-gradient-to-br to-transparent'
+                  ? 'border-primary/40 from-primary/[0.06] via-primary/[0.02] bg-linear-to-br to-transparent'
                   : 'border-border bg-card hover:bg-muted/50',
               )}
               onClick={() => {

--- a/frontend/apps/web/src/components/overview/OnboardingSteps.tsx
+++ b/frontend/apps/web/src/components/overview/OnboardingSteps.tsx
@@ -75,7 +75,7 @@ export function OnboardingStep({
                 : status === 'done' || nextStatus === 'done'
                   ? '-bottom-[81px]'
                   : '-bottom-[57px]',
-              status === 'done' && nextStatus === 'done' && 'bg-blue-500/60',
+              status === 'done' && nextStatus === 'done' && 'bg-primary/60',
               status === 'done' &&
                 nextStatus !== 'done' &&
                 'to-border bg-gradient-to-b from-blue-500',
@@ -87,7 +87,7 @@ export function OnboardingStep({
           aria-hidden="true"
           className={cn(
             'bg-background absolute -left-12 top-[9px] hidden size-[11px] rounded-full border-2 transition-colors duration-500 sm:block',
-            status === 'done' && 'border-blue-500/80',
+            status === 'done' && 'border-primary/80',
             status === 'active' && 'border-foreground',
             status === 'upcoming' && 'border-muted-foreground',
           )}
@@ -109,14 +109,14 @@ export function OnboardingStep({
             <div className="flex min-w-0 flex-col gap-5 sm:gap-8">
               <div className="flex flex-col items-start gap-1.5 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:gap-x-6">
                 <div className="flex flex-col gap-1.5">
-                  <h3 className="flex items-center gap-2 text-lg font-semibold tracking-tight sm:text-xl">
+                  <h3 className="type-card-title flex items-center gap-2">
                     {status === 'done' ? doneTitle : title}
                     {pending && status !== 'done' && (
                       <span
                         role="status"
                         aria-label="Working"
                         data-slot="step-spinner"
-                        className="border-muted-foreground/25 size-4 animate-spin rounded-full border-2 border-t-blue-500"
+                        className="border-muted-foreground/25 size-4 rounded-full border-2 border-t-blue-500 motion-safe:animate-spin"
                       />
                     )}
                   </h3>
@@ -127,7 +127,7 @@ export function OnboardingStep({
                 {status === 'done' && completion && (
                   <div
                     data-slot="step-completion"
-                    className="flex items-center text-sm font-medium text-blue-600/70 dark:text-blue-300/70"
+                    className="text-link flex items-center text-sm font-medium"
                   >
                     {completion}
                   </div>

--- a/frontend/apps/web/src/components/overview/OnboardingSteps.tsx
+++ b/frontend/apps/web/src/components/overview/OnboardingSteps.tsx
@@ -12,6 +12,70 @@ export function OnboardingSteps({ children }: { children: ReactNode }) {
   )
 }
 
+function StepRail({ status, nextStatus }: { status: StepStatus; nextStatus: StepStatus }) {
+  return (
+    <span
+      aria-hidden="true"
+      data-slot="step-rail"
+      className={cn(
+        'absolute -left-[43px] hidden w-px transition-colors duration-700 sm:block',
+        'top-[20px]',
+        status === 'done' && nextStatus === 'done'
+          ? '-bottom-[105px]'
+          : status === 'done' || nextStatus === 'done'
+            ? '-bottom-[81px]'
+            : '-bottom-[57px]',
+        status === 'done' && nextStatus === 'done' && 'bg-primary/60',
+        status === 'done' && nextStatus !== 'done' && 'to-border from-primary bg-gradient-to-b',
+        status !== 'done' && 'bg-border',
+      )}
+    />
+  )
+}
+
+function StepHeading({
+  title,
+  doneTitle,
+  description,
+  status,
+  pending,
+  completion,
+}: {
+  title: string
+  doneTitle: string
+  description: string
+  status: StepStatus
+  pending: boolean
+  completion?: ReactNode
+}) {
+  return (
+    <div className="flex flex-col items-start gap-1.5 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:gap-x-6">
+      <div className="flex flex-col gap-1.5">
+        <h3 className="type-card-title flex items-center gap-2">
+          {status === 'done' ? doneTitle : title}
+          {pending && status !== 'done' && (
+            <span
+              role="status"
+              aria-label="Working"
+              data-slot="step-spinner"
+              className="border-muted-foreground/25 border-t-primary size-4 rounded-full border-2 motion-safe:animate-spin"
+            />
+          )}
+        </h3>
+        {status !== 'done' && <p className="text-muted-foreground text-sm">{description}</p>}
+      </div>
+      {status === 'done' && completion && (
+        <div
+          data-slot="step-completion"
+          className="text-link flex items-center text-sm font-medium"
+        >
+          {completion}
+        </div>
+      )}
+    </div>
+  )
+}
+
 export function OnboardingStep({
   index,
   title,
@@ -63,26 +127,7 @@ export function OnboardingStep({
           status === 'upcoming' && 'pointer-events-none select-none opacity-40',
         )}
       >
-        {nextStatus && (
-          <span
-            aria-hidden="true"
-            data-slot="step-rail"
-            className={cn(
-              'absolute -left-[43px] hidden w-px transition-colors duration-700 sm:block',
-              'top-[20px]',
-              status === 'done' && nextStatus === 'done'
-                ? '-bottom-[105px]'
-                : status === 'done' || nextStatus === 'done'
-                  ? '-bottom-[81px]'
-                  : '-bottom-[57px]',
-              status === 'done' && nextStatus === 'done' && 'bg-primary/60',
-              status === 'done' &&
-                nextStatus !== 'done' &&
-                'to-border bg-gradient-to-b from-blue-500',
-              status !== 'done' && 'bg-border',
-            )}
-          />
-        )}
+        {nextStatus && <StepRail status={status} nextStatus={nextStatus} />}
         <span
           aria-hidden="true"
           className={cn(
@@ -95,7 +140,7 @@ export function OnboardingStep({
         <div
           className={cn(
             'min-w-0 flex-1 rounded-2xl p-px sm:-m-6',
-            status === 'done' && 'bg-gradient-to-r from-blue-500/25 to-transparent',
+            status === 'done' && 'from-primary/25 bg-gradient-to-r to-transparent',
             status === 'done' && statusChanged && 'animate-in fade-in-0 duration-500',
           )}
         >
@@ -103,36 +148,18 @@ export function OnboardingStep({
             className={cn(
               'min-w-0 rounded-[15px] p-[15px] sm:p-[23px]',
               status === 'done' &&
-                'bg-background bg-gradient-to-r from-blue-500/[0.07] to-transparent',
+                'bg-background from-primary/[0.07] bg-gradient-to-r to-transparent',
             )}
           >
             <div className="flex min-w-0 flex-col gap-5 sm:gap-8">
-              <div className="flex flex-col items-start gap-1.5 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:gap-x-6">
-                <div className="flex flex-col gap-1.5">
-                  <h3 className="type-card-title flex items-center gap-2">
-                    {status === 'done' ? doneTitle : title}
-                    {pending && status !== 'done' && (
-                      <span
-                        role="status"
-                        aria-label="Working"
-                        data-slot="step-spinner"
-                        className="border-muted-foreground/25 size-4 rounded-full border-2 border-t-blue-500 motion-safe:animate-spin"
-                      />
-                    )}
-                  </h3>
-                  {status !== 'done' && (
-                    <p className="text-muted-foreground text-sm">{description}</p>
-                  )}
-                </div>
-                {status === 'done' && completion && (
-                  <div
-                    data-slot="step-completion"
-                    className="text-link flex items-center text-sm font-medium"
-                  >
-                    {completion}
-                  </div>
-                )}
-              </div>
+              <StepHeading
+                title={title}
+                doneTitle={doneTitle}
+                description={description}
+                status={status}
+                pending={pending}
+                completion={completion}
+              />
               {children}
             </div>
           </div>

--- a/frontend/apps/web/src/components/overview/OnboardingSteps.tsx
+++ b/frontend/apps/web/src/components/overview/OnboardingSteps.tsx
@@ -26,7 +26,7 @@ function StepRail({ status, nextStatus }: { status: StepStatus; nextStatus: Step
             ? '-bottom-[81px]'
             : '-bottom-[57px]',
         status === 'done' && nextStatus === 'done' && 'bg-primary/60',
-        status === 'done' && nextStatus !== 'done' && 'to-border from-primary bg-gradient-to-b',
+        status === 'done' && nextStatus !== 'done' && 'to-border from-primary bg-linear-to-b',
         status !== 'done' && 'bg-border',
       )}
     />
@@ -140,7 +140,7 @@ export function OnboardingStep({
         <div
           className={cn(
             'min-w-0 flex-1 rounded-2xl p-px sm:-m-6',
-            status === 'done' && 'from-primary/25 bg-gradient-to-r to-transparent',
+            status === 'done' && 'from-primary/25 bg-linear-to-r to-transparent',
             status === 'done' && statusChanged && 'animate-in fade-in-0 duration-500',
           )}
         >
@@ -148,7 +148,7 @@ export function OnboardingStep({
             className={cn(
               'min-w-0 rounded-[15px] p-[15px] sm:p-[23px]',
               status === 'done' &&
-                'bg-background from-primary/[0.07] bg-gradient-to-r to-transparent',
+                'bg-background from-primary/[0.07] bg-linear-to-r to-transparent',
             )}
           >
             <div className="flex min-w-0 flex-col gap-5 sm:gap-8">

--- a/frontend/apps/web/src/components/overview/RecentAgents.tsx
+++ b/frontend/apps/web/src/components/overview/RecentAgents.tsx
@@ -31,9 +31,7 @@ export function RecentAgentsSection({
     <div className="flex flex-col gap-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex flex-col gap-1">
-          <h2 className="text-2xl font-bold tracking-tight">
-            {showProfiles ? 'Recent profiles' : 'Recent agents'}
-          </h2>
+          <h2 className="type-title">{showProfiles ? 'Recent profiles' : 'Recent agents'}</h2>
           {showProfiles && (
             <p className="text-muted-foreground text-sm">
               No agents running right now. Open a profile to launch one.

--- a/frontend/apps/web/src/components/projects/ProjectPageFrame.tsx
+++ b/frontend/apps/web/src/components/projects/ProjectPageFrame.tsx
@@ -18,7 +18,7 @@ export function ProjectPageFrame({
   if (!context.project) {
     return (
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-2">
-        <h1 className="text-xl font-semibold tracking-tight">Project not found</h1>
+        <h1 className="type-title">Project not found</h1>
         <p className="text-muted-foreground text-sm">
           This project doesn&rsquo;t exist or you don&rsquo;t have access to it.
         </p>

--- a/frontend/apps/web/src/components/skills/SkillMdEditor.tsx
+++ b/frontend/apps/web/src/components/skills/SkillMdEditor.tsx
@@ -4,15 +4,12 @@ import type * as Monaco from 'monaco-editor'
 import { use, useEffect, useEffectEvent, useRef } from 'react'
 
 import { cn } from '@/lib/utils'
+import { editorAppearance } from '@/styles/editor'
 
 const monacoPromise = Promise.all([
   import('monaco-editor'),
   import('monaco-editor/esm/vs/basic-languages/markdown/markdown.contribution.js'),
 ]).then(([module]) => module)
-
-function monacoThemeFromDocument() {
-  return document.documentElement.classList.contains('dark') ? 'vs-dark' : 'vs'
-}
 
 export function SkillMdEditor({
   id,
@@ -48,21 +45,20 @@ export function SkillMdEditor({
       model,
       ariaLabel: 'SKILL.md',
       automaticLayout: true,
-      fontFamily: 'var(--font-mono)',
-      fontSize: 12,
-      lineHeight: 18,
+      ...editorAppearance(monaco, editorElementRef.current),
       minimap: { enabled: false },
       padding: { top: 12, bottom: 12 },
       readOnly: initialReadOnlyRef.current,
       scrollBeyondLastLine: false,
       stickyScroll: { enabled: false },
-      theme: monacoThemeFromDocument(),
       wordWrap: 'on',
       wrappingIndent: 'same',
     })
 
     const themeObserver = new MutationObserver(() => {
-      editorRef.current?.updateOptions({ theme: monacoThemeFromDocument() })
+      if (editorElementRef.current) {
+        editorRef.current?.updateOptions(editorAppearance(monaco, editorElementRef.current))
+      }
     })
     themeObserver.observe(document.documentElement, {
       attributeFilter: ['class'],
@@ -99,7 +95,7 @@ export function SkillMdEditor({
       id={id}
       ref={editorElementRef}
       className={cn(
-        'border-input bg-background h-80 overflow-hidden rounded-md border text-xs',
+        'border-input bg-card type-code rounded-control h-80 overflow-hidden border',
         className,
       )}
     />

--- a/frontend/apps/web/src/components/skills/UpdateSkillDialog.tsx
+++ b/frontend/apps/web/src/components/skills/UpdateSkillDialog.tsx
@@ -30,7 +30,7 @@ function SkillMdEditorFallback() {
       role="status"
       aria-live="polite"
     >
-      <Spinner className="text-muted-foreground h-6 w-6" />
+      <Spinner className="text-muted-foreground size-6" />
       <span className="sr-only">Loading SKILL.md editor</span>
     </div>
   )

--- a/frontend/apps/web/src/components/skills/UpdateSkillDialog.tsx
+++ b/frontend/apps/web/src/components/skills/UpdateSkillDialog.tsx
@@ -26,7 +26,7 @@ const LazySkillMdEditor = lazy(async () => {
 function SkillMdEditorFallback() {
   return (
     <div
-      className="border-input bg-background flex h-[65vh] items-center justify-center overflow-hidden rounded-md border"
+      className="border-input bg-card type-code rounded-control flex h-[65vh] items-center justify-center overflow-hidden border"
       role="status"
       aria-live="polite"
     >

--- a/frontend/apps/web/src/components/ui/badge.tsx
+++ b/frontend/apps/web/src/components/ui/badge.tsx
@@ -5,11 +5,12 @@ import type { ComponentProps } from 'react'
 import { cn } from '@/lib/utils'
 
 const badgeVariants = cva(
-  'inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-md border px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3',
+  'inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-md border px-2 py-0.5 text-xs font-medium whitespace-nowrap control-transition aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3',
   {
     variants: {
       variant: {
-        default: 'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+        default:
+          'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-(--primary-hover)',
         secondary:
           'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
         destructive:

--- a/frontend/apps/web/src/components/ui/button-variants.ts
+++ b/frontend/apps/web/src/components/ui/button-variants.ts
@@ -1,26 +1,24 @@
 import { cva } from 'class-variance-authority'
 
 export const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4.5",
+  "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap type-control control-focus control-transition rounded-control border border-transparent disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4.5",
   {
     variants: {
       variant: {
         default:
-          'bg-primary text-primary-foreground hover:bg-(--primary-hover) active:bg-(--primary-active) shadow-xs shadow-primary/30',
-        destructive:
-          'bg-destructive text-destructive-foreground hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40',
-        outline:
-          'border bg-background hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+          'bg-primary text-primary-foreground hover:bg-(--primary-hover) active:bg-(--primary-active)',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline: 'border-input bg-background hover:bg-accent hover:text-accent-foreground',
         secondary:
-          'bg-secondary text-secondary-foreground border-border/60 hover:bg-(--secondary-hover) border shadow-none',
-        ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
-        link: 'text-primary underline-offset-4 hover:underline',
+          'border-border bg-secondary text-secondary-foreground hover:bg-(--secondary-hover)',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-link hover:text-link-hover underline-offset-4 hover:underline',
       },
       size: {
-        default: 'h-10 px-4 py-2 has-[>svg]:px-3 data-[has-icon]:px-3 sm:h-9',
-        sm: 'h-9 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5 data-[has-icon]:px-2.5 sm:h-8',
-        lg: 'h-11 rounded-md px-6 has-[>svg]:px-4 data-[has-icon]:px-4 sm:h-10',
-        icon: 'size-10 sm:size-9',
+        default: 'h-10 px-5 py-2 has-[>svg]:px-3 data-[has-icon]:px-3',
+        sm: 'h-9 gap-1.5 px-3 has-[>svg]:px-2.5 data-[has-icon]:px-2.5',
+        lg: 'h-11 px-7 has-[>svg]:px-4 data-[has-icon]:px-4 sm:px-8',
+        icon: 'size-10',
       },
     },
     defaultVariants: { variant: 'default', size: 'default' },

--- a/frontend/apps/web/src/components/ui/card.tsx
+++ b/frontend/apps/web/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: ComponentProps<'div'>) {
     <div
       data-slot="card"
       className={cn(
-        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6',
+        'bg-card text-card-foreground rounded-card flex flex-col gap-6 border py-6',
         className,
       )}
       {...props}
@@ -29,13 +29,7 @@ function CardHeader({ className, ...props }: ComponentProps<'div'>) {
 }
 
 function CardTitle({ className, ...props }: ComponentProps<'div'>) {
-  return (
-    <div
-      data-slot="card-title"
-      className={cn('font-semibold leading-none', className)}
-      {...props}
-    />
-  )
+  return <div data-slot="card-title" className={cn('type-card-title', className)} {...props} />
 }
 
 function CardDescription({ className, ...props }: ComponentProps<'div'>) {

--- a/frontend/apps/web/src/components/ui/combobox.tsx
+++ b/frontend/apps/web/src/components/ui/combobox.tsx
@@ -11,7 +11,7 @@ function ComboboxInput({ className, ...props }: ComponentProps<typeof ComboboxPr
     <div className="relative">
       <ComboboxPrimitive.Input
         className={cn(
-          'border-input shadow-xs placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40 pointer-coarse:text-base h-9 w-full rounded-md border bg-transparent pl-3 pr-9 text-base outline-none transition-[color,box-shadow] focus-visible:ring-[3px] md:text-sm',
+          'border-input placeholder:text-muted-foreground aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 pointer-coarse:text-base control-focus control-transition bg-card h-10 w-full rounded-md border pl-3 pr-9 text-base md:text-sm',
           className,
         )}
         {...props}
@@ -28,7 +28,7 @@ function ComboboxChips({ className, ...props }: ComponentProps<typeof ComboboxPr
     <ComboboxPrimitive.InputGroup className="w-full">
       <ComboboxPrimitive.Chips
         className={cn(
-          'border-input shadow-xs focus-within:border-ring focus-within:ring-ring/50 dark:bg-input/30 flex min-h-9 w-full flex-wrap items-center gap-1 rounded-md border bg-transparent px-2 py-1 transition-[color,box-shadow] focus-within:ring-[3px]',
+          'border-input control-focus-within control-transition bg-card flex min-h-10 w-full flex-wrap items-center gap-1 rounded-md border px-2 py-1',
           className,
         )}
         {...props}
@@ -44,7 +44,7 @@ function ComboboxChipsInput({
   return (
     <ComboboxPrimitive.Input
       className={cn(
-        'placeholder:text-muted-foreground pointer-coarse:text-base h-6 min-w-28 flex-1 bg-transparent px-1 text-base outline-none md:text-sm',
+        'placeholder:text-muted-foreground pointer-coarse:text-base h-6 min-w-28 flex-1 bg-transparent px-1 text-base focus-visible:outline-none md:text-sm',
         className,
       )}
       {...props}
@@ -64,7 +64,7 @@ function ComboboxChip({
   return (
     <ComboboxPrimitive.Chip
       className={cn(
-        'bg-secondary text-secondary-foreground inline-flex h-6 max-w-full items-center gap-1 rounded-sm pl-2 pr-1 text-xs font-medium outline-none focus-visible:ring-2',
+        'bg-secondary text-secondary-foreground control-focus inline-flex h-6 max-w-full items-center gap-1 rounded-sm pl-2 pr-1 text-xs font-medium',
         className,
       )}
       {...props}
@@ -92,7 +92,7 @@ function ComboboxContent({ className, ...props }: ComponentProps<typeof Combobox
       >
         <ComboboxPrimitive.Popup
           className={cn(
-            'bg-popover text-popover-foreground w-[var(--anchor-width)] min-w-64 overflow-hidden rounded-md border shadow-lg outline-none',
+            'bg-popover text-popover-foreground control-focus w-[var(--anchor-width)] min-w-64 overflow-hidden rounded-md border shadow-lg',
             className,
           )}
           // Radix modal dialogs cancel wheel/touch events that reach document
@@ -128,7 +128,7 @@ function ComboboxItem({
   return (
     <ComboboxPrimitive.Item
       className={cn(
-        'data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-2 pl-2 pr-8 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        'data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground control-focus relative flex cursor-default items-center gap-2 rounded-sm py-2 pl-2 pr-8 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
         className,
       )}
       {...props}
@@ -162,7 +162,7 @@ function ComboboxStatus({ className, ...props }: ComponentProps<typeof ComboboxP
 function ComboboxLoading({ label = 'Searching…' }: { label?: string }) {
   return (
     <div className="text-muted-foreground flex items-center gap-2 border-t px-3 py-2 text-xs">
-      <LoaderCircleIcon className="size-3.5 animate-spin" />
+      <LoaderCircleIcon className="size-3.5 motion-safe:animate-spin" />
       {label}
     </div>
   )

--- a/frontend/apps/web/src/components/ui/combobox.tsx
+++ b/frontend/apps/web/src/components/ui/combobox.tsx
@@ -128,7 +128,7 @@ function ComboboxItem({
   return (
     <ComboboxPrimitive.Item
       className={cn(
-        'data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground control-focus relative flex cursor-default items-center gap-2 rounded-sm py-2 pl-2 pr-8 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        'data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground outline-hidden relative flex cursor-default items-center gap-2 rounded-sm py-2 pl-2 pr-8 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
         className,
       )}
       {...props}

--- a/frontend/apps/web/src/components/ui/dialog.tsx
+++ b/frontend/apps/web/src/components/ui/dialog.tsx
@@ -46,7 +46,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100svh-2rem)] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border p-4 shadow-lg duration-200 sm:max-w-lg sm:p-6',
+          'bg-card data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 rounded-card duration-(--duration-panel) fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100svh-2rem)] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border p-4 shadow-lg sm:max-w-lg sm:p-6',
           className,
         )}
         onSubmit={(event) => {
@@ -57,7 +57,7 @@ function DialogContent({
       >
         {children}
         {showCloseButton && (
-          <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground rounded-xs focus:outline-hidden [&_svg:not([class*='size-'])]:size-4.5 absolute right-4 top-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0">
+          <DialogPrimitive.Close className="control-focus data-[state=open]:bg-accent data-[state=open]:text-muted-foreground rounded-xs [&_svg:not([class*='size-'])]:size-4.5 absolute right-4 top-4 opacity-70 transition-opacity hover:opacity-100 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0">
             <XIcon />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>
@@ -91,7 +91,7 @@ function DialogTitle({ className, ...props }: ComponentProps<typeof DialogPrimit
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn('text-lg font-semibold leading-none', className)}
+      className={cn('type-card-title', className)}
       {...props}
     />
   )

--- a/frontend/apps/web/src/components/ui/dialog.tsx
+++ b/frontend/apps/web/src/components/ui/dialog.tsx
@@ -46,7 +46,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'bg-card data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 rounded-card duration-(--duration-panel) fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100svh-2rem)] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border p-4 shadow-lg sm:max-w-lg sm:p-6',
+          'bg-card data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 rounded-card fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100svh-2rem)] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border p-4 shadow-lg duration-[var(--duration-panel)] sm:max-w-lg sm:p-6',
           className,
         )}
         onSubmit={(event) => {

--- a/frontend/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/frontend/apps/web/src/components/ui/dropdown-menu.tsx
@@ -55,7 +55,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground control-focus [&_svg:not([class*='size-'])]:size-4.5 relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-2.5 text-base data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[disabled]:opacity-50 sm:py-1.5 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden [&_svg:not([class*='size-'])]:size-4.5 relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-2.5 text-base data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[disabled]:opacity-50 sm:py-1.5 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
@@ -73,7 +73,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground control-focus [&_svg:not([class*='size-'])]:size-4.5 relative flex cursor-default select-none items-center gap-2 rounded-sm py-2.5 pl-8 pr-2 text-base data-[disabled]:pointer-events-none data-[disabled]:opacity-50 sm:py-1.5 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground outline-hidden [&_svg:not([class*='size-'])]:size-4.5 relative flex cursor-default select-none items-center gap-2 rounded-sm py-2.5 pl-8 pr-2 text-base data-[disabled]:pointer-events-none data-[disabled]:opacity-50 sm:py-1.5 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       checked={checked}
@@ -104,7 +104,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground control-focus [&_svg:not([class*='size-'])]:size-4.5 relative flex cursor-default select-none items-center gap-2 rounded-sm py-2.5 pl-8 pr-2 text-base data-[disabled]:pointer-events-none data-[disabled]:opacity-50 sm:py-1.5 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground outline-hidden [&_svg:not([class*='size-'])]:size-4.5 relative flex cursor-default select-none items-center gap-2 rounded-sm py-2.5 pl-8 pr-2 text-base data-[disabled]:pointer-events-none data-[disabled]:opacity-50 sm:py-1.5 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
@@ -172,7 +172,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground control-focus flex cursor-default select-none items-center rounded-sm px-2 py-2.5 text-base data-[inset]:pl-8 sm:py-1.5 sm:text-sm',
+        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground outline-hidden flex cursor-default select-none items-center rounded-sm px-2 py-2.5 text-base data-[inset]:pl-8 sm:py-1.5 sm:text-sm',
         className,
       )}
       {...props}

--- a/frontend/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/frontend/apps/web/src/components/ui/dropdown-menu.tsx
@@ -55,7 +55,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden [&_svg:not([class*='size-'])]:size-4.5 relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-2.5 text-base data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[disabled]:opacity-50 sm:py-1.5 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground control-focus [&_svg:not([class*='size-'])]:size-4.5 relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-2.5 text-base data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[disabled]:opacity-50 sm:py-1.5 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
@@ -73,7 +73,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground outline-hidden [&_svg:not([class*='size-'])]:size-4.5 relative flex cursor-default select-none items-center gap-2 rounded-sm py-2.5 pl-8 pr-2 text-base data-[disabled]:pointer-events-none data-[disabled]:opacity-50 sm:py-1.5 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground control-focus [&_svg:not([class*='size-'])]:size-4.5 relative flex cursor-default select-none items-center gap-2 rounded-sm py-2.5 pl-8 pr-2 text-base data-[disabled]:pointer-events-none data-[disabled]:opacity-50 sm:py-1.5 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       checked={checked}
@@ -104,7 +104,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground outline-hidden [&_svg:not([class*='size-'])]:size-4.5 relative flex cursor-default select-none items-center gap-2 rounded-sm py-2.5 pl-8 pr-2 text-base data-[disabled]:pointer-events-none data-[disabled]:opacity-50 sm:py-1.5 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground control-focus [&_svg:not([class*='size-'])]:size-4.5 relative flex cursor-default select-none items-center gap-2 rounded-sm py-2.5 pl-8 pr-2 text-base data-[disabled]:pointer-events-none data-[disabled]:opacity-50 sm:py-1.5 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
@@ -128,7 +128,7 @@ function DropdownMenuLabel({
     <DropdownMenuPrimitive.Label
       data-slot="dropdown-menu-label"
       data-inset={inset}
-      className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
+      className={cn('type-control px-2 py-1.5 data-[inset]:pl-8', className)}
       {...props}
     />
   )
@@ -151,7 +151,7 @@ function DropdownMenuShortcut({ className, ...props }: ComponentProps<'span'>) {
   return (
     <span
       data-slot="dropdown-menu-shortcut"
-      className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+      className={cn('text-muted-foreground tracking-eyebrow ml-auto text-xs', className)}
       {...props}
     />
   )
@@ -172,7 +172,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground outline-hidden flex cursor-default select-none items-center rounded-sm px-2 py-2.5 text-base data-[inset]:pl-8 sm:py-1.5 sm:text-sm',
+        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground control-focus flex cursor-default select-none items-center rounded-sm px-2 py-2.5 text-base data-[inset]:pl-8 sm:py-1.5 sm:text-sm',
         className,
       )}
       {...props}

--- a/frontend/apps/web/src/components/ui/empty.tsx
+++ b/frontend/apps/web/src/components/ui/empty.tsx
@@ -7,7 +7,7 @@ function Empty({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="empty"
       className={cn(
-        'flex min-w-0 flex-1 flex-col items-center justify-center gap-6 text-balance rounded-lg border-dashed p-6 text-center md:p-12',
+        'rounded-card flex min-w-0 flex-1 flex-col items-center justify-center gap-6 text-balance border-dashed p-6 text-center md:p-12',
         className,
       )}
       {...props}
@@ -56,13 +56,7 @@ function EmptyMedia({
 }
 
 function EmptyTitle({ className, ...props }: React.ComponentProps<'div'>) {
-  return (
-    <div
-      data-slot="empty-title"
-      className={cn('text-lg font-medium tracking-tight', className)}
-      {...props}
-    />
-  )
+  return <div data-slot="empty-title" className={cn('type-card-title', className)} {...props} />
 }
 
 function EmptyDescription({ className, ...props }: React.ComponentProps<'p'>) {
@@ -70,7 +64,7 @@ function EmptyDescription({ className, ...props }: React.ComponentProps<'p'>) {
     <div
       data-slot="empty-description"
       className={cn(
-        'text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4',
+        'text-muted-foreground [&>a:hover]:text-link-hover type-body-small [&>a]:underline [&>a]:underline-offset-4',
         className,
       )}
       {...props}

--- a/frontend/apps/web/src/components/ui/field.tsx
+++ b/frontend/apps/web/src/components/ui/field.tsx
@@ -78,7 +78,7 @@ function CheckboxField({
           <span
             id={descriptionId}
             data-slot="field-description"
-            className="text-muted-foreground text-sm leading-normal"
+            className="text-muted-foreground type-body-small"
           >
             {description}
           </span>
@@ -141,7 +141,7 @@ function FieldDescription({ className, ...props }: ComponentProps<'p'>) {
   return (
     <p
       data-slot="field-description"
-      className={cn('text-muted-foreground text-sm leading-normal', className)}
+      className={cn('text-muted-foreground type-body-small', className)}
       {...props}
     />
   )
@@ -178,7 +178,7 @@ function FieldError({ className, children, errors, ...props }: FieldErrorProps) 
     <div
       role="alert"
       data-slot="field-error"
-      className={cn('text-destructive text-sm font-medium', className)}
+      className={cn('text-destructive type-control', className)}
       {...props}
     >
       {content}

--- a/frontend/apps/web/src/components/ui/input.tsx
+++ b/frontend/apps/web/src/components/ui/input.tsx
@@ -8,10 +8,8 @@ function Input({ className, type, ...props }: ComponentProps<'input'>) {
       type={type}
       data-slot="input"
       className={cn(
-        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input pointer-coarse:text-base flex h-10 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base outline-none transition-[color,box-shadow] file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 sm:h-9 md:text-sm',
-        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input pointer-coarse:text-base bg-card control-focus control-transition flex h-10 w-full min-w-0 rounded-md border px-3 py-1 text-base file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         'aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
-        'dark:bg-input/30',
         className,
       )}
       {...props}

--- a/frontend/apps/web/src/components/ui/input.tsx
+++ b/frontend/apps/web/src/components/ui/input.tsx
@@ -1,15 +1,23 @@
+import type { VariantProps } from 'class-variance-authority'
 import type { ComponentProps } from 'react'
 
+import { textFieldVariants } from '@/components/ui/text-field-variants'
 import { cn } from '@/lib/utils'
 
-function Input({ className, type, ...props }: ComponentProps<'input'>) {
+function Input({
+  className,
+  type,
+  variant,
+  ...props
+}: ComponentProps<'input'> & VariantProps<typeof textFieldVariants>) {
   return (
     <input
       type={type}
       data-slot="input"
       className={cn(
-        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input pointer-coarse:text-base bg-card control-focus control-transition flex h-10 w-full min-w-0 rounded-md border px-3 py-1 text-base file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground pointer-coarse:text-base control-transition flex h-10 w-full min-w-0 px-3 py-1 text-base file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         'aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
+        textFieldVariants({ variant }),
         className,
       )}
       {...props}

--- a/frontend/apps/web/src/components/ui/label.tsx
+++ b/frontend/apps/web/src/components/ui/label.tsx
@@ -8,7 +8,7 @@ function Label({ className, ...props }: ComponentProps<typeof LabelPrimitive.Roo
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        'flex select-none items-center gap-2 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50',
+        'type-label flex select-none items-center gap-2 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50',
         className,
       )}
       {...props}

--- a/frontend/apps/web/src/components/ui/message-scroller.tsx
+++ b/frontend/apps/web/src/components/ui/message-scroller.tsx
@@ -92,7 +92,7 @@ function MessageScrollerButton({
       data-size={size}
       direction={direction}
       className={cn(
-        'inset-s-1/2 border-border bg-background text-foreground hover:bg-muted hover:text-foreground data-[active=false]:duration-400 absolute -translate-x-1/2 transition-[translate,scale,opacity] duration-200 data-[active=false]:pointer-events-none data-[direction=end]:bottom-4 data-[direction=start]:top-4 data-[active=true]:translate-y-0 data-[direction=end]:data-[active=false]:translate-y-full data-[direction=start]:data-[active=false]:-translate-y-full data-[active=false]:scale-95 data-[active=true]:scale-100 data-[active=false]:opacity-0 data-[active=true]:opacity-100 data-[active=false]:ease-[cubic-bezier(0.7,0,0.84,0)] data-[active=true]:ease-[cubic-bezier(0.23,1,0.32,1)] rtl:translate-x-1/2 data-[direction=start]:[&_svg]:rotate-180',
+        'inset-s-1/2 border-border bg-background text-foreground hover:bg-muted hover:text-foreground data-[active=false]:duration-400 duration-(--duration-panel) absolute -translate-x-1/2 transition-[translate,scale,opacity] data-[active=false]:pointer-events-none data-[direction=end]:bottom-4 data-[direction=start]:top-4 data-[active=true]:translate-y-0 data-[direction=end]:data-[active=false]:translate-y-full data-[direction=start]:data-[active=false]:-translate-y-full data-[active=false]:scale-95 data-[active=true]:scale-100 data-[active=false]:opacity-0 data-[active=true]:opacity-100 data-[active=false]:ease-[cubic-bezier(0.7,0,0.84,0)] data-[active=true]:ease-[cubic-bezier(0.23,1,0.32,1)] rtl:translate-x-1/2 data-[direction=start]:[&_svg]:rotate-180',
         className,
       )}
       render={render ?? <Button variant={variant} size={size} />}

--- a/frontend/apps/web/src/components/ui/message-scroller.tsx
+++ b/frontend/apps/web/src/components/ui/message-scroller.tsx
@@ -92,7 +92,7 @@ function MessageScrollerButton({
       data-size={size}
       direction={direction}
       className={cn(
-        'inset-s-1/2 border-border bg-background text-foreground hover:bg-muted hover:text-foreground data-[active=false]:duration-400 duration-(--duration-panel) absolute -translate-x-1/2 transition-[translate,scale,opacity] data-[active=false]:pointer-events-none data-[direction=end]:bottom-4 data-[direction=start]:top-4 data-[active=true]:translate-y-0 data-[direction=end]:data-[active=false]:translate-y-full data-[direction=start]:data-[active=false]:-translate-y-full data-[active=false]:scale-95 data-[active=true]:scale-100 data-[active=false]:opacity-0 data-[active=true]:opacity-100 data-[active=false]:ease-[cubic-bezier(0.7,0,0.84,0)] data-[active=true]:ease-[cubic-bezier(0.23,1,0.32,1)] rtl:translate-x-1/2 data-[direction=start]:[&_svg]:rotate-180',
+        'inset-s-1/2 border-border bg-background text-foreground hover:bg-muted hover:text-foreground data-[active=false]:duration-400 absolute -translate-x-1/2 transition-[translate,scale,opacity] duration-[var(--duration-panel)] data-[active=false]:pointer-events-none data-[direction=end]:bottom-4 data-[direction=start]:top-4 data-[active=true]:translate-y-0 data-[direction=end]:data-[active=false]:translate-y-full data-[direction=start]:data-[active=false]:-translate-y-full data-[active=false]:scale-95 data-[active=true]:scale-100 data-[active=false]:opacity-0 data-[active=true]:opacity-100 data-[active=false]:ease-[cubic-bezier(0.7,0,0.84,0)] data-[active=true]:ease-[cubic-bezier(0.23,1,0.32,1)] rtl:translate-x-1/2 data-[direction=start]:[&_svg]:rotate-180',
         className,
       )}
       render={render ?? <Button variant={variant} size={size} />}

--- a/frontend/apps/web/src/components/ui/select.tsx
+++ b/frontend/apps/web/src/components/ui/select.tsx
@@ -113,7 +113,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground control-focus [&_svg:not([class*='size-'])]:size-4.5 relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-2.5 pl-2 pr-8 text-base data-[disabled]:pointer-events-none data-[disabled]:opacity-50 sm:py-1.5 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden [&_svg:not([class*='size-'])]:size-4.5 relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-2.5 pl-2 pr-8 text-base data-[disabled]:pointer-events-none data-[disabled]:opacity-50 sm:py-1.5 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}

--- a/frontend/apps/web/src/components/ui/select.tsx
+++ b/frontend/apps/web/src/components/ui/select.tsx
@@ -46,7 +46,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 dark:bg-input/30 dark:hover:bg-input/50 [&_svg:not([class*='size-'])]:size-4.5 flex w-fit items-center justify-between gap-2 whitespace-nowrap rounded-md border bg-transparent px-3 py-2 text-base outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-10 data-[size=sm]:h-9 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 sm:text-sm sm:data-[size=default]:h-9 sm:data-[size=sm]:h-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='size-'])]:size-4.5 bg-card hover:bg-(--secondary-hover) control-focus control-transition flex w-fit items-center justify-between gap-2 whitespace-nowrap rounded-md border px-3 py-2 text-base disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-10 data-[size=sm]:h-9 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
@@ -113,7 +113,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden [&_svg:not([class*='size-'])]:size-4.5 relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-2.5 pl-2 pr-8 text-base data-[disabled]:pointer-events-none data-[disabled]:opacity-50 sm:py-1.5 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground control-focus [&_svg:not([class*='size-'])]:size-4.5 relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-2.5 pl-2 pr-8 text-base data-[disabled]:pointer-events-none data-[disabled]:opacity-50 sm:py-1.5 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}

--- a/frontend/apps/web/src/components/ui/sheet.tsx
+++ b/frontend/apps/web/src/components/ui/sheet.tsx
@@ -61,7 +61,7 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary rounded-xs focus:outline-hidden absolute right-4 top-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none">
+        <SheetPrimitive.Close className="control-focus data-[state=open]:bg-secondary rounded-xs absolute right-4 top-4 opacity-70 transition-opacity hover:opacity-100 disabled:pointer-events-none">
           <XIcon className="size-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
@@ -94,7 +94,7 @@ function SheetTitle({ className, ...props }: ComponentProps<typeof SheetPrimitiv
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn('text-foreground font-semibold', className)}
+      className={cn('type-card-title text-foreground', className)}
       {...props}
     />
   )

--- a/frontend/apps/web/src/components/ui/sidebar.tsx
+++ b/frontend/apps/web/src/components/ui/sidebar.tsx
@@ -86,7 +86,7 @@ function Sidebar({
       <div
         data-slot="sidebar-gap"
         className={cn(
-          'w-(--sidebar-width) relative bg-transparent transition-[width] duration-150 ease-out',
+          'w-(--sidebar-width) duration-(--duration-control) relative bg-transparent transition-[width] ease-out',
           'group-data-[collapsible=offcanvas]:w-0',
           'group-data-[side=right]:rotate-180',
           variant === 'floating' || variant === 'inset'
@@ -97,7 +97,7 @@ function Sidebar({
       <div
         data-slot="sidebar-container"
         className={cn(
-          'w-(--sidebar-width) fixed inset-y-0 z-10 hidden h-svh transition-[left,right,width] duration-150 ease-out md:flex',
+          'w-(--sidebar-width) duration-(--duration-control) fixed inset-y-0 z-10 hidden h-svh transition-[left,right,width] ease-out md:flex',
           side === 'left'
             ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
             : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
@@ -171,7 +171,7 @@ function SidebarInset({ className, ...props }: ComponentProps<'main'>) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        'bg-background relative flex w-full flex-1 flex-col',
+        'surface-page relative flex w-full flex-1 flex-col',
         'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm',
         className,
       )}
@@ -260,7 +260,7 @@ function SidebarGroupLabel({
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        'text-sidebar-foreground/70 ring-sidebar-ring outline-hidden [&>svg]:size-4.5 flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:shrink-0',
+        'text-sidebar-foreground/70 control-focus [&>svg]:size-4.5 duration-(--duration-panel) flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium transition-[margin,opacity] ease-linear [&>svg]:shrink-0',
         'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
         className,
       )}
@@ -280,7 +280,7 @@ function SidebarGroupAction({
       data-slot="sidebar-group-action"
       data-sidebar="group-action"
       className={cn(
-        'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground outline-hidden [&>svg]:size-4.5 absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 transition-transform focus-visible:ring-2 [&>svg]:shrink-0',
+        'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground control-focus [&>svg]:size-4.5 absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 transition-transform [&>svg]:shrink-0',
         'after:absolute after:-inset-2 md:after:hidden',
         'group-data-[collapsible=icon]:hidden',
         className,
@@ -324,7 +324,7 @@ function SidebarMenuItem({ className, ...props }: ComponentProps<'li'>) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  'peer/menu-button ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground group-has-data-[sidebar=menu-action]/menu-item:pr-8 data-[active=true]:bg-sidebar-primary/10 data-[active=true]:text-sidebar-primary data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden transition-[width,height,padding] group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:font-medium [&>span:last-child]:truncate [&>svg]:size-4.5 [&>svg]:shrink-0',
+  'peer/menu-button hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground group-has-data-[sidebar=menu-action]/menu-item:pr-8 data-[active=true]:bg-sidebar-primary/10 data-[active=true]:text-sidebar-primary data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm control-focus transition-[width,height,padding] group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:font-medium [&>span:last-child]:truncate [&>svg]:size-4.5 [&>svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -395,7 +395,7 @@ function SidebarMenuAction({
       data-slot="sidebar-menu-action"
       data-sidebar="menu-action"
       className={cn(
-        'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground outline-hidden [&>svg]:size-4.5 absolute right-1 top-1/2 flex aspect-square w-5 -translate-y-1/2 items-center justify-center rounded-md p-0 transition-transform focus-visible:ring-2 [&>svg]:shrink-0',
+        'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground control-focus [&>svg]:size-4.5 absolute right-1 top-1/2 flex aspect-square w-5 -translate-y-1/2 items-center justify-center rounded-md p-0 transition-transform [&>svg]:shrink-0',
         'after:absolute after:-inset-2 md:after:hidden',
         'group-data-[collapsible=icon]:hidden',
         showOnHover &&
@@ -485,7 +485,7 @@ function SidebarMenuSubButton({
       data-size={size}
       data-active={isActive}
       className={cn(
-        'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground data-[active=true]:bg-sidebar-primary/10 data-[active=true]:text-sidebar-primary outline-hidden [&>svg]:size-4.5 flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md pl-2.5 pr-2 focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:rounded-l-none data-[active=true]:shadow-[inset_2px_0_0_0_var(--sidebar-primary)] [&>span:last-child]:truncate [&>svg]:shrink-0',
+        'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground data-[active=true]:bg-sidebar-primary/10 data-[active=true]:text-sidebar-primary control-focus [&>svg]:size-4.5 flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md pl-2.5 pr-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:rounded-l-none data-[active=true]:shadow-[inset_2px_0_0_0_var(--sidebar-primary)] [&>span:last-child]:truncate [&>svg]:shrink-0',
         size === 'sm' && 'text-xs',
         size === 'md' && 'text-sm',
         'group-data-[collapsible=icon]:hidden',

--- a/frontend/apps/web/src/components/ui/sidebar.tsx
+++ b/frontend/apps/web/src/components/ui/sidebar.tsx
@@ -86,7 +86,7 @@ function Sidebar({
       <div
         data-slot="sidebar-gap"
         className={cn(
-          'w-(--sidebar-width) duration-(--duration-control) relative bg-transparent transition-[width] ease-out',
+          'w-(--sidebar-width) relative bg-transparent transition-[width] duration-[var(--duration-control)] ease-out',
           'group-data-[collapsible=offcanvas]:w-0',
           'group-data-[side=right]:rotate-180',
           variant === 'floating' || variant === 'inset'
@@ -97,7 +97,7 @@ function Sidebar({
       <div
         data-slot="sidebar-container"
         className={cn(
-          'w-(--sidebar-width) duration-(--duration-control) fixed inset-y-0 z-10 hidden h-svh transition-[left,right,width] ease-out md:flex',
+          'w-(--sidebar-width) fixed inset-y-0 z-10 hidden h-svh transition-[left,right,width] duration-[var(--duration-control)] ease-out md:flex',
           side === 'left'
             ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
             : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
@@ -260,7 +260,7 @@ function SidebarGroupLabel({
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        'text-sidebar-foreground/70 control-focus [&>svg]:size-4.5 duration-(--duration-panel) flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium transition-[margin,opacity] ease-linear [&>svg]:shrink-0',
+        'text-sidebar-foreground/70 control-focus [&>svg]:size-4.5 flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-[var(--duration-panel)] ease-linear [&>svg]:shrink-0',
         'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
         className,
       )}

--- a/frontend/apps/web/src/components/ui/spinner.tsx
+++ b/frontend/apps/web/src/components/ui/spinner.tsx
@@ -19,7 +19,7 @@ export function FullPageSpinner() {
       role="status"
       aria-live="polite"
     >
-      <Spinner className="text-muted-foreground h-6 w-6" />
+      <Spinner className="text-muted-foreground size-6" />
       <span className="sr-only">Loading</span>
     </div>
   )

--- a/frontend/apps/web/src/components/ui/spinner.tsx
+++ b/frontend/apps/web/src/components/ui/spinner.tsx
@@ -1,8 +1,15 @@
-import { Loader2 } from '@/components/icons'
 import { cn } from '@/lib/utils'
 
 export function Spinner({ className }: { className?: string }) {
-  return <Loader2 className={cn('h-4 w-4 animate-spin', className)} aria-hidden />
+  return (
+    <span
+      className={cn(
+        'state-loading inline-block size-5 shrink-0 motion-safe:animate-spin',
+        className,
+      )}
+      aria-hidden
+    />
+  )
 }
 
 export function FullPageSpinner() {

--- a/frontend/apps/web/src/components/ui/tabs.tsx
+++ b/frontend/apps/web/src/components/ui/tabs.tsx
@@ -57,7 +57,7 @@ function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPr
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "text-foreground/60 hover:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:text-muted-foreground dark:hover:text-foreground [&_svg:not([class*='size-'])]:size-4.5 relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1 text-sm font-medium transition-all focus-visible:outline-1 focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground [&_svg:not([class*='size-'])]:size-4.5 type-control control-transition relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1 disabled:pointer-events-none disabled:opacity-50 group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start [&_svg]:pointer-events-none [&_svg]:shrink-0",
         'group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent',
         'data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground',
         'after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100',
@@ -72,7 +72,7 @@ function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPr
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"
-      className={cn('flex-1 outline-none', className)}
+      className={cn('control-focus flex-1', className)}
       {...props}
     />
   )

--- a/frontend/apps/web/src/components/ui/text-field-variants.ts
+++ b/frontend/apps/web/src/components/ui/text-field-variants.ts
@@ -1,0 +1,12 @@
+import { cva } from 'class-variance-authority'
+
+export const textFieldVariants = cva('', {
+  variants: {
+    variant: {
+      default: 'control-focus rounded-control border border-input bg-card',
+      // Embedded fields use their containing control or an inline underline for focus.
+      embedded: 'border-0 bg-transparent shadow-none focus-visible:outline-none',
+    },
+  },
+  defaultVariants: { variant: 'default' },
+})

--- a/frontend/apps/web/src/components/ui/textarea.tsx
+++ b/frontend/apps/web/src/components/ui/textarea.tsx
@@ -1,13 +1,20 @@
+import type { VariantProps } from 'class-variance-authority'
 import type { ComponentProps } from 'react'
 
+import { textFieldVariants } from '@/components/ui/text-field-variants'
 import { cn } from '@/lib/utils'
 
-function Textarea({ className, ...props }: ComponentProps<'textarea'>) {
+function Textarea({
+  className,
+  variant,
+  ...props
+}: ComponentProps<'textarea'> & VariantProps<typeof textFieldVariants>) {
   return (
     <textarea
       data-slot="textarea"
       className={cn(
-        'border-input placeholder:text-muted-foreground aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 field-sizing-content pointer-coarse:text-base bg-card control-focus control-transition flex min-h-16 w-full rounded-md border px-3 py-2 text-base disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'placeholder:text-muted-foreground aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 field-sizing-content pointer-coarse:text-base control-transition flex min-h-16 w-full px-3 py-2 text-base disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        textFieldVariants({ variant }),
         className,
       )}
       {...props}

--- a/frontend/apps/web/src/components/ui/textarea.tsx
+++ b/frontend/apps/web/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: ComponentProps<'textarea'>) {
     <textarea
       data-slot="textarea"
       className={cn(
-        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 dark:bg-input/30 field-sizing-content pointer-coarse:text-base flex min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'border-input placeholder:text-muted-foreground aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 field-sizing-content pointer-coarse:text-base bg-card control-focus control-transition flex min-h-16 w-full rounded-md border px-3 py-2 text-base disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         className,
       )}
       {...props}

--- a/frontend/apps/web/src/components/ui/tooltip.tsx
+++ b/frontend/apps/web/src/components/ui/tooltip.tsx
@@ -40,7 +40,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          'text-popover-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin) ring-sidebar-primary/25 pointer-events-none z-50 w-fit text-balance rounded-md bg-[color-mix(in_oklab,var(--sidebar-primary)_10%,var(--sidebar))] px-3 py-1.5 text-xs shadow-xl shadow-black/40 ring-1',
+          'text-popover-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin) ring-border bg-popover type-caption pointer-events-none z-50 w-fit text-balance rounded-md px-3 py-1.5 shadow-md ring-1',
           className,
         )}
         {...props}
@@ -53,23 +53,14 @@ function TooltipContent({
             preserveAspectRatio="none"
             className="overflow-visible"
           >
-            <polygon
-              points="0,0 30,0 15,10"
-              className="fill-[color-mix(in_oklab,var(--sidebar-primary)_10%,var(--sidebar))]"
-            />
-            <rect
-              x="0"
-              y="-1"
-              width="30"
-              height="2"
-              className="fill-[color-mix(in_oklab,var(--sidebar-primary)_10%,var(--sidebar))]"
-            />
+            <polygon points="0,0 30,0 15,10" className="fill-popover" />
+            <rect x="0" y="-1" width="30" height="2" className="fill-popover" />
             <path
               d="M0 0 L15 10 L30 0"
               vectorEffect="non-scaling-stroke"
               strokeLinecap="round"
               strokeLinejoin="round"
-              className="stroke-sidebar-primary/35 fill-none stroke-1"
+              className="stroke-border fill-none stroke-1"
             />
           </svg>
         </TooltipPrimitive.Arrow>

--- a/frontend/apps/web/src/fonts.ts
+++ b/frontend/apps/web/src/fonts.ts
@@ -1,2 +1,3 @@
 import '@fontsource-variable/geist'
+import '@fontsource-variable/geist/wght-italic.css'
 import '@fontsource-variable/geist-mono'

--- a/frontend/apps/web/src/lib/utils.ts
+++ b/frontend/apps/web/src/lib/utils.ts
@@ -1,5 +1,17 @@
 import { type ClassValue, clsx } from 'clsx'
-import { twMerge } from 'tailwind-merge'
+import { extendTailwindMerge } from 'tailwind-merge'
+
+const twMerge = extendTailwindMerge({
+  extend: {
+    theme: { borderRadius: ['control', 'card'] },
+    classGroups: {
+      'font-size': [{ text: ['caption'] }],
+      'font-weight': [{ font: ['heading'] }],
+      leading: [{ leading: ['prose', 'control'] }],
+      tracking: [{ tracking: ['eyebrow'] }],
+    },
+  },
+})
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))

--- a/frontend/apps/web/src/lib/utils.ts
+++ b/frontend/apps/web/src/lib/utils.ts
@@ -3,12 +3,12 @@ import { extendTailwindMerge } from 'tailwind-merge'
 
 const twMerge = extendTailwindMerge({
   extend: {
-    theme: { borderRadius: ['control', 'card'] },
-    classGroups: {
-      'font-size': [{ text: ['caption'] }],
-      'font-weight': [{ font: ['heading'] }],
-      leading: [{ leading: ['prose', 'control'] }],
-      tracking: [{ tracking: ['eyebrow'] }],
+    theme: {
+      text: ['caption'],
+      'font-weight': ['heading'],
+      leading: ['prose', 'control'],
+      tracking: ['eyebrow'],
+      radius: ['control', 'card'],
     },
   },
 })

--- a/frontend/apps/web/src/routes/CreateAgentPage.tsx
+++ b/frontend/apps/web/src/routes/CreateAgentPage.tsx
@@ -10,9 +10,7 @@ export function CreateAgentPage() {
   if (!project?.access.can_manage) {
     return (
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-2">
-        <h1 className="text-xl font-semibold tracking-tight">
-          {project ? 'Not allowed' : 'Project not found'}
-        </h1>
+        <h1 className="type-title">{project ? 'Not allowed' : 'Project not found'}</h1>
         <p className="text-muted-foreground text-sm">
           {project
             ? 'You don’t have permission to create agents in this project.'

--- a/frontend/apps/web/src/routes/DeviceAuth.tsx
+++ b/frontend/apps/web/src/routes/DeviceAuth.tsx
@@ -66,7 +66,7 @@ export function DeviceAuth() {
     <AuthLayout>
       <div className="flex flex-col gap-6">
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Approve device login</h1>
+          <h1 className="type-title">Approve device login</h1>
           <p className="text-muted-foreground mt-1 text-sm">
             Only approve if this code matches the one shown by the CLI where you started login.
           </p>

--- a/frontend/apps/web/src/routes/Invitations.tsx
+++ b/frontend/apps/web/src/routes/Invitations.tsx
@@ -25,7 +25,7 @@ export function Invitations() {
   if (me.orgs.length === 0) {
     return (
       <div className="flex min-h-svh flex-col items-center gap-8 p-6 sm:pt-12">
-        <Link to="/onboarding" className="flex items-center gap-2 text-base font-semibold">
+        <Link to="/onboarding" className="type-card-title flex items-center gap-2 text-base">
           <BrandMark />
           Omnara
         </Link>
@@ -80,7 +80,7 @@ function InvitationsContent({
       {hasOrganizations && <PageBreadcrumb items={[{ id: 'invitations', label: 'Invitations' }]} />}
 
       <div className="flex flex-col gap-2">
-        <h1 className="text-2xl font-semibold tracking-tight">Pending invitations</h1>
+        <h1 className="type-title">Pending invitations</h1>
         <p className="text-muted-foreground text-sm">
           Review invitations to join other organizations.
         </p>

--- a/frontend/apps/web/src/routes/Members.tsx
+++ b/frontend/apps/web/src/routes/Members.tsx
@@ -117,7 +117,7 @@ export function Members() {
 
       <div className="flex flex-col gap-3">
         <div className="flex items-center justify-between gap-2">
-          <h2 className="text-2xl font-bold tracking-tight">Members</h2>
+          <h2 className="type-title">Members</h2>
           {canManage ? (
             <Button
               size="sm"

--- a/frontend/apps/web/src/routes/Members.tsx
+++ b/frontend/apps/web/src/routes/Members.tsx
@@ -1,23 +1,17 @@
-import { useDeleteOrgInvitation, useOrgInvitations, useOrgMembers } from '@omnara/react'
-import type { OrgInvitation, OrgMember } from '@omnara/sdk'
+import { useDeleteOrgInvitation } from '@omnara/react'
+import type { OrgMember } from '@omnara/sdk'
 import { useState } from 'react'
 
 import { DataTable } from '@/components/data-table/DataTable'
 import { PageBreadcrumb } from '@/components/layout/PageBreadcrumb'
 import { InviteMemberDialog } from '@/components/org/InviteMemberDialog'
 import { MemberDetailPanel } from '@/components/org/MemberDetailPanel'
+import { useMembersPage } from '@/components/org/useMembersPage'
 import { Button } from '@/components/ui/button'
-import type { PaginationControls } from '@/hooks/use-paged-query'
 import { formatDateTime } from '@/lib/format'
 import { canManageOrg } from '@/lib/permissions'
 import { errorMessage } from '@/lib/submit-status'
 import { useActiveOrg } from '@/lib/use-active-org'
-
-type CombinedRow =
-  | { kind: 'invitation'; id: string; invitation: OrgInvitation }
-  | { kind: 'member'; id: string; member: OrgMember }
-
-const PAGE_SIZE = 15
 
 function memberName(member: OrgMember) {
   return member.display_name || member.email || 'Unnamed user'
@@ -27,84 +21,9 @@ export function Members() {
   const { activeOrg } = useActiveOrg()
   const [inviteOpen, setInviteOpen] = useState(false)
   const canManage = canManageOrg(activeOrg.role)
-  const [page, setPage] = useState(0)
-  const [paginationOwner, setPaginationOwner] = useState({
-    orgID: activeOrg.id,
-    canManage,
-  })
-  if (paginationOwner.orgID !== activeOrg.id || paginationOwner.canManage !== canManage) {
-    setPaginationOwner({ orgID: activeOrg.id, canManage })
-    setPage(0)
-  }
-
-  const invitationsQuery = useOrgInvitations(activeOrg.id, {
-    pageSize: PAGE_SIZE,
-    enabled: canManage,
-  })
   const deleteInvitation = useDeleteOrgInvitation(activeOrg.id)
-  const invitationsExhausted =
-    !canManage ||
-    invitationsQuery.isError ||
-    (invitationsQuery.isSuccess && !invitationsQuery.hasNextPage)
-  const membersQuery = useOrgMembers(activeOrg.id, {
-    sort: 'name',
-    pageSize: PAGE_SIZE,
-    enabled: invitationsExhausted,
-  })
-
-  const loadedRows: CombinedRow[] = []
-  for (const loadedPage of invitationsQuery.data?.pages ?? []) {
-    for (const invitation of loadedPage.data) {
-      loadedRows.push({ kind: 'invitation', id: invitation.id, invitation })
-    }
-  }
-  for (const loadedPage of membersQuery.data?.pages ?? []) {
-    for (const member of loadedPage.data) {
-      loadedRows.push({ kind: 'member', id: member.user_id, member })
-    }
-  }
-  const pageStart = page * PAGE_SIZE
-  const rows = loadedRows.slice(pageStart, pageStart + PAGE_SIZE)
-  const nextPageStart = pageStart + PAGE_SIZE
-  const nextPageEnd = nextPageStart + PAGE_SIZE
-  const hasLoadedNextPage = loadedRows.length > nextPageStart
-  const pagination: PaginationControls = {
-    page,
-    canPrev: page > 0,
-    canNext:
-      hasLoadedNextPage ||
-      invitationsQuery.hasNextPage ||
-      (invitationsExhausted && membersQuery.hasNextPage),
-    onPrev: () => {
-      setPage((current) => Math.max(current - 1, 0))
-    },
-    onNext: () => {
-      if (
-        loadedRows.length < nextPageEnd &&
-        invitationsQuery.hasNextPage &&
-        !invitationsQuery.isFetchingNextPage
-      ) {
-        void invitationsQuery.fetchNextPage().then(() => {
-          setPage((current) => current + 1)
-        })
-        return
-      }
-      if (
-        loadedRows.length < nextPageEnd &&
-        invitationsExhausted &&
-        membersQuery.hasNextPage &&
-        !membersQuery.isFetchingNextPage
-      ) {
-        void membersQuery.fetchNextPage().then(() => {
-          setPage((current) => current + 1)
-        })
-        return
-      }
-      if (hasLoadedNextPage) {
-        setPage((current) => current + 1)
-      }
-    },
-  }
+  const { invitationsQuery, membersQuery, invitationsExhausted, rows, pagination, setPage } =
+    useMembersPage(activeOrg.id, canManage)
 
   return (
     <div className="mx-auto flex w-full max-w-5xl flex-col gap-8">

--- a/frontend/apps/web/src/routes/Onboarding.tsx
+++ b/frontend/apps/web/src/routes/Onboarding.tsx
@@ -55,14 +55,14 @@ export function Onboarding() {
 
   return (
     <div className="flex min-h-svh flex-col items-center justify-center gap-8 p-6">
-      <div className="flex items-center gap-2 text-base font-semibold tracking-tight">
+      <div className="type-card-title flex items-center gap-2 text-base">
         <BrandMark />
         Omnara
       </div>
 
       <div className="flex w-full max-w-md flex-col gap-6">
         <div className="flex flex-col gap-1 text-center">
-          <h1 className="text-2xl font-semibold tracking-tight">Welcome to Omnara</h1>
+          <h1 className="type-title">Welcome to Omnara</h1>
           <p className="text-muted-foreground text-sm">
             {pending.length > 0
               ? 'Accept an invitation or create your own organization'

--- a/frontend/apps/web/src/routes/ProjectGrantsPage.tsx
+++ b/frontend/apps/web/src/routes/ProjectGrantsPage.tsx
@@ -12,7 +12,7 @@ export function ProjectGrantsPage() {
   if (!project) {
     return (
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-2">
-        <h1 className="text-xl font-semibold tracking-tight">Project not found</h1>
+        <h1 className="type-title">Project not found</h1>
         <p className="text-muted-foreground text-sm">
           This project doesn&rsquo;t exist or you don&rsquo;t have access to it.
         </p>

--- a/frontend/apps/web/src/routes/RootError.tsx
+++ b/frontend/apps/web/src/routes/RootError.tsx
@@ -14,7 +14,7 @@ export function RootError({ error }: ErrorComponentProps) {
   return (
     <div className="flex h-full flex-col items-center justify-center gap-4 p-6 text-center">
       <div>
-        <h1 className="text-lg font-semibold">Something went wrong</h1>
+        <h1 className="type-card-title">Something went wrong</h1>
         <p className="text-muted-foreground mt-1 max-w-md text-sm">{message}</p>
       </div>
       <Button

--- a/frontend/apps/web/src/styles/editor.ts
+++ b/frontend/apps/web/src/styles/editor.ts
@@ -1,0 +1,44 @@
+import type * as Monaco from 'monaco-editor'
+
+export function editorAppearance(monaco: typeof Monaco, element: HTMLElement) {
+  const rootStyle = getComputedStyle(document.documentElement)
+  const textStyle = getComputedStyle(element)
+  const dark = document.documentElement.classList.contains('dark')
+  const mode = dark ? 'dark' : 'light'
+  const theme = `omnara-${mode}`
+  // Monaco's theme API takes hex colors rather than CSS custom properties.
+  const color = (token: string) =>
+    `#${rootStyle
+      .getPropertyValue(token)
+      .trim()
+      .split(/\s+/)
+      .map((channel) => Number(channel).toString(16).padStart(2, '0'))
+      .join('')}`
+  const foreground = color(`--palette-${mode}-fg`)
+  const primary = color('--palette-primary')
+
+  monaco.editor.defineTheme(theme, {
+    base: dark ? 'vs-dark' : 'vs',
+    inherit: true,
+    rules: [],
+    colors: {
+      'editor.background': color(`--palette-${mode}-surface`),
+      'editor.foreground': foreground,
+      'editorLineNumber.foreground': `${foreground}80`,
+      'editorLineNumber.activeForeground': foreground,
+      'editorCursor.foreground': color(`--palette-${mode}-accent`),
+      'editor.selectionBackground': `${primary}40`,
+      'editor.inactiveSelectionBackground': `${primary}20`,
+      'editor.lineHighlightBackground': `${primary}10`,
+      'editorWidget.background': color(`--palette-${mode}-surface-2`),
+      'editorWidget.border': color(`--palette-${mode}-line`),
+    },
+  })
+
+  return {
+    theme,
+    fontFamily: textStyle.fontFamily,
+    fontSize: Number.parseFloat(textStyle.fontSize),
+    lineHeight: Number.parseFloat(textStyle.lineHeight),
+  }
+}

--- a/frontend/apps/web/src/styles/index.css
+++ b/frontend/apps/web/src/styles/index.css
@@ -140,7 +140,6 @@
 
   body {
     @apply bg-background text-foreground font-sans;
-    background-image: var(--page-texture);
     font-size: var(--type-size-body);
     font-weight: var(--type-weight-body);
     line-height: var(--type-leading-body);

--- a/frontend/apps/web/src/styles/index.css
+++ b/frontend/apps/web/src/styles/index.css
@@ -1,6 +1,10 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
+@import './palette.css';
+@import './theme.css';
+@import './typography.css';
+@import './interaction.css';
 @source '../../node_modules/streamdown/dist/*.js';
 
 @custom-variant dark (&:is(.dark *));
@@ -58,96 +62,6 @@
   );
 }
 
-:root {
-  --font-sans: 'Geist Variable', ui-sans-serif, system-ui, -apple-system, sans-serif;
-  --font-mono: 'Geist Mono Variable', ui-monospace, SFMono-Regular, monospace;
-  --radius: 0.625rem;
-
-  /* Palette: Technical indigo #4372cf over strictly neutral greys — bg
-     #0b0b0c, surface #161618, alt surface / ink #232326. Chrome stays
-     neutral white/near-black/grey; indigo is reserved for action, active,
-     and selected states. #5782d4 lightens the accent for hover, #3162c2
-     deepens it for pressed states and small text on light. */
-  --background: #ffffff;
-  --foreground: #232326;
-  --card: #ffffff;
-  --card-foreground: #232326;
-  --popover: #ffffff;
-  --popover-foreground: #232326;
-  --primary: #4372cf;
-  --primary-foreground: #ffffff;
-  --primary-hover: #5782d4;
-  --primary-active: #3162c2;
-  --secondary: color-mix(in oklab, #232326 6%, white);
-  --secondary-hover: color-mix(in oklab, #232326 10%, white);
-  --secondary-foreground: #232326;
-  --muted: color-mix(in oklab, #232326 6%, white);
-  --muted-foreground: color-mix(in oklab, #232326 64%, white);
-  --accent: color-mix(in oklab, #4372cf 10%, white);
-  --accent-foreground: #232326;
-  --destructive: oklch(0.58 0.24 27);
-  --destructive-foreground: #ffffff;
-  --warning: oklch(0.55 0.17 40);
-  --overlay: oklch(0 0 0 / 50%);
-  --border: color-mix(in oklab, #232326 11%, white);
-  --input: color-mix(in oklab, #232326 15%, white);
-  --ring: #4372cf;
-  --chart-1: #4372cf;
-  --chart-2: #3162c2;
-  --chart-3: color-mix(in oklab, #232326 28%, white);
-  --chart-4: color-mix(in oklab, #4372cf 45%, white);
-  --chart-5: #232326;
-  --sidebar: color-mix(in oklab, #232326 3%, white);
-  --sidebar-foreground: #232326;
-  /* One ramp step darker than the shared accent so active nav text stays
-     readable on the light sidebar. */
-  --sidebar-primary: #3162c2;
-  --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent: color-mix(in oklab, #4372cf 10%, white);
-  --sidebar-accent-foreground: #232326;
-  --sidebar-border: color-mix(in oklab, #232326 12%, white);
-  --sidebar-ring: #3162c2;
-}
-
-.dark {
-  --background: #0b0b0c;
-  --foreground: #ececee;
-  --card: #161618;
-  --card-foreground: #ececee;
-  --popover: #161618;
-  --popover-foreground: #ececee;
-  --primary: #4372cf;
-  --primary-foreground: #ffffff;
-  --primary-hover: #5782d4;
-  --primary-active: #3162c2;
-  --secondary: #232326;
-  --secondary-hover: color-mix(in oklab, #ffffff 8%, #232326);
-  --secondary-foreground: #ececee;
-  --muted: #232326;
-  --muted-foreground: color-mix(in oklab, #ffffff 60%, #232326);
-  --accent: color-mix(in oklab, #4372cf 13%, #0b0b0c);
-  --accent-foreground: #ececee;
-  --destructive: oklch(0.7 0.19 22);
-  --destructive-foreground: #ffffff;
-  --warning: oklch(0.72 0.16 45);
-  --border: color-mix(in oklab, #ffffff 8%, transparent);
-  --input: color-mix(in oklab, #ffffff 12%, transparent);
-  --ring: #4372cf;
-  --chart-1: #4372cf;
-  --chart-2: color-mix(in oklab, #4372cf 55%, white);
-  --chart-3: color-mix(in oklab, #ffffff 55%, #232326);
-  --chart-4: #3162c2;
-  --chart-5: color-mix(in oklab, #4372cf 30%, #232326);
-  --sidebar: #101012;
-  --sidebar-foreground: #ececee;
-  --sidebar-primary: #81a1df;
-  --sidebar-primary-foreground: #0b0b0c;
-  --sidebar-accent: color-mix(in oklab, #4372cf 13%, #0b0b0c);
-  --sidebar-accent-foreground: #ececee;
-  --sidebar-border: color-mix(in oklab, #ffffff 8%, transparent);
-  --sidebar-ring: #4372cf;
-}
-
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -166,6 +80,9 @@
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
   --color-warning: var(--warning);
+  --color-success: var(--success);
+  --color-link: var(--link);
+  --color-link-hover: var(--link-hover);
   --color-overlay: var(--overlay);
   --color-border: var(--border);
   --color-input: var(--input);
@@ -187,20 +104,30 @@
   --font-sans: var(--font-sans);
   --font-mono: var(--font-mono);
 
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  --font-weight-normal: var(--type-weight-body);
+  --font-weight-medium: var(--type-weight-control);
+  --font-weight-semibold: var(--type-weight-emphasis);
+  --font-weight-heading: var(--type-weight-heading);
+  --text-xs: var(--type-size-fine);
+  --text-xs--line-height: var(--type-leading-body);
+  --text-sm: var(--type-size-small);
+  --text-sm--line-height: var(--type-leading-body);
+  --text-base: var(--type-size-body);
+  --text-base--line-height: var(--type-leading-body);
+  --text-caption: var(--type-size-caption);
+  --text-caption--line-height: var(--type-leading-body);
+  --leading-prose: var(--type-leading-prose);
+  --leading-control: var(--type-leading-control);
+  --tracking-eyebrow: var(--type-tracking-eyebrow);
+  --radius-sm: calc(var(--shape-radius-control) - 0.25rem);
+  --radius-md: var(--shape-radius-control);
+  --radius-lg: var(--shape-radius-card);
+  --radius-xl: var(--shape-radius-card);
+  --radius-control: var(--shape-radius-control);
+  --radius-card: var(--shape-radius-card);
 }
 
 @layer base {
-  :root {
-    color-scheme: light;
-  }
-  .dark {
-    color-scheme: dark;
-  }
-
   * {
     @apply border-border outline-ring/50;
   }
@@ -213,9 +140,19 @@
 
   body {
     @apply bg-background text-foreground font-sans;
+    background-image: var(--page-texture);
+    font-size: var(--type-size-body);
+    font-weight: var(--type-weight-body);
+    line-height: var(--type-leading-body);
+    letter-spacing: var(--type-tracking-body);
     margin: 0;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizelegibility;
+  }
+
+  input[type='checkbox'],
+  input[type='radio'] {
+    accent-color: var(--primary);
   }
 
   /* Tailwind v4 preflight leaves buttons with the browser's default cursor. */
@@ -226,13 +163,13 @@
 }
 
 ::view-transition-group(*) {
-  animation-duration: 450ms;
-  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  animation-duration: var(--duration-page);
+  animation-timing-function: var(--ease-page);
 }
 
 ::view-transition-old(*),
 ::view-transition-new(*) {
-  animation-duration: 450ms;
+  animation-duration: var(--duration-page);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/apps/web/src/styles/interaction.css
+++ b/frontend/apps/web/src/styles/interaction.css
@@ -11,7 +11,7 @@
 
 @layer components {
   .control-focus:focus-visible,
-  .control-focus-within:has(:focus-visible) {
+  .control-focus-within:has(:is(input, textarea):focus-visible) {
     outline: var(--focus-width) solid var(--ring);
     outline-offset: var(--focus-offset);
   }

--- a/frontend/apps/web/src/styles/interaction.css
+++ b/frontend/apps/web/src/styles/interaction.css
@@ -34,7 +34,6 @@
 }
 
 @layer base {
-  /* Programmatically focused headings do not need a control focus outline. */
   :where(
     a[href],
     button,

--- a/frontend/apps/web/src/styles/interaction.css
+++ b/frontend/apps/web/src/styles/interaction.css
@@ -29,7 +29,6 @@
 
   .surface-page {
     background-color: var(--background);
-    background-image: var(--page-texture);
   }
 }
 

--- a/frontend/apps/web/src/styles/interaction.css
+++ b/frontend/apps/web/src/styles/interaction.css
@@ -1,0 +1,50 @@
+:root {
+  --shape-radius-control: 0.5rem;
+  --shape-radius-card: 0.75rem;
+  --focus-width: 2px;
+  --focus-offset: 4px;
+  --duration-control: 150ms;
+  --duration-panel: 200ms;
+  --duration-page: 450ms;
+  --ease-page: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@layer components {
+  .control-focus:focus-visible,
+  .control-focus-within:has(:focus-visible) {
+    outline: var(--focus-width) solid var(--ring);
+    outline-offset: var(--focus-offset);
+  }
+
+  .control-transition {
+    transition-property: background-color, border-color, color, box-shadow;
+    transition-duration: var(--duration-control);
+  }
+
+  .state-loading {
+    border: 2px solid color-mix(in srgb, currentColor 25%, transparent);
+    border-top-color: currentColor;
+    border-radius: 50%;
+  }
+
+  .surface-page {
+    background-color: var(--background);
+    background-image: var(--page-texture);
+  }
+}
+
+@layer base {
+  /* Programmatically focused headings do not need a control focus outline. */
+  :where(
+    a[href],
+    button,
+    input,
+    select,
+    textarea,
+    summary,
+    [tabindex]:not([tabindex='-1'])
+  ):focus-visible {
+    outline: var(--focus-width) solid var(--ring);
+    outline-offset: var(--focus-offset);
+  }
+}

--- a/frontend/apps/web/src/styles/palette.css
+++ b/frontend/apps/web/src/styles/palette.css
@@ -1,0 +1,36 @@
+/* Store RGB channels separately so Tailwind opacity modifiers can compose with each color. */
+:root {
+  --palette-primary: 80 111 207;
+  --palette-primary-hover: 61 91 181;
+  --palette-primary-active: 61 91 181;
+  --palette-on-primary: 255 255 255;
+
+  --palette-dark-bg: 11 12 16;
+  --palette-dark-fg: 255 255 255;
+  --palette-dark-surface: 15 16 21;
+  --palette-dark-surface-2: 23 24 33;
+  --palette-dark-surface-3: 31 33 41;
+  --palette-dark-line: 47 51 64;
+  --palette-dark-line-strong: 63 68 84;
+  --palette-dark-accent: 133 160 230;
+  --palette-dark-accent-strong: 166 187 239;
+  --palette-dark-accent-soft: 193 207 244;
+  --palette-dark-destructive: oklch(0.7 0.19 22);
+  --palette-dark-success: 98 207 158;
+
+  --palette-light-bg: 235 236 240;
+  --palette-light-fg: 17 18 24;
+  --palette-light-surface: 243 244 247;
+  --palette-light-surface-2: 226 228 235;
+  --palette-light-surface-3: 214 217 226;
+  --palette-light-line: 200 204 216;
+  --palette-light-line-strong: 172 178 196;
+  --palette-light-accent: 61 94 181;
+  --palette-light-accent-strong: 51 81 164;
+  --palette-light-accent-soft: 112 140 217;
+  --palette-light-destructive: oklch(0.58 0.24 27);
+  --palette-light-success: 13 122 79;
+
+  /* Keep grain beneath content so texture opacity never affects text contrast. */
+  --palette-dark-texture: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180' viewBox='0 0 180 180'%3E%3Cfilter id='grain'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='3' seed='4' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23grain)' opacity='.05'/%3E%3C/svg%3E");
+}

--- a/frontend/apps/web/src/styles/palette.css
+++ b/frontend/apps/web/src/styles/palette.css
@@ -4,31 +4,30 @@
   --palette-primary-active: 61 91 181;
   --palette-on-primary: 255 255 255;
 
-  --palette-dark-bg: 11 12 16;
-  --palette-dark-fg: 255 255 255;
-  --palette-dark-surface: 15 16 21;
-  --palette-dark-surface-2: 23 24 33;
-  --palette-dark-surface-3: 31 33 41;
-  --palette-dark-line: 47 51 64;
-  --palette-dark-line-strong: 63 68 84;
+  --palette-dark-bg: 18 18 18;
+  --palette-dark-fg: 238 238 238;
+  --palette-dark-sidebar: 26 26 26;
+  --palette-dark-surface: 32 32 32;
+  --palette-dark-surface-2: 40 40 40;
+  --palette-dark-surface-3: 48 48 48;
+  --palette-dark-line: 54 54 54;
+  --palette-dark-line-strong: 82 82 82;
   --palette-dark-accent: 133 160 230;
   --palette-dark-accent-strong: 166 187 239;
   --palette-dark-accent-soft: 193 207 244;
   --palette-dark-destructive: oklch(0.7 0.19 22);
   --palette-dark-success: 98 207 158;
 
-  --palette-light-bg: 235 236 240;
-  --palette-light-fg: 17 18 24;
-  --palette-light-surface: 243 244 247;
-  --palette-light-surface-2: 226 228 235;
-  --palette-light-surface-3: 214 217 226;
-  --palette-light-line: 200 204 216;
-  --palette-light-line-strong: 172 178 196;
+  --palette-light-bg: 250 250 250;
+  --palette-light-fg: 24 24 24;
+  --palette-light-surface: 255 255 255;
+  --palette-light-surface-2: 242 242 242;
+  --palette-light-surface-3: 230 230 230;
+  --palette-light-line: 218 218 218;
+  --palette-light-line-strong: 176 176 176;
   --palette-light-accent: 61 94 181;
   --palette-light-accent-strong: 51 81 164;
   --palette-light-accent-soft: 112 140 217;
   --palette-light-destructive: oklch(0.58 0.24 27);
   --palette-light-success: 13 122 79;
-
-  --palette-dark-texture: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180' viewBox='0 0 180 180'%3E%3Cfilter id='grain'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='3' seed='4' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23grain)' opacity='.05'/%3E%3C/svg%3E");
 }

--- a/frontend/apps/web/src/styles/palette.css
+++ b/frontend/apps/web/src/styles/palette.css
@@ -1,4 +1,3 @@
-/* Store RGB channels separately so Tailwind opacity modifiers can compose with each color. */
 :root {
   --palette-primary: 80 111 207;
   --palette-primary-hover: 61 91 181;
@@ -31,6 +30,5 @@
   --palette-light-destructive: oklch(0.58 0.24 27);
   --palette-light-success: 13 122 79;
 
-  /* Keep grain beneath content so texture opacity never affects text contrast. */
   --palette-dark-texture: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180' viewBox='0 0 180 180'%3E%3Cfilter id='grain'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='3' seed='4' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23grain)' opacity='.05'/%3E%3C/svg%3E");
 }

--- a/frontend/apps/web/src/styles/theme.css
+++ b/frontend/apps/web/src/styles/theme.css
@@ -31,15 +31,14 @@
   --chart-3: var(--muted-foreground);
   --chart-4: rgb(var(--palette-light-accent-soft));
   --chart-5: var(--foreground);
-  --sidebar: var(--card);
+  --sidebar: var(--muted);
   --sidebar-foreground: var(--foreground);
   --sidebar-primary: var(--link);
   --sidebar-primary-foreground: var(--primary-foreground);
-  --sidebar-accent: var(--accent);
+  --sidebar-accent: color-mix(in oklab, var(--primary) 10%, var(--sidebar));
   --sidebar-accent-foreground: var(--foreground);
   --sidebar-border: var(--border);
   --sidebar-ring: var(--ring);
-  --page-texture: none;
   color-scheme: light;
 }
 
@@ -59,6 +58,7 @@
   --border: rgb(var(--palette-dark-line));
   --input: rgb(var(--palette-dark-line-strong));
   --chart-4: rgb(var(--palette-dark-accent-soft));
-  --page-texture: var(--palette-dark-texture);
+  --sidebar: rgb(var(--palette-dark-sidebar));
+  --sidebar-accent: color-mix(in oklab, var(--primary) 13%, var(--sidebar));
   color-scheme: dark;
 }

--- a/frontend/apps/web/src/styles/theme.css
+++ b/frontend/apps/web/src/styles/theme.css
@@ -1,0 +1,64 @@
+:root {
+  --background: rgb(var(--palette-light-bg));
+  --foreground: rgb(var(--palette-light-fg));
+  --card: rgb(var(--palette-light-surface));
+  --card-foreground: var(--foreground);
+  --popover: var(--card);
+  --popover-foreground: var(--foreground);
+  --primary: rgb(var(--palette-primary));
+  --primary-foreground: rgb(var(--palette-on-primary));
+  --primary-hover: rgb(var(--palette-primary-hover));
+  --primary-active: rgb(var(--palette-primary-active));
+  --secondary: var(--card);
+  --secondary-hover: rgb(var(--palette-light-surface-2));
+  --secondary-foreground: var(--foreground);
+  --muted: rgb(var(--palette-light-surface-2));
+  --muted-foreground: color-mix(in oklab, var(--foreground) 64%, var(--background));
+  --accent: color-mix(in oklab, var(--primary) 10%, var(--background));
+  --accent-foreground: var(--foreground);
+  --link: rgb(var(--palette-light-accent));
+  --link-hover: rgb(var(--palette-light-accent-strong));
+  --destructive: var(--palette-light-destructive);
+  --destructive-foreground: rgb(var(--palette-on-primary));
+  --success: rgb(var(--palette-light-success));
+  --warning: oklch(0.55 0.17 40);
+  --overlay: oklch(0 0 0 / 50%);
+  --border: rgb(var(--palette-light-line));
+  --input: rgb(var(--palette-light-line-strong));
+  --ring: var(--link);
+  --chart-1: var(--primary);
+  --chart-2: var(--link-hover);
+  --chart-3: var(--muted-foreground);
+  --chart-4: rgb(var(--palette-light-accent-soft));
+  --chart-5: var(--foreground);
+  --sidebar: var(--card);
+  --sidebar-foreground: var(--foreground);
+  --sidebar-primary: var(--link);
+  --sidebar-primary-foreground: var(--primary-foreground);
+  --sidebar-accent: var(--accent);
+  --sidebar-accent-foreground: var(--foreground);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--ring);
+  --page-texture: none;
+  color-scheme: light;
+}
+
+.dark {
+  --background: rgb(var(--palette-dark-bg));
+  --foreground: rgb(var(--palette-dark-fg));
+  --card: rgb(var(--palette-dark-surface));
+  --secondary-hover: rgb(var(--palette-dark-surface-3));
+  --muted: rgb(var(--palette-dark-surface-2));
+  --muted-foreground: color-mix(in oklab, var(--foreground) 60%, var(--background));
+  --accent: color-mix(in oklab, var(--primary) 13%, var(--background));
+  --link: rgb(var(--palette-dark-accent));
+  --link-hover: rgb(var(--palette-dark-accent-strong));
+  --destructive: var(--palette-dark-destructive);
+  --success: rgb(var(--palette-dark-success));
+  --warning: oklch(0.72 0.16 45);
+  --border: rgb(var(--palette-dark-line));
+  --input: rgb(var(--palette-dark-line-strong));
+  --chart-4: rgb(var(--palette-dark-accent-soft));
+  --page-texture: var(--palette-dark-texture);
+  color-scheme: dark;
+}

--- a/frontend/apps/web/src/styles/typography.css
+++ b/frontend/apps/web/src/styles/typography.css
@@ -1,0 +1,108 @@
+:root {
+  --font-sans: 'Geist Variable', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-mono: 'Geist Mono Variable', ui-monospace, SFMono-Regular, monospace;
+  --type-weight-body: 400;
+  --type-weight-control: 500;
+  --type-weight-display: 525;
+  --type-weight-heading: 525;
+  --type-weight-emphasis: 600;
+  --type-tracking-display: -0.0375em;
+  --type-tracking-title: -0.02em;
+  --type-tracking-body: 0;
+  --type-tracking-eyebrow: 0.14em;
+  --type-leading-display: 1.08;
+  --type-leading-title: 1.25;
+  --type-leading-body: 1.6;
+  --type-leading-prose: 1.75;
+  --type-leading-control: 1.4;
+  --type-leading-code: 1.75;
+  --type-size-page: clamp(2.2rem, 4.5vw, 3.2rem);
+  --type-size-title: 1.5rem;
+  --type-size-card: 1.125rem;
+  --type-size-body: 1rem;
+  --type-size-small: 0.875rem;
+  --type-size-caption: 0.8125rem;
+  --type-size-fine: 0.75rem;
+  --type-size-code: var(--type-size-caption);
+}
+
+@layer components {
+  .type-page-title {
+    font-family: var(--font-sans);
+    font-size: var(--type-size-page);
+    font-weight: var(--type-weight-display);
+    line-height: var(--type-leading-display);
+    letter-spacing: var(--type-tracking-display);
+  }
+
+  .type-title,
+  .type-card-title {
+    font-family: var(--font-sans);
+    font-weight: var(--type-weight-heading);
+    line-height: var(--type-leading-title);
+    letter-spacing: var(--type-tracking-title);
+  }
+
+  .type-title {
+    font-size: var(--type-size-title);
+  }
+
+  .type-card-title {
+    font-size: var(--type-size-card);
+  }
+
+  .type-body-small,
+  .type-caption,
+  .type-fine {
+    font-family: var(--font-sans);
+    font-weight: var(--type-weight-body);
+    line-height: var(--type-leading-body);
+    letter-spacing: var(--type-tracking-body);
+  }
+
+  .type-body-small {
+    font-size: var(--type-size-small);
+  }
+
+  .type-caption {
+    font-size: var(--type-size-caption);
+  }
+
+  .type-fine {
+    font-size: var(--type-size-fine);
+  }
+
+  .type-control,
+  .type-control-small,
+  .type-label,
+  .type-eyebrow {
+    font-family: var(--font-sans);
+    font-size: var(--type-size-small);
+    font-weight: var(--type-weight-control);
+    line-height: var(--type-leading-control);
+    letter-spacing: var(--type-tracking-body);
+  }
+
+  .type-control-small {
+    font-size: var(--type-size-caption);
+  }
+
+  .type-label {
+    font-weight: var(--type-weight-heading);
+  }
+
+  .type-eyebrow {
+    font-size: var(--type-size-fine);
+    font-weight: var(--type-weight-heading);
+    letter-spacing: var(--type-tracking-eyebrow);
+    text-transform: uppercase;
+  }
+
+  .type-code {
+    font-family: var(--font-mono);
+    font-size: var(--type-size-code);
+    font-weight: var(--type-weight-body);
+    line-height: var(--type-leading-code);
+    letter-spacing: var(--type-tracking-body);
+  }
+}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -112,8 +112,8 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.3.0-canary-eb8feb71-20260814(react@19.3.0-canary-eb8feb71-20260814))(react@19.3.0-canary-eb8feb71-20260814)(supports-color@7.2.0)
       tailwind-merge:
-        specifier: ^2.5.0
-        version: 2.6.1
+        specifier: ^3.6.0
+        version: 3.6.0
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -5020,9 +5020,6 @@ packages:
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
-
-  tailwind-merge@2.6.1:
-    resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
 
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
@@ -10357,8 +10354,6 @@ snapshots:
   systeminformation@5.31.13: {}
 
   tagged-tag@1.0.0: {}
-
-  tailwind-merge@2.6.1: {}
 
   tailwind-merge@3.6.0: {}
 


### PR DESCRIPTION
Centralize typography, color, surface, radius, and interaction tokens into a frontend design system. Page headings and UI components use shared roles for controls, focus states, navigation, status indicators, and code. YAML and Markdown editors derive their appearance from these tokens, including their loading placeholders.

Standalone and embedded text fields declare focus ownership through a shared variant. The class-merging helper targets Tailwind 4 and recognizes custom tokens so component overrides preserve unrelated styling. Gradients use Tailwind 4 syntax, and container focus outlines follow embedded fields without duplicating nested button outlines. Existing form draft/submission state, member pagination, and onboarding presentation are extracted into focused hooks and components; their requests, retries, permissions, and navigation remain unchanged.

Validation:
- `make web-check` passed: existing tests, typechecking, production build, lint, formatting, generated SDK verification, and the embedded frontend compile check.
- React Doctor reports zero new errors or warnings against `origin/main`.
- Direct class-merging checks cover custom tokens, CSS-variable shorthand, important modifiers, and gradient/background preservation. Compiled CSS confirms the updated gradient syntax preserves the existing appearance in modern browsers.
- Read-only Claude reviews covered the logic extractions, class-merging migration, and focus behavior. Identified issues are fixed, and follow-up reviews found no remaining actionable issues.

Local browser automation was not run; the existing CI frontend job includes browser E2E coverage.
