### PR TITLE
test: consolidate model fixtures and clarify coverage ownership

### DIFF
--- a/internal/e2e/service_e2e_output_limit_test.go
+++ b/internal/e2e/service_e2e_output_limit_test.go
@@ -154,7 +154,7 @@ func TestServiceE2EOpenRouterOutputLimitContinuesThroughTool(t *testing.T) {
 	agentUUID := mustDecodeServiceE2EPublicID(t, publicid.KindAgent, agentID)
 	waitForServiceE2ETextOutput(t, ctx, env, projectUUID, agentUUID, finalText, failures, worker)
 	waitForServiceE2EAgentIdle(t, ctx, env, projectUUID, agentUUID)
-	var succeeded, failed, turns, truncated, calls, results int
+	var succeeded, failed, truncated, calls int
 	require.NoError(t, env.db.QueryRow(
 		ctx,
 		`SELECT count(*) FILTER(WHERE state='succeeded'),count(*) FILTER(WHERE state='failed') FROM model_call_contexts WHERE agent_id=$1`,
@@ -165,11 +165,6 @@ func TestServiceE2EOpenRouterOutputLimitContinuesThroughTool(t *testing.T) {
 	))
 	require.NoError(t, env.db.QueryRow(
 		ctx,
-		`SELECT count(DISTINCT turn_id) FROM agent_events WHERE agent_id=$1 AND event_kind='model_output'`,
-		agentUUID,
-	).Scan(&turns))
-	require.NoError(t, env.db.QueryRow(
-		ctx,
 		`SELECT count(*) FROM model_outputs output JOIN model_call_contexts context ON context.agent_id=output.agent_id AND context.id=output.model_call_context_id WHERE output.agent_id=$1 AND output.stop_reason='max_tokens' AND output.continue_after_truncation AND output.provider_replay IS NULL AND context.provider_metadata->>'request_max_output_tokens'='65536' AND context.provider_metadata->'openrouter'->>'finish_reason'='tool_calls' AND context.provider_metadata->'openrouter'->>'native_finish_reason'='length'`,
 		agentUUID,
 	).Scan(&truncated))
@@ -178,27 +173,18 @@ func TestServiceE2EOpenRouterOutputLimitContinuesThroughTool(t *testing.T) {
 		`SELECT count(*) FROM tool_calls WHERE agent_id=$1`,
 		agentUUID,
 	).Scan(&calls))
-	require.NoError(t, env.db.QueryRow(
-		ctx,
-		`SELECT count(*) FROM tool_call_results result JOIN tool_calls call ON call.agent_id=result.agent_id AND call.id=result.tool_call_id WHERE result.agent_id=$1 AND call.provider_call_id='accepted-call' AND result.outcome='succeeded'`,
-		agentUUID,
-	).Scan(&results))
 	if requests.Load() != 3 ||
 		succeeded != 3 ||
 		failed != 0 ||
-		turns != 1 ||
 		truncated != 1 ||
-		calls != 1 ||
-		results != 1 {
+		calls != 1 {
 		t.Fatalf(
-			"requests=%d succeeded=%d failed=%d turns=%d truncated=%d calls=%d results=%d",
+			"requests=%d succeeded=%d failed=%d truncated=%d calls=%d",
 			requests.Load(),
 			succeeded,
 			failed,
-			turns,
 			truncated,
 			calls,
-			results,
 		)
 	}
 }

--- a/internal/harness/kernel/agent_executor_compaction_local_budget_integration_test.go
+++ b/internal/harness/kernel/agent_executor_compaction_local_budget_integration_test.go
@@ -13,10 +13,9 @@ import (
 	"github.com/omnara-ai/omnara/internal/harness/tools"
 	"github.com/omnara-ai/omnara/internal/model"
 	"github.com/omnara-ai/omnara/internal/modelcontext"
-	"github.com/omnara-ai/omnara/internal/modelprotocol"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
-	"github.com/omnara-ai/omnara/internal/storage/modelstore"
 	"github.com/omnara-ai/omnara/internal/testutil/modeltest"
+	"github.com/omnara-ai/omnara/internal/testutil/storagefixture"
 )
 
 func TestAgentExecutorSendsFittingRequestAfterHighUsageTruncation(t *testing.T) {
@@ -199,40 +198,11 @@ func TestAgentExecutorCompactionKeepsRecentRawTail(t *testing.T) {
 	fixture := newKernelFixture(t, ctx)
 	providerName := "openai-keep-recent-prod"
 	configuredModelName := "kernel-keep-recent-test"
-	secret, err := fixture.ensureProviderCredential(t, ctx, providerName, fixture.Now)
-	if err != nil {
-		t.Fatalf("ensure provider credential: %v", err)
-	}
-	providerConfig, err := fixture.Store.Models().CreateModelProviderConfig(ctx, modelstore.CreateModelProviderConfigInput{
-		OrgID:              kernelTestOrgID,
-		Name:               providerName,
-		APIFormat:          modelprotocol.APIFormatOpenAIResponses,
-		APIVariant:         "default",
-		BaseURL:            "https://api.openai.com/v1",
-		CredentialSecretID: secret.ID,
-	})
-	if err != nil {
-		t.Fatalf("create keep-recent provider config: %v", err)
-	}
-	configuredModel, err := fixture.Store.Models().CreateConfiguredModel(ctx, modelstore.CreateConfiguredModelInput{
-		OrgID:                  kernelTestOrgID,
-		ModelProviderConfigID:  providerConfig.ID,
-		Name:                   configuredModelName,
-		ProviderModelSlug:      configuredModelName,
-		ContextWindowTokens:    3500,
-		MaxOutputTokens:        new(64),
-		DefaultMaxOutputTokens: intPtrForKernelCompactionTest(64),
-	})
-	if err != nil {
-		t.Fatalf("create keep-recent configured model: %v", err)
-	}
-	if _, err := fixture.Store.Models().CreateProjectModelGrant(ctx, modelstore.CreateProjectModelGrantInput{
-		OrgID:             kernelTestOrgID,
-		ProjectID:         kernelTestProjectID,
-		ConfiguredModelID: configuredModel.ID,
-	}); err != nil {
-		t.Fatalf("grant keep-recent configured model: %v", err)
-	}
+	provider := storagefixture.EnsureModelProvider(t, ctx, fixture.Store.Models(), fixture.Store.Secrets(),
+		storagefixture.ModelProviderInput{OrgID: kernelTestOrgID, UserID: kernelTestUserID, Name: providerName})
+	input := storagefixture.DefaultModelInput(kernelTestOrgID, provider.ID, configuredModelName)
+	input.ContextWindowTokens, input.MaxOutputTokens, input.DefaultMaxOutputTokens = 3500, new(64), new(64)
+	configuredModel := storagefixture.SeedModel(t, ctx, fixture.Store.Models(), kernelTestProjectID, input)
 	sourceYAML := "instruction: Help the user make progress.\nmodel:\n  provider_config: " + providerName + "\n  name: " +
 		configuredModelName +
 		"\n"

--- a/internal/harness/kernel/agent_executor_mcp_integration_test.go
+++ b/internal/harness/kernel/agent_executor_mcp_integration_test.go
@@ -44,7 +44,7 @@ mcp:
     permission:
       mode: always_allow
 `
-	agent := fixture.createConfigAndProfileBookmark(t, ctx, "Kernel MCP", "kernel-mcp-agent", sourceYAML, now)
+	agent := fixture.createConfigAndProfileBookmark(t, ctx, "Kernel MCP", "kernel-mcp-agent", sourceYAML)
 	launch, err := fixture.Store.Execution().LaunchAgent(
 		ctx,
 		executionstore.LaunchAgentInput{
@@ -235,7 +235,6 @@ mcp:
 		"Kernel MCP Connect Retry",
 		"kernel-mcp-connect-retry-agent",
 		sourceYAML,
-		now,
 	)
 	launch, err := fixture.Store.Execution().LaunchAgent(
 		ctx,
@@ -352,7 +351,6 @@ mcp:
 		"Kernel MCP List Tools Failure",
 		"kernel-mcp-list-tools-failure-agent",
 		sourceYAML,
-		now,
 	)
 	launch, err := fixture.Store.Execution().LaunchAgent(
 		ctx,
@@ -455,7 +453,6 @@ mcp:
 		"Kernel MCP Refresh",
 		"kernel-mcp-refresh-agent",
 		sourceYAML,
-		now,
 	)
 	launch, err := fixture.Store.Execution().LaunchAgent(
 		ctx,
@@ -563,7 +560,6 @@ mcp:
 		"Kernel MCP Config Change",
 		"kernel-mcp-config-change",
 		oldSource,
-		now,
 	)
 	launch, err := fixture.Store.Execution().LaunchAgent(ctx, executionstore.LaunchAgentInput{
 		ProjectID:      kernelTestProjectID,
@@ -576,7 +572,7 @@ mcp:
 		t.Fatalf("launch agent: %v", err)
 	}
 	newSource := strings.Replace(oldSource, "https://old.example.com/mcp", "https://new.example.com/mcp", 1)
-	compiled := fixture.compileAgentYAMLResolved(t, ctx, newSource, now.Add(time.Second))
+	compiled := fixture.compileAgentYAMLResolved(t, ctx, newSource)
 	nextConfig := executionstore.CreateAgentConfigInput{
 		ProjectID:               kernelTestProjectID,
 		Definition:              json.RawMessage(compiled.CanonicalJSON),
@@ -706,7 +702,6 @@ mcp:
 		"Kernel MCP Refresh Failure",
 		"kernel-mcp-refresh-failure-agent",
 		sourceYAML,
-		now,
 	)
 	launch, err := fixture.Store.Execution().LaunchAgent(
 		ctx,
@@ -877,7 +872,6 @@ mcp:
 		"Kernel MCP Failure",
 		"kernel-mcp-failure-agent",
 		sourceYAML,
-		now,
 	)
 	launch, err := fixture.Store.Execution().LaunchAgent(
 		ctx,

--- a/internal/harness/kernel/agent_executor_model_context_integration_test.go
+++ b/internal/harness/kernel/agent_executor_model_context_integration_test.go
@@ -46,7 +46,6 @@ model:
 		"Kernel Context Model Options",
 		"kernel-context-model-options-agent",
 		sourceYAML,
-		now,
 	)
 	launch, err := fixture.Store.Execution().LaunchAgent(
 		ctx,
@@ -125,7 +124,6 @@ model:
 		"Kernel Implicit Integration Tool",
 		"kernel-implicit-integration-tool-agent",
 		sourceYAML,
-		now,
 	)
 	launch, err := fixture.Store.Execution().LaunchAgent(
 		ctx,
@@ -224,7 +222,6 @@ model:
 		"Kernel Unavailable Grant",
 		"kernel-unavailable-grant-agent",
 		sourceYAML,
-		now,
 	)
 	launch, err := fixture.Store.Execution().LaunchAgent(
 		ctx,
@@ -708,7 +705,6 @@ tools:
 		"Kernel Tool Support",
 		"kernel-tool-support-agent",
 		sourceYAML,
-		now,
 	)
 	launch, err := fixture.Store.Execution().LaunchAgent(
 		ctx,

--- a/internal/harness/kernel/agent_executor_model_request_integration_test.go
+++ b/internal/harness/kernel/agent_executor_model_request_integration_test.go
@@ -506,7 +506,6 @@ model:
 		"Kernel Model Options",
 		"kernel-model-options-agent",
 		sourceYAML,
-		now,
 	)
 	launch, err := fixture.Store.Execution().LaunchAgent(
 		ctx,

--- a/internal/harness/kernel/agent_executor_output_truncation_integration_test.go
+++ b/internal/harness/kernel/agent_executor_output_truncation_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/omnara-ai/omnara/internal/model"
 	"github.com/omnara-ai/omnara/internal/modelcontext"
 	"github.com/omnara-ai/omnara/internal/modelprotocol"
+	"github.com/omnara-ai/omnara/internal/storage"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
 	"github.com/stretchr/testify/require"
@@ -262,13 +263,7 @@ func TestCancelOutputContinuationBeforeAndAfterRuntimeClaim(t *testing.T) {
 					t.Fatal("canceled claimed work was executable")
 				}
 			}
-			var next int
-			require.NoError(t, fixture.Pool.QueryRow(
-				ctx,
-				`SELECT count(*) FROM agent_next_model_work($1,$2)`,
-				kernelTestProjectID,
-				agentID,
-			).Scan(&next))
+			next := pendingModelWork(t, ctx, fixture, agentID)
 			if next != 0 || client.respondedCount() != 1 {
 				t.Fatalf("work=%d sends=%d", next, client.respondedCount())
 			}
@@ -301,13 +296,8 @@ func TestOutputContinuationIsConsumedBySuccessorTerminalFailure(t *testing.T) {
 	executor.ModelResolver = liveTestModelResolver(fixture.Store, client)
 	work = executeNextModelWork(t, ctx, fixture, executor, work)
 	fixture.releaseModelRuntimeLock(t, ctx, work)
-	var next, failures int
-	require.NoError(t, fixture.Pool.QueryRow(
-		ctx,
-		`SELECT count(*) FROM agent_next_model_work($1,$2)`,
-		kernelTestProjectID,
-		agentID,
-	).Scan(&next))
+	var failures int
+	next := pendingModelWork(t, ctx, fixture, agentID)
 	require.NoError(t, fixture.Pool.QueryRow(
 		ctx,
 		`SELECT count(*) FROM model_outputs WHERE agent_id=$1 AND stop_reason='error'`,
@@ -405,7 +395,7 @@ func TestOutputContinuationBoundSurvivesRetryAndCompaction(t *testing.T) {
 			fixture.releaseModelRuntimeLock(t, ctx, work)
 			work = executeNextModelWork(t, ctx, fixture, executor, work)
 			fixture.releaseModelRuntimeLock(t, ctx, work)
-			var outputs, continued, checkpoints, next int
+			var outputs, continued, checkpoints int
 			require.NoError(t, fixture.Pool.QueryRow(
 				ctx,
 				`SELECT count(*),count(*) FILTER(WHERE continue_after_truncation) FROM model_outputs WHERE agent_id=$1 AND stop_reason='max_tokens'`,
@@ -419,12 +409,7 @@ func TestOutputContinuationBoundSurvivesRetryAndCompaction(t *testing.T) {
 				`SELECT count(*) FROM context_checkpoints WHERE agent_id=$1`,
 				agentID,
 			).Scan(&checkpoints))
-			require.NoError(t, fixture.Pool.QueryRow(
-				ctx,
-				`SELECT count(*) FROM agent_next_model_work($1,$2)`,
-				kernelTestProjectID,
-				agentID,
-			).Scan(&next))
+			next := pendingModelWork(t, ctx, fixture, agentID)
 			wantCheckpoints, wantSends := 0, 3
 			if compact {
 				wantCheckpoints, wantSends = 1, 4
@@ -550,7 +535,7 @@ func TestOutputContinuationBoundResetsOnSteeringAndToolProgress(t *testing.T) {
 				require.NoError(t, executor.ExecuteModelWork(ctx, work))
 				fixture.releaseModelRuntimeLock(t, ctx, work)
 			}
-			var outputs, continued, next int
+			var outputs, continued int
 			require.NoError(t, fixture.Pool.QueryRow(
 				ctx,
 				`SELECT count(*),count(*) FILTER(WHERE continue_after_truncation) FROM model_outputs WHERE agent_id=$1 AND stop_reason='max_tokens'`,
@@ -559,15 +544,18 @@ func TestOutputContinuationBoundResetsOnSteeringAndToolProgress(t *testing.T) {
 				&outputs,
 				&continued,
 			))
-			require.NoError(t, fixture.Pool.QueryRow(
-				ctx,
-				`SELECT count(*) FROM agent_next_model_work($1,$2)`,
-				kernelTestProjectID,
-				agentID,
-			).Scan(&next))
+			next := pendingModelWork(t, ctx, fixture, agentID)
 			if outputs != 5 || continued != 4 || next != 0 {
 				t.Fatalf("outputs=%d continued=%d next=%d", outputs, continued, next)
 			}
 		})
 	}
+}
+
+func pendingModelWork(t *testing.T, ctx context.Context, fixture kernelFixture, agentID storage.ID) int {
+	t.Helper()
+	var count int
+	require.NoError(t, fixture.Pool.QueryRow(ctx,
+		`SELECT count(*) FROM agent_next_model_work($1,$2)`, kernelTestProjectID, agentID).Scan(&count))
+	return count
 }

--- a/internal/harness/kernel/agent_executor_prompt_cache_integration_test.go
+++ b/internal/harness/kernel/agent_executor_prompt_cache_integration_test.go
@@ -87,7 +87,6 @@ tools:
 skills:
   - %s
 `, machinePool.Name, skillPublicID),
-		now,
 	)
 	launch, err := fixture.Store.Execution().LaunchAgent(ctx, executionstore.LaunchAgentInput{
 		ProjectID:      kernelTestProjectID,

--- a/internal/harness/kernel/agent_executor_test_helpers_test.go
+++ b/internal/harness/kernel/agent_executor_test_helpers_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
 
 	"github.com/omnara-ai/omnara/internal/agentconfig"
 	"github.com/omnara-ai/omnara/internal/harness/tools"
@@ -37,6 +38,7 @@ import (
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
 	"github.com/omnara-ai/omnara/internal/testutil/integrationblob"
 	"github.com/omnara-ai/omnara/internal/testutil/integrationdb"
+	"github.com/omnara-ai/omnara/internal/testutil/storagefixture"
 )
 
 var (
@@ -244,7 +246,6 @@ func (f kernelFixture) createNamedAgentWithModelOptions(
 		name,
 		agentProfileIdempotencyKey,
 		sourceYAML,
-		now,
 		modelOptions,
 	)
 	launch, err := f.Store.Execution().LaunchAgent(
@@ -267,7 +268,6 @@ func (f kernelFixture) createConfigAndProfileBookmark(
 	t *testing.T,
 	ctx context.Context,
 	name, idempotencyKey, sourceYAML string,
-	now time.Time,
 ) executionstore.AgentProfileRecord {
 	t.Helper()
 	return f.createConfigAndProfileBookmarkWithModelOptions(
@@ -276,7 +276,6 @@ func (f kernelFixture) createConfigAndProfileBookmark(
 		name,
 		idempotencyKey,
 		sourceYAML,
-		now,
 		kernelConfiguredModelOptions{},
 	)
 }
@@ -285,11 +284,10 @@ func (f kernelFixture) createConfigAndProfileBookmarkWithModelOptions(
 	t *testing.T,
 	ctx context.Context,
 	name, idempotencyKey, sourceYAML string,
-	now time.Time,
 	modelOptions kernelConfiguredModelOptions,
 ) executionstore.AgentProfileRecord {
 	t.Helper()
-	compiled := f.compileAgentYAMLResolvedWithModelOptions(t, ctx, sourceYAML, now, modelOptions)
+	compiled := f.compileAgentYAMLResolvedWithModelOptions(t, ctx, sourceYAML, modelOptions)
 	config, err := f.Store.Execution().CreateAgentConfig(ctx, executionstore.CreateAgentConfigInput{
 		ProjectID:               kernelTestProjectID,
 		Definition:              json.RawMessage(compiled.CanonicalJSON),
@@ -319,17 +317,15 @@ func (f kernelFixture) compileAgentYAMLResolved(
 	t *testing.T,
 	ctx context.Context,
 	sourceYAML string,
-	now time.Time,
 ) agentconfig.Result {
 	t.Helper()
-	return f.compileAgentYAMLResolvedWithModelOptions(t, ctx, sourceYAML, now, kernelConfiguredModelOptions{})
+	return f.compileAgentYAMLResolvedWithModelOptions(t, ctx, sourceYAML, kernelConfiguredModelOptions{})
 }
 
 func (f kernelFixture) compileAgentYAMLResolvedWithModelOptions(
 	t *testing.T,
 	ctx context.Context,
 	sourceYAML string,
-	now time.Time,
 	modelOptions kernelConfiguredModelOptions,
 ) agentconfig.Result {
 	t.Helper()
@@ -337,7 +333,7 @@ func (f kernelFixture) compileAgentYAMLResolvedWithModelOptions(
 	if err != nil {
 		t.Fatalf("parse agent config source: %v", err)
 	}
-	configuredModel := f.ensureModelSelection(t, ctx, source.Model.ProviderConfig, source.Model.Name, now, modelOptions)
+	configuredModel := f.ensureModelSelection(t, ctx, source.Model.ProviderConfig, source.Model.Name, modelOptions)
 	compiled, err := agentconfig.Compile(agentconfig.SourceFormatYAML, []byte(sourceYAML), agentconfig.CompileOptions{
 		ResolveModelSelection: func(
 			providerConfigName string,
@@ -392,62 +388,26 @@ func (f kernelFixture) ensureModelSelection(
 	t *testing.T,
 	ctx context.Context,
 	providerConfigName, configuredModelName string,
-	now time.Time,
 	options kernelConfiguredModelOptions,
 ) modelstore.ConfiguredModelRecord {
 	t.Helper()
-	providerConfig, err := f.Store.Models().GetModelProviderConfigByName(ctx, kernelTestOrgID, providerConfigName)
-	if err != nil {
-		if !storeerr.IsNotFound(err) {
-			t.Fatalf("load model provider config %q: %v", providerConfigName, err)
-		}
-		secret, err := f.ensureProviderCredential(t, ctx, providerConfigName, now)
-		if err != nil {
-			t.Fatalf("ensure provider credential: %v", err)
-		}
-		providerConfig, err = f.Store.Models().CreateModelProviderConfig(ctx, modelstore.CreateModelProviderConfigInput{
-			OrgID:              kernelTestOrgID,
-			Name:               providerConfigName,
-			APIFormat:          modelprotocol.APIFormatOpenAIResponses,
-			APIVariant:         "default",
-			BaseURL:            "https://api.openai.com/v1",
-			CredentialSecretID: secret.ID,
-		})
-		if err != nil {
-			t.Fatalf("create model provider config %q: %v", providerConfigName, err)
-		}
-	}
-	if providerConfig.ManagementKind == management.Cluster {
+	provider := storagefixture.EnsureModelProvider(t, ctx, f.Store.Models(), f.Store.Secrets(),
+		storagefixture.ModelProviderInput{OrgID: kernelTestOrgID, UserID: kernelTestUserID, Name: providerConfigName})
+	if provider.ManagementKind == management.Cluster {
 		configuredModel, err := f.Store.Models().GetConfiguredModelByName(
-			ctx,
-			kernelTestOrgID,
-			providerConfig.ID,
-			configuredModelName,
+			ctx, kernelTestOrgID, provider.ID, configuredModelName,
 		)
-		if err != nil {
-			t.Fatalf("load cluster configured model %s/%s: %v", providerConfigName, configuredModelName, err)
-		}
+		require.NoError(t, err, "load cluster configured model %s/%s", providerConfigName, configuredModelName)
 		return configuredModel
 	}
-	configuredModel, err := f.Store.Models().CreateConfiguredModel(ctx, modelstore.CreateConfiguredModelInput{
-		OrgID:                 kernelTestOrgID,
-		ModelProviderConfigID: providerConfig.ID,
-		Name:                  configuredModelName,
-		ProviderModelSlug:     configuredModelName,
-		ContextWindowTokens:   firstKernelTestInt(options.ContextWindowTokens, 128000),
-		MaxOutputTokens:       new(firstKernelTestInt(options.MaxOutputTokens, 8192)),
-	})
-	if err != nil {
-		t.Fatalf("create configured model %s/%s: %v", providerConfigName, configuredModelName, err)
+	input := storagefixture.DefaultModelInput(kernelTestOrgID, provider.ID, configuredModelName)
+	if options.ContextWindowTokens != nil {
+		input.ContextWindowTokens = *options.ContextWindowTokens
 	}
-	if _, err := f.Store.Models().CreateProjectModelGrant(ctx, modelstore.CreateProjectModelGrantInput{
-		OrgID:             kernelTestOrgID,
-		ProjectID:         kernelTestProjectID,
-		ConfiguredModelID: configuredModel.ID,
-	}); err != nil {
-		t.Fatalf("grant configured model %s/%s: %v", providerConfigName, configuredModelName, err)
+	if options.MaxOutputTokens != nil {
+		input.MaxOutputTokens = options.MaxOutputTokens
 	}
-	return configuredModel
+	return storagefixture.SeedModel(t, ctx, f.Store.Models(), kernelTestProjectID, input)
 }
 
 func (f kernelFixture) provisionClusterModel(
@@ -516,45 +476,6 @@ SET new_managed_work_allowed = EXCLUDED.new_managed_work_allowed
 `, kernelTestOrgID, allowed); err != nil {
 		t.Fatalf("set managed work admission to %v: %v", allowed, err)
 	}
-}
-
-func firstKernelTestInt(value *int, fallback int) int {
-	if value != nil {
-		return *value
-	}
-	return fallback
-}
-
-func (f kernelFixture) ensureProviderCredential(
-	t *testing.T,
-	ctx context.Context,
-	providerConfigName string,
-	now time.Time,
-) (secretstore.SecretRecord, error) {
-	t.Helper()
-	name := "kernel-provider-" + providerConfigName
-	secret, err := f.Store.Secrets().GetSecretByOwnerName(
-		ctx,
-		kernelTestOrgID,
-		secretstore.SecretOwnerOrg,
-		storage.NilID,
-		storage.NilID,
-		name,
-	)
-	if err == nil {
-		return secret, nil
-	}
-	if !storeerr.IsNotFound(err) {
-		return secretstore.SecretRecord{}, err
-	}
-	secret, _, err = f.Store.Secrets().CreateSecret(ctx, secretstore.CreateSecretInput{
-		OrgID:     kernelTestOrgID,
-		OwnerKind: secretstore.SecretOwnerOrg,
-		Name:      name,
-		Material:  secrets.GenericMaterial{Value: "test-key"},
-		Actor:     kernelTestUserPrincipal(kernelTestUserID),
-	})
-	return secret, err
 }
 
 func parseConfiguredModelID(t *testing.T, compiled agentconfig.Result) storage.ID {

--- a/internal/harness/kernel/agent_executor_tool_lifecycle_integration_test.go
+++ b/internal/harness/kernel/agent_executor_tool_lifecycle_integration_test.go
@@ -63,7 +63,6 @@ model:
 skills:
   - %s
 `, skillPublicID),
-		fixture.Now,
 	)
 	launch, err := fixture.Store.Execution().LaunchAgent(ctx, executionstore.LaunchAgentInput{
 		ProjectID:      kernelTestProjectID,
@@ -765,7 +764,7 @@ func (f kernelFixture) kernelAgentConfigInput(
 	sourceYAML := "instruction: Help the user make progress.\nmodel:\n  provider_config: openai-prod\n  name: " +
 		configuredModelName +
 		"\n"
-	compiled := f.compileAgentYAMLResolved(t, ctx, sourceYAML, f.Now)
+	compiled := f.compileAgentYAMLResolved(t, ctx, sourceYAML)
 	return executionstore.CreateAgentConfigInput{
 		ProjectID:               kernelTestProjectID,
 		Definition:              json.RawMessage(compiled.CanonicalJSON),
@@ -811,7 +810,7 @@ tools:
     input_schema:
       type: object
 `
-	compiled := fixture.compileAgentYAMLResolved(t, ctx, sourceYAML, fixture.Now)
+	compiled := fixture.compileAgentYAMLResolved(t, ctx, sourceYAML)
 	config, err := fixture.Store.Execution().CreateAgentConfig(ctx, executionstore.CreateAgentConfigInput{
 		ProjectID:               kernelTestProjectID,
 		Definition:              json.RawMessage(compiled.CanonicalJSON),

--- a/internal/harness/tools/integration_tools_integration_test.go
+++ b/internal/harness/tools/integration_tools_integration_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/omnara-ai/omnara/internal/testutil/integrationblob"
 	"github.com/omnara-ai/omnara/internal/testutil/integrationdb"
 	"github.com/omnara-ai/omnara/internal/testutil/modeltest"
+	"github.com/omnara-ai/omnara/internal/testutil/storagefixture"
 	"github.com/omnara-ai/omnara/internal/testutil/storagetest"
 	"github.com/omnara-ai/omnara/internal/toolcatalog"
 	"github.com/omnara-ai/omnara/internal/toolpermission"
@@ -1803,7 +1804,7 @@ VALUES ($1, $2, 'Tools Integration Project', $3, $4, $4)
 	}
 	ensureIntegrationToolsProjectAdmin(t, ctx, store, user.ID, now)
 
-	profile := createIntegrationToolProfile(t, ctx, store, user.ID, label, now.Add(time.Second), withMCP)
+	profile := createIntegrationToolProfile(t, ctx, store, user.ID, label, withMCP)
 	launch, err := store.Execution().LaunchAgent(
 		ctx,
 		executionstore.LaunchAgentInput{
@@ -2058,7 +2059,6 @@ func createIntegrationToolProfile(
 	store *storage.Store,
 	userID storage.ID,
 	label string,
-	now time.Time,
 	withMCP bool,
 ) executionstore.AgentProfileRecord {
 	t.Helper()
@@ -2083,7 +2083,7 @@ tools:
       parameters: {}
 `
 	}
-	compiled := compileToolsAgentYAMLResolved(t, ctx, store, userID, sourceYAML, now)
+	compiled := compileToolsAgentYAMLResolved(t, ctx, store, userID, sourceYAML)
 	config, err := store.Execution().CreateAgentConfig(ctx, executionstore.CreateAgentConfigInput{
 		ProjectID:               toolsTestProjectID,
 		Definition:              json.RawMessage(compiled.CanonicalJSON),
@@ -2115,22 +2115,16 @@ func compileToolsAgentYAMLResolved(
 	store *storage.Store,
 	userID storage.ID,
 	sourceYAML string,
-	now time.Time,
 ) agentconfig.Result {
 	t.Helper()
 	source, err := agentconfig.ParseSource(agentconfig.SourceFormatYAML, []byte(sourceYAML))
 	if err != nil {
 		t.Fatalf("parse agent config source: %v", err)
 	}
-	configuredModel := ensureToolsModelSelection(
-		t,
-		ctx,
-		store,
-		userID,
-		source.Model.ProviderConfig,
-		source.Model.Name,
-		now,
-	)
+	provider := storagefixture.EnsureModelProvider(t, ctx, store.Models(), store.Secrets(),
+		storagefixture.ModelProviderInput{OrgID: toolsTestOrgID, UserID: userID, Name: source.Model.ProviderConfig})
+	configuredModel := storagefixture.SeedModel(t, ctx, store.Models(), toolsTestProjectID,
+		storagefixture.DefaultModelInput(toolsTestOrgID, provider.ID, source.Model.Name))
 	compiled, err := agentconfig.Compile(agentconfig.SourceFormatYAML, []byte(sourceYAML), agentconfig.CompileOptions{
 		ResolveModelSelection: func(
 			providerConfigName string,
@@ -2189,90 +2183,6 @@ func resolvedToolsAgentConfigModel(
 		ConfiguredModelID: configuredModel.ID.String(),
 		SupportsTools:     &supportsTools,
 	}
-}
-
-func ensureToolsModelSelection(
-	t *testing.T,
-	ctx context.Context,
-	store *storage.Store,
-	userID storage.ID,
-	providerConfigName, configuredModelName string,
-	now time.Time,
-) modelstore.ConfiguredModelRecord {
-	t.Helper()
-	providerConfig, err := store.Models().GetModelProviderConfigByName(ctx, toolsTestOrgID, providerConfigName)
-	if err != nil {
-		if !storeerr.IsNotFound(err) {
-			t.Fatalf("load model provider config %q: %v", providerConfigName, err)
-		}
-		secret, err := ensureToolsProviderCredential(t, ctx, store, userID, providerConfigName)
-		if err != nil {
-			t.Fatalf("ensure provider credential: %v", err)
-		}
-		providerConfig, err = store.Models().CreateModelProviderConfig(ctx, modelstore.CreateModelProviderConfigInput{
-			OrgID:              toolsTestOrgID,
-			Name:               providerConfigName,
-			APIFormat:          modelprotocol.APIFormatOpenAIResponses,
-			APIVariant:         "default",
-			BaseURL:            "https://api.openai.com/v1",
-			CredentialSecretID: secret.ID,
-		})
-		if err != nil {
-			t.Fatalf("create model provider config %q: %v", providerConfigName, err)
-		}
-	}
-	configuredModel, err := store.Models().CreateConfiguredModel(ctx, modelstore.CreateConfiguredModelInput{
-		OrgID:                 toolsTestOrgID,
-		ModelProviderConfigID: providerConfig.ID,
-		Name:                  configuredModelName,
-		ProviderModelSlug:     configuredModelName,
-		ContextWindowTokens:   128000,
-		MaxOutputTokens:       new(8192),
-	})
-	if err != nil {
-		t.Fatalf("create configured model %s/%s: %v", providerConfigName, configuredModelName, err)
-	}
-	if _, err := store.Models().CreateProjectModelGrant(ctx, modelstore.CreateProjectModelGrantInput{
-		OrgID:             toolsTestOrgID,
-		ProjectID:         toolsTestProjectID,
-		ConfiguredModelID: configuredModel.ID,
-	}); err != nil {
-		t.Fatalf("grant configured model %s/%s: %v", providerConfigName, configuredModelName, err)
-	}
-	return configuredModel
-}
-
-func ensureToolsProviderCredential(
-	t *testing.T,
-	ctx context.Context,
-	store *storage.Store,
-	userID storage.ID,
-	providerConfigName string,
-) (secretstore.SecretRecord, error) {
-	t.Helper()
-	name := "tools-provider-" + providerConfigName
-	secret, err := store.Secrets().GetSecretByOwnerName(
-		ctx,
-		toolsTestOrgID,
-		secretstore.SecretOwnerOrg,
-		storage.NilID,
-		storage.NilID,
-		name,
-	)
-	if err == nil {
-		return secret, nil
-	}
-	if !storeerr.IsNotFound(err) {
-		return secretstore.SecretRecord{}, err
-	}
-	secret, _, err = store.Secrets().CreateSecret(ctx, secretstore.CreateSecretInput{
-		OrgID:     toolsTestOrgID,
-		OwnerKind: secretstore.SecretOwnerOrg,
-		Name:      name,
-		Material:  secrets.GenericMaterial{Value: "test-key"},
-		Actor:     toolsTestUserPrincipal(userID),
-	})
-	return secret, err
 }
 
 func intPtrForToolsTest(value int) *int {

--- a/internal/harness/tools/machine_execution_target_integration_test.go
+++ b/internal/harness/tools/machine_execution_target_integration_test.go
@@ -126,7 +126,6 @@ func TestResolveMachineExecutionTargetUsesMachineRefSelection(t *testing.T) {
 			{MachineName: firstBinding.DisplayName, Cwd: "/first"},
 			{MachineName: secondBinding.DisplayName, Cwd: "/second"},
 		},
-		now.Add(3*time.Second),
 	)
 	if len(launch.MachineBindings) != 2 {
 		t.Fatalf("machine bindings = %+v, want two", launch.MachineBindings)
@@ -160,7 +159,6 @@ func TestResolveMachineExecutionTargetUsesMachineRefSelection(t *testing.T) {
 		user.ID,
 		"tools-target-single",
 		[]toolsAgentMachineSource{{MachineName: firstBinding.DisplayName, Cwd: "/only"}},
-		now.Add(6*time.Second),
 	)
 	if len(singleLaunch.MachineBindings) != 1 {
 		t.Fatalf("single machine bindings = %+v, want one", singleLaunch.MachineBindings)
@@ -214,7 +212,6 @@ tools:
 		fixture.Store,
 		fixture.UserID,
 		sourceYAML,
-		fixture.Now.Add(6*time.Second),
 	)
 	config, err := fixture.Store.Execution().CreateAgentConfig(ctx, executionstore.CreateAgentConfigInput{
 		ProjectID:               toolsTestProjectID,
@@ -679,7 +676,6 @@ func TestProcessToolMachineSelectionFailureKeepsStructuredPayload(t *testing.T) 
 			{MachineName: firstBinding.DisplayName},
 			{MachineName: secondBinding.DisplayName},
 		},
-		now.Add(3*time.Second),
 	)
 	if len(launch.MachineBindings) != 2 {
 		t.Fatalf("machine bindings = %+v, want two", launch.MachineBindings)
@@ -1647,7 +1643,6 @@ func TestReadProcessAfterTerminalWakesAsleepMachine(t *testing.T) {
 		user.ID,
 		"tools-replay",
 		[]toolsAgentMachineSource{{MachineName: binding.DisplayName, Cwd: "/replay"}},
-		now.Add(2*time.Second),
 	)
 	if len(launch.MachineBindings) != 1 {
 		t.Fatalf("machine bindings = %+v, want one", launch.MachineBindings)
@@ -2255,7 +2250,7 @@ tools:
       mode: always_allow
       parameters: {}
 `
-	compiled := compileToolsAgentYAMLResolved(t, ctx, store, user.ID, sourceYAML, now.Add(3*time.Second))
+	compiled := compileToolsAgentYAMLResolved(t, ctx, store, user.ID, sourceYAML)
 	config, err := store.Execution().CreateAgentConfig(ctx, executionstore.CreateAgentConfigInput{
 		ProjectID:               toolsTestProjectID,
 		Definition:              json.RawMessage(compiled.CanonicalJSON),
@@ -2513,7 +2508,6 @@ func createToolsRuntimeAgentWithMachineSources(
 	userID storage.ID,
 	name string,
 	machineSources []toolsAgentMachineSource,
-	now time.Time,
 ) executionstore.LaunchAgentResult {
 	t.Helper()
 	return createToolsRuntimeAgentWithMachineSourcesAndSkills(
@@ -2524,7 +2518,6 @@ func createToolsRuntimeAgentWithMachineSources(
 		name,
 		machineSources,
 		nil,
-		now,
 	)
 }
 
@@ -2536,7 +2529,6 @@ func createToolsRuntimeAgentWithMachineSourcesAndSkills(
 	name string,
 	machineSources []toolsAgentMachineSource,
 	skillIDs []string,
-	now time.Time,
 ) executionstore.LaunchAgentResult {
 	t.Helper()
 	sourceYAML := `instruction: Test tool execution.
@@ -2565,7 +2557,7 @@ model:
       mode: always_allow
       parameters: {}
 `
-	compiled := compileToolsAgentYAMLResolved(t, ctx, store, userID, sourceYAML, now)
+	compiled := compileToolsAgentYAMLResolved(t, ctx, store, userID, sourceYAML)
 	config, err := store.Execution().CreateAgentConfig(ctx, executionstore.CreateAgentConfigInput{
 		ProjectID:               toolsTestProjectID,
 		Definition:              json.RawMessage(compiled.CanonicalJSON),

--- a/internal/harness/tools/machine_sleep_target_integration_test.go
+++ b/internal/harness/tools/machine_sleep_target_integration_test.go
@@ -63,7 +63,6 @@ func TestRunCommandCommitsBeforeWakingAsleepMachine(t *testing.T) {
 		user.ID,
 		"tools-sleep",
 		[]toolsAgentMachineSource{{MachineName: binding.DisplayName, Cwd: "/asleep"}},
-		now.Add(2*time.Second),
 	)
 	if len(launch.MachineBindings) != 1 {
 		t.Fatalf("machine bindings = %+v, want one", launch.MachineBindings)
@@ -296,7 +295,6 @@ func TestSkillToolBroadcastsExecutableBindingsAndReportsOutcomes(t *testing.T) {
 			{MachineName: second.DisplayName, Cwd: "/second"},
 		},
 		[]string{skillPublicID},
-		now.Add(4*time.Second),
 	)
 	_, _, _, modelContext := createMachineToolCallForDirectStoreTest(
 		t,

--- a/internal/harness/worker/worker_integration_test.go
+++ b/internal/harness/worker/worker_integration_test.go
@@ -27,11 +27,10 @@ import (
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 	"github.com/omnara-ai/omnara/internal/storage/identitystore"
 	"github.com/omnara-ai/omnara/internal/storage/modelstore"
-	"github.com/omnara-ai/omnara/internal/storage/secretstore"
-	"github.com/omnara-ai/omnara/internal/storage/storeerr"
 	"github.com/omnara-ai/omnara/internal/testutil/integrationdb"
 	"github.com/omnara-ai/omnara/internal/testutil/integrationredis"
 	"github.com/omnara-ai/omnara/internal/testutil/modeltest"
+	"github.com/omnara-ai/omnara/internal/testutil/storagefixture"
 	"github.com/omnara-ai/omnara/internal/testutil/storagetest"
 	"github.com/omnara-ai/omnara/internal/toolpermission"
 )
@@ -1888,7 +1887,7 @@ func createWorkerAgentFromSource(
 	sourceYAML string,
 ) (storage.ID, storage.ID) {
 	t.Helper()
-	compiled := compileWorkerAgentYAMLResolved(t, ctx, store, projectID, sourceYAML, now)
+	compiled := compileWorkerAgentYAMLResolved(t, ctx, store, projectID, sourceYAML)
 	config, err := store.Execution().CreateAgentConfig(ctx, executionstore.CreateAgentConfigInput{
 		ProjectID:               projectID,
 		Definition:              json.RawMessage(compiled.CanonicalJSON),
@@ -1930,22 +1929,18 @@ func compileWorkerAgentYAMLResolved(
 	store *storage.Store,
 	projectID storage.ID,
 	sourceYAML string,
-	now time.Time,
 ) agentconfig.Result {
 	t.Helper()
 	source, err := agentconfig.ParseSource(agentconfig.SourceFormatYAML, []byte(sourceYAML))
 	if err != nil {
 		t.Fatalf("parse worker test agent source: %v", err)
 	}
-	configuredModel := ensureWorkerModelSelection(
-		t,
-		ctx,
-		store,
-		projectID,
-		source.Model.ProviderConfig,
-		source.Model.Name,
-		now,
-	)
+	provider := storagefixture.EnsureModelProvider(t, ctx, store.Models(), store.Secrets(),
+		storagefixture.ModelProviderInput{
+			OrgID: workerTestOrgID, UserID: workerTestUserID, Name: source.Model.ProviderConfig,
+		})
+	configuredModel := storagefixture.SeedModel(t, ctx, store.Models(), projectID,
+		storagefixture.DefaultModelInput(workerTestOrgID, provider.ID, source.Model.Name))
 	compiled, err := agentconfig.Compile(agentconfig.SourceFormatYAML, []byte(sourceYAML), agentconfig.CompileOptions{
 		ResolveModelSelection: func(
 			providerConfigName string,
@@ -1975,89 +1970,6 @@ func resolvedWorkerAgentConfigModel(
 		ConfiguredModelID: configuredModel.ID.String(),
 		SupportsTools:     &supportsTools,
 	}
-}
-
-func ensureWorkerModelSelection(
-	t *testing.T,
-	ctx context.Context,
-	store *storage.Store,
-	projectID storage.ID,
-	providerConfigName, configuredModelName string,
-	now time.Time,
-) modelstore.ConfiguredModelRecord {
-	t.Helper()
-	providerConfig, err := store.Models().GetModelProviderConfigByName(ctx, workerTestOrgID, providerConfigName)
-	if err != nil {
-		if !storeerr.IsNotFound(err) {
-			t.Fatalf("load model provider config %q: %v", providerConfigName, err)
-		}
-		secret, err := ensureWorkerProviderCredential(t, ctx, store, providerConfigName)
-		if err != nil {
-			t.Fatalf("ensure provider credential: %v", err)
-		}
-		providerConfig, err = store.Models().CreateModelProviderConfig(ctx, modelstore.CreateModelProviderConfigInput{
-			OrgID:              workerTestOrgID,
-			Name:               providerConfigName,
-			APIFormat:          modelprotocol.APIFormatOpenAIResponses,
-			APIVariant:         "default",
-			BaseURL:            "https://api.openai.com/v1",
-			CredentialSecretID: secret.ID,
-		})
-		if err != nil {
-			t.Fatalf("create model provider config %q: %v", providerConfigName, err)
-		}
-	}
-	configuredModel, err := store.Models().CreateConfiguredModel(ctx, modelstore.CreateConfiguredModelInput{
-		OrgID:                 workerTestOrgID,
-		ModelProviderConfigID: providerConfig.ID,
-		Name:                  configuredModelName,
-		ProviderModelSlug:     configuredModelName,
-		ContextWindowTokens:   128000,
-		MaxOutputTokens:       new(8192),
-	})
-	if err != nil {
-		t.Fatalf("create configured model %s/%s: %v", providerConfigName, configuredModelName, err)
-	}
-	if _, err := store.Models().CreateProjectModelGrant(ctx, modelstore.CreateProjectModelGrantInput{
-		OrgID:             workerTestOrgID,
-		ProjectID:         projectID,
-		ConfiguredModelID: configuredModel.ID,
-	}); err != nil {
-		t.Fatalf("grant configured model %s/%s: %v", providerConfigName, configuredModelName, err)
-	}
-	return configuredModel
-}
-
-func ensureWorkerProviderCredential(
-	t *testing.T,
-	ctx context.Context,
-	store *storage.Store,
-	providerConfigName string,
-) (secretstore.SecretRecord, error) {
-	t.Helper()
-	name := "worker-provider-" + providerConfigName
-	secret, err := store.Secrets().GetSecretByOwnerName(
-		ctx,
-		workerTestOrgID,
-		secretstore.SecretOwnerOrg,
-		storage.NilID,
-		storage.NilID,
-		name,
-	)
-	if err == nil {
-		return secret, nil
-	}
-	if !storeerr.IsNotFound(err) {
-		return secretstore.SecretRecord{}, err
-	}
-	secret, _, err = store.Secrets().CreateSecret(ctx, secretstore.CreateSecretInput{
-		OrgID:     workerTestOrgID,
-		OwnerKind: secretstore.SecretOwnerOrg,
-		Name:      name,
-		Material:  secrets.GenericMaterial{Value: "test-key"},
-		Actor:     workerTestUserPrincipal(workerTestUserID),
-	})
-	return secret, err
 }
 
 func parseWorkerConfiguredModelID(t *testing.T, compiled agentconfig.Result) storage.ID {

--- a/internal/httpapi/agent_config_test_helpers_test.go
+++ b/internal/httpapi/agent_config_test_helpers_test.go
@@ -8,14 +8,11 @@ import (
 	"testing"
 
 	"github.com/omnara-ai/omnara/internal/agentconfig"
-	"github.com/omnara-ai/omnara/internal/modelprotocol"
 	"github.com/omnara-ai/omnara/internal/publicid"
-	"github.com/omnara-ai/omnara/internal/secrets"
 	"github.com/omnara-ai/omnara/internal/storage"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
 	"github.com/omnara-ai/omnara/internal/storage/modelstore"
-	"github.com/omnara-ai/omnara/internal/storage/secretstore"
-	"github.com/omnara-ai/omnara/internal/storage/storeerr"
+	"github.com/omnara-ai/omnara/internal/testutil/storagefixture"
 )
 
 func createHTTPRuntimeAgent(
@@ -119,16 +116,10 @@ func compileHTTPAgentYAMLResolved(
 	if err != nil {
 		t.Fatalf("parse agent config source: %v", err)
 	}
-	configuredModel := ensureHTTPModelSelection(
-		t,
-		ctx,
-		store,
-		orgID,
-		projectID,
-		userID,
-		source.Model.ProviderConfig,
-		source.Model.Name,
-	)
+	provider := storagefixture.EnsureModelProvider(t, ctx, store.Models(), store.Secrets(),
+		storagefixture.ModelProviderInput{OrgID: orgID, UserID: userID, Name: source.Model.ProviderConfig})
+	configuredModel := storagefixture.SeedModel(t, ctx, store.Models(), projectID,
+		storagefixture.DefaultModelInput(orgID, provider.ID, source.Model.Name))
 	compiled, err := agentconfig.Compile(agentconfig.SourceFormatYAML, []byte(sourceYAML), agentconfig.CompileOptions{
 		ResolveModelSelection: func(
 			providerConfigName string,
@@ -156,84 +147,6 @@ func resolvedHTTPAgentConfigModel(configuredModel modelstore.ConfiguredModelReco
 		ConfiguredModelID: configuredModel.ID.String(),
 		SupportsTools:     &supportsTools,
 	}
-}
-
-func ensureHTTPModelSelection(
-	t *testing.T,
-	ctx context.Context,
-	store *storage.Store,
-	orgID, projectID, userID storage.ID,
-	providerConfigName, configuredModelName string,
-) modelstore.ConfiguredModelRecord {
-	t.Helper()
-	providerConfig, err := store.Models().GetModelProviderConfigByName(ctx, orgID, providerConfigName)
-	if err != nil {
-		if !storeerr.IsNotFound(err) {
-			t.Fatalf("load model provider config %q: %v", providerConfigName, err)
-		}
-		secret, err := ensureHTTPProviderCredential(t, ctx, store, orgID, userID, providerConfigName)
-		if err != nil {
-			t.Fatalf("ensure provider credential: %v", err)
-		}
-		providerConfig, err = store.Models().CreateModelProviderConfig(ctx, modelstore.CreateModelProviderConfigInput{
-			OrgID:              orgID,
-			Name:               providerConfigName,
-			APIFormat:          modelprotocol.APIFormatOpenAIResponses,
-			APIVariant:         "default",
-			BaseURL:            "https://api.openai.com/v1",
-			CredentialSecretID: secret.ID,
-		})
-		if err != nil {
-			t.Fatalf("create model provider config %q: %v", providerConfigName, err)
-		}
-	}
-	configuredModel, err := store.Models().CreateConfiguredModel(ctx, modelstore.CreateConfiguredModelInput{
-		OrgID:                 orgID,
-		ModelProviderConfigID: providerConfig.ID,
-		Name:                  configuredModelName,
-		ProviderModelSlug:     configuredModelName,
-		ContextWindowTokens:   128000,
-		MaxOutputTokens:       new(8192),
-	})
-	if err != nil {
-		t.Fatalf("create configured model %s/%s: %v", providerConfigName, configuredModelName, err)
-	}
-	if _, err := store.Models().CreateProjectModelGrant(ctx, modelstore.CreateProjectModelGrantInput{
-		OrgID:             orgID,
-		ProjectID:         projectID,
-		ConfiguredModelID: configuredModel.ID,
-	}); err != nil {
-		t.Fatalf("grant configured model %s/%s: %v", providerConfigName, configuredModelName, err)
-	}
-	return configuredModel
-}
-
-func ensureHTTPProviderCredential(
-	t *testing.T,
-	ctx context.Context,
-	store *storage.Store,
-	orgID, userID storage.ID,
-	providerConfigName string,
-) (secretstore.SecretRecord, error) {
-	t.Helper()
-	name := "http-provider-" + providerConfigName
-	secret, err := store.Secrets().GetSecretByOwnerName(
-		ctx, orgID, secretstore.SecretOwnerOrg, storage.NilID, storage.NilID, name,
-	)
-	if err == nil {
-		return secret, nil
-	}
-	if !storeerr.IsNotFound(err) {
-		return secretstore.SecretRecord{}, err
-	}
-	secret, _, err = store.Secrets().CreateSecret(ctx, secretstore.CreateSecretInput{
-		OrgID:     orgID,
-		OwnerKind: secretstore.SecretOwnerOrg,
-		Name:      name,
-		Material:  secrets.GenericMaterial{Value: "test-key"},
-		Actor:     httpUserPrincipal(userID),
-	})
-	return secret, err
 }
 
 func parseConfiguredModelID(t *testing.T, compiled agentconfig.Result) storage.ID {

--- a/internal/modelprovider/resolver_test.go
+++ b/internal/modelprovider/resolver_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/omnara-ai/omnara/internal/agentconfig"
 	"github.com/omnara-ai/omnara/internal/metrics"
 	"github.com/omnara-ai/omnara/internal/model"
@@ -18,7 +19,6 @@ import (
 	"github.com/omnara-ai/omnara/internal/modelprotocol"
 	"github.com/omnara-ai/omnara/internal/ssrf"
 	"github.com/omnara-ai/omnara/internal/storage/modelstore"
-	"github.com/omnara-ai/omnara/internal/storage/storeerr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -259,151 +259,61 @@ func intPtr(value int) *int {
 	return &value
 }
 
-func TestUnknownCapacityUsesProjectAndAgentAllowancesForAnthropic(t *testing.T) {
-	for _, tc := range []struct {
-		name                                       string
-		capacity, projectAllowance, agentAllowance *int
-		want                                       int
-		invalid                                    bool
-	}{
-		{name: "project allowance", projectAllowance: new(32000), want: 32000},
-		{name: "agent allowance", agentAllowance: new(48000), want: 48000},
-		{name: "project capacity", capacity: new(64000), want: 64000},
-		{
-			name:             "agent overrides project default",
-			capacity:         new(64000),
-			projectAllowance: new(32000),
-			agentAllowance:   new(48000),
-			want:             48000,
-		},
-		{name: "project capacity exhausts context", capacity: new(100000), invalid: true},
-		{name: "project allowance exhausts context", projectAllowance: new(100000), invalid: true},
-		{name: "agent allowance exhausts context", agentAllowance: new(100000), invalid: true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			revision := modelstore.ConfiguredModelRevisionRecord{
-				ContextWindowTokens: 100000,
-				ProviderModelSlug:   "custom-model",
+func TestEffectiveRevisionReachesAnthropicWire(t *testing.T) {
+	for _, narrowed := range []bool{false, true} {
+		name := "unknown capacity with project allowance"
+		if narrowed {
+			name = "inherited capacity with project and agent narrowing"
+		}
+		t.Run(name, func(t *testing.T) {
+			revision := modelstore.ConfiguredModelRevisionRecord{ContextWindowTokens: 128000}
+			grant := modelstore.ProjectModelGrantRecord{DefaultMaxOutputTokens: new(32000)}
+			overrides := agentconfig.ModelOverrides{}
+			if narrowed {
+				revision.MaxOutputTokens = new(64000)
+				grant = modelstore.ProjectModelGrantRecord{ContextWindowTokens: new(48000)}
+				overrides.ContextWindowTokens = new(32000)
 			}
 			effective, err := modelstore.EffectiveConfiguredModelRevisionForProjectGrant(
-				modelprotocol.APIFormatAnthropicMessages,
-				revision,
-				modelstore.ProjectModelGrantRecord{
-					MaxOutputTokens:        tc.capacity,
-					DefaultMaxOutputTokens: tc.projectAllowance,
-				},
+				modelprotocol.APIFormatAnthropicMessages, revision, grant,
 			)
-			if err == nil {
-				effective, err = modelstore.EffectiveConfiguredModelRevisionForAgentOptions(
-					modelprotocol.APIFormatAnthropicMessages,
-					effective,
-					agentconfig.ModelOverrides{
-						DefaultMaxOutputTokens: tc.agentAllowance,
-					},
-				)
-			}
-			if tc.invalid {
-				if !errors.Is(err, storeerr.ErrInvalidModelProviderConfig) {
-					t.Fatalf("invalid allowance error=%v", err)
-				}
-				return
-			}
 			require.NoError(t, err)
-			if tc.capacity == nil && effective.MaxOutputTokens != nil {
-				t.Fatal("request allowance manufactured a capacity")
+			effective, err = modelstore.EffectiveConfiguredModelRevisionForAgentOptions(
+				modelprotocol.APIFormatAnthropicMessages, effective, overrides,
+			)
+			require.NoError(t, err)
+			caps := capabilitiesForRevision(effective)
+			client := anthropicmessages.Client{
+				EndpointPath: "/messages", ProviderModelSlug: "custom-model", ModelCapabilities: caps,
 			}
-			prepared := prepareAnthropicRequest(t, capabilitiesForRevision(effective))
-			if prepared.MaxOutputTokens != tc.want {
-				t.Fatalf("allowance=%d want=%d", prepared.MaxOutputTokens, tc.want)
+			prepared, err := model.PrepareForSend(t.Context(), client, model.PrepareForSendInput{
+				Context: modelcontext.Bundle{Messages: []modelcontext.Message{{
+					ID: "input", Sequence: 1, Role: modelprotocol.RoleUser,
+					Content: json.RawMessage(`[{"type":"text","text":"hello"}]`),
+				}}},
+				Policy: model.RequestPolicyFromCapabilities(caps), ErrorSource: "test",
+			})
+			require.NoError(t, err)
+			var wire struct {
+				MaxTokens int `json:"max_tokens"`
+			}
+			require.NoError(t, json.Unmarshal(prepared.Body, &wire))
+			want := 32000
+			if narrowed {
+				if caps.ContextWindowTokens != 32000 {
+					t.Fatalf("context = %d, want 32000", caps.ContextWindowTokens)
+				}
+				if diff := cmp.Diff(new(64000), caps.MaxOutputTokens); diff != "" {
+					t.Fatalf("inherited capacity (-want +got):\n%s", diff)
+				}
+				want = 32000 - modelcontext.DefaultSafetyMarginTokens(32000) - prepared.InputTokenEstimate
+			} else if caps.MaxOutputTokens != nil {
+				t.Fatalf("capacity = %d, want unknown", *caps.MaxOutputTokens)
+			}
+			if !prepared.InputBudget.Fits() || prepared.MaxOutputTokens != want || wire.MaxTokens != want {
+				t.Fatalf("budget=%+v recorded=%d wire=%d, want fitting allowance %d",
+					prepared.InputBudget, prepared.MaxOutputTokens, wire.MaxTokens, want)
 			}
 		})
 	}
-}
-
-func TestCapacityIncreasePreservesNarrowedContextOverrides(t *testing.T) {
-	for _, level := range []string{"project", "agent", "both"} {
-		for _, allowance := range []struct {
-			name    string
-			value   *int
-			invalid bool
-		}{
-			{name: "capacity only"},
-			{name: "fitting inherited default", value: new(4000)},
-			{name: "inherited default exhausts context", value: new(32000), invalid: true},
-		} {
-			t.Run(level+"/"+allowance.name, func(t *testing.T) {
-				for _, capacity := range []int{8192, 64000} {
-					if allowance.invalid && capacity == 8192 {
-						continue // The source default itself must fit the source capacity.
-					}
-					revision := modelstore.ConfiguredModelRevisionRecord{
-						ContextWindowTokens: 128000, MaxOutputTokens: new(capacity),
-						DefaultMaxOutputTokens: allowance.value,
-					}
-					grant := modelstore.ProjectModelGrantRecord{}
-					overrides := agentconfig.ModelOverrides{}
-					if level != "agent" {
-						grant.ContextWindowTokens = new(32000)
-					}
-					if level != "project" {
-						overrides.ContextWindowTokens = new(32000)
-					}
-					effective, err := modelstore.EffectiveConfiguredModelRevisionForProjectGrant(
-						modelprotocol.APIFormatAnthropicMessages, revision, grant,
-					)
-					if err == nil {
-						effective, err = modelstore.EffectiveConfiguredModelRevisionForAgentOptions(
-							modelprotocol.APIFormatAnthropicMessages, effective, overrides,
-						)
-					}
-					if allowance.invalid {
-						if !errors.Is(err, storeerr.ErrInvalidModelProviderConfig) {
-							t.Fatalf("inherited allowance error=%v", err)
-						}
-						continue
-					}
-					if err != nil {
-						t.Fatalf("capacity=%d: %v", capacity, err)
-					}
-					caps := capabilitiesForRevision(effective)
-					if caps.ContextWindowTokens != 32000 || caps.MaxOutputTokens == nil ||
-						*caps.MaxOutputTokens != capacity {
-						t.Fatalf("effective capabilities=%+v", caps)
-					}
-					prepared := prepareAnthropicRequest(t, caps)
-					remaining := 32000 - modelcontext.DefaultSafetyMarginTokens(32000) - prepared.InputTokenEstimate
-					want := min(capacity, remaining)
-					if allowance.value != nil {
-						want = min(want, *allowance.value)
-					}
-					if prepared.MaxOutputTokens != want {
-						t.Fatalf("capacity=%d allowance=%d want=%d", capacity, prepared.MaxOutputTokens, want)
-					}
-				}
-			})
-		}
-	}
-}
-
-func prepareAnthropicRequest(t *testing.T, caps model.Capabilities) model.PreparedRequest {
-	t.Helper()
-	client := anthropicmessages.Client{
-		EndpointPath: "/messages", ProviderModelSlug: "custom-model", ModelCapabilities: caps,
-	}
-	prepared, err := model.PrepareForSend(context.Background(), client, model.PrepareForSendInput{
-		Context: modelcontext.Bundle{Messages: []modelcontext.Message{{
-			ID: "input", Sequence: 1, Role: modelprotocol.RoleUser,
-			Content: json.RawMessage(`[{"type":"text","text":"hello"}]`),
-		}}},
-		Policy: model.RequestPolicyFromCapabilities(caps), ErrorSource: "test",
-	})
-	require.NoError(t, err)
-	var body struct {
-		MaxTokens int `json:"max_tokens"`
-	}
-	require.NoError(t, json.Unmarshal(prepared.Body, &body))
-	if body.MaxTokens != prepared.MaxOutputTokens {
-		t.Fatalf("wire allowance=%d, recorded=%d", body.MaxTokens, prepared.MaxOutputTokens)
-	}
-	return prepared
 }

--- a/internal/storage/modelstore/store_test.go
+++ b/internal/storage/modelstore/store_test.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/omnara-ai/omnara/internal/storage/management"
 	"math"
 	"slices"
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/omnara-ai/omnara/internal/agentconfig"
 	"github.com/omnara-ai/omnara/internal/modelprotocol"
+	"github.com/omnara-ai/omnara/internal/storage/management"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateModelProviderConfigTxRejectsInvalidNameBeforeDatabaseAccess(t *testing.T) {
@@ -656,5 +658,128 @@ func TestReconciliationOutputCapacityComparisonRemainsStrict(t *testing.T) {
 	record.MaxOutputTokens = nil
 	if sameConfiguredModelIntent(record, input) {
 		t.Fatal("reconciliation ignored desired known capacity")
+	}
+}
+
+func TestUnknownCapacityPreservesOverrideAllowances(t *testing.T) {
+	for _, tc := range []struct {
+		name                                       string
+		capacity, projectAllowance, agentAllowance *int
+		wantAllowance                              *int
+		invalid                                    bool
+	}{
+		{name: "project allowance", projectAllowance: new(32000), wantAllowance: new(32000)},
+		{name: "agent allowance", agentAllowance: new(48000), wantAllowance: new(48000)},
+		{name: "project capacity", capacity: new(64000)},
+		{
+			name:             "agent overrides project default",
+			capacity:         new(64000),
+			projectAllowance: new(32000),
+			agentAllowance:   new(48000),
+			wantAllowance:    new(48000),
+		},
+		{name: "project capacity exhausts context", capacity: new(100000), invalid: true},
+		{name: "project allowance exhausts context", projectAllowance: new(100000), invalid: true},
+		{name: "agent allowance exhausts context", agentAllowance: new(100000), invalid: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			revision := ConfiguredModelRevisionRecord{
+				ContextWindowTokens: 100000,
+				ProviderModelSlug:   "custom-model",
+			}
+			effective, err := EffectiveConfiguredModelRevisionForProjectGrant(
+				modelprotocol.APIFormatAnthropicMessages,
+				revision,
+				ProjectModelGrantRecord{
+					MaxOutputTokens:        tc.capacity,
+					DefaultMaxOutputTokens: tc.projectAllowance,
+				},
+			)
+			if err == nil {
+				effective, err = EffectiveConfiguredModelRevisionForAgentOptions(
+					modelprotocol.APIFormatAnthropicMessages,
+					effective,
+					agentconfig.ModelOverrides{
+						DefaultMaxOutputTokens: tc.agentAllowance,
+					},
+				)
+			}
+			if tc.invalid {
+				if !errors.Is(err, storeerr.ErrInvalidModelProviderConfig) {
+					t.Fatalf("invalid allowance error=%v", err)
+				}
+				return
+			}
+			require.NoError(t, err)
+			if diff := cmp.Diff(tc.capacity, effective.MaxOutputTokens); diff != "" {
+				t.Fatalf("capacity (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantAllowance, effective.DefaultMaxOutputTokens); diff != "" {
+				t.Fatalf("allowance (-want +got):\n%s", diff)
+			}
+			if effective.ContextWindowTokens != 100000 {
+				t.Fatalf("context = %d, want 100000", effective.ContextWindowTokens)
+			}
+		})
+	}
+}
+
+func TestCapacityIncreasePreservesNarrowedContextOverrides(t *testing.T) {
+	for _, level := range []string{"project", "agent", "both"} {
+		for _, allowance := range []struct {
+			name    string
+			value   *int
+			invalid bool
+		}{
+			{name: "capacity only"},
+			{name: "fitting inherited default", value: new(4000)},
+			{name: "inherited default exhausts context", value: new(32000), invalid: true},
+		} {
+			t.Run(level+"/"+allowance.name, func(t *testing.T) {
+				for _, capacity := range []int{8192, 64000} {
+					if allowance.invalid && capacity == 8192 {
+						continue // The source default itself must fit the source capacity.
+					}
+					revision := ConfiguredModelRevisionRecord{
+						ContextWindowTokens: 128000, MaxOutputTokens: new(capacity),
+						DefaultMaxOutputTokens: allowance.value,
+					}
+					grant := ProjectModelGrantRecord{}
+					overrides := agentconfig.ModelOverrides{}
+					if level != "agent" {
+						grant.ContextWindowTokens = new(32000)
+					}
+					if level != "project" {
+						overrides.ContextWindowTokens = new(32000)
+					}
+					effective, err := EffectiveConfiguredModelRevisionForProjectGrant(
+						modelprotocol.APIFormatAnthropicMessages, revision, grant,
+					)
+					if err == nil {
+						effective, err = EffectiveConfiguredModelRevisionForAgentOptions(
+							modelprotocol.APIFormatAnthropicMessages, effective, overrides,
+						)
+					}
+					if allowance.invalid {
+						if !errors.Is(err, storeerr.ErrInvalidModelProviderConfig) {
+							t.Fatalf("inherited allowance error=%v", err)
+						}
+						continue
+					}
+					if err != nil {
+						t.Fatalf("capacity=%d: %v", capacity, err)
+					}
+					if effective.ContextWindowTokens != 32000 {
+						t.Fatalf("capacity=%d: context = %d, want 32000", capacity, effective.ContextWindowTokens)
+					}
+					if diff := cmp.Diff(new(capacity), effective.MaxOutputTokens); diff != "" {
+						t.Fatalf("capacity (-want +got):\n%s", diff)
+					}
+					if diff := cmp.Diff(allowance.value, effective.DefaultMaxOutputTokens); diff != "" {
+						t.Fatalf("capacity=%d: allowance (-want +got):\n%s", capacity, diff)
+					}
+				}
+			})
+		}
 	}
 }

--- a/internal/testutil/storagefixture/model.go
+++ b/internal/testutil/storagefixture/model.go
@@ -12,6 +12,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// DefaultModelInput returns independent defaults that callers can override before seeding.
+func DefaultModelInput(orgID, providerID uuid.UUID, name string) modelstore.CreateConfiguredModelInput {
+	return modelstore.CreateConfiguredModelInput{
+		OrgID: orgID, ModelProviderConfigID: providerID, Name: name, ProviderModelSlug: name,
+		ContextWindowTokens: 128000, MaxOutputTokens: new(8192),
+	}
+}
+
+func SeedModel(
+	t testing.TB,
+	ctx context.Context,
+	models *modelstore.Store,
+	projectID uuid.UUID,
+	input modelstore.CreateConfiguredModelInput,
+) modelstore.ConfiguredModelRecord {
+	t.Helper()
+	configuredModel, err := models.CreateConfiguredModel(ctx, input)
+	require.NoError(t, err, "create test configured model %q", input.Name)
+	_, err = models.CreateProjectModelGrant(ctx, modelstore.CreateProjectModelGrantInput{
+		OrgID: input.OrgID, ProjectID: projectID, ConfiguredModelID: configuredModel.ID,
+	})
+	require.NoError(t, err, "grant test configured model %q", input.Name)
+	return configuredModel
+}
+
 func SeedModelForAgentYAML(
 	t testing.TB,
 	ctx context.Context,
@@ -31,23 +56,9 @@ func SeedModelForAgentYAML(
 	}
 	providerConfig, err := models.GetModelProviderConfigByName(ctx, orgID, providerConfigName)
 	require.NoError(t, err, "load test provider config %q", providerConfigName)
-	configuredModel, err := models.CreateConfiguredModel(ctx, modelstore.CreateConfiguredModelInput{
-		OrgID:                  orgID,
-		ModelProviderConfigID:  providerConfig.ID,
-		Name:                   configuredModelName,
-		ProviderModelSlug:      configuredModelName,
-		ContextWindowTokens:    128000,
-		MaxOutputTokens:        new(8192),
-		DefaultMaxOutputTokens: new(4096),
-	})
-	require.NoError(t, err, "create test configured model %s/%s", providerConfigName, configuredModelName)
-	_, err = models.CreateProjectModelGrant(ctx, modelstore.CreateProjectModelGrantInput{
-		OrgID:             orgID,
-		ProjectID:         projectID,
-		ConfiguredModelID: configuredModel.ID,
-	})
-	require.NoError(t, err, "grant test configured model %s/%s", providerConfigName, configuredModelName)
-	return configuredModel
+	input := DefaultModelInput(orgID, providerConfig.ID, configuredModelName)
+	input.DefaultMaxOutputTokens = new(4096)
+	return SeedModel(t, ctx, models, projectID, input)
 }
 
 func SeedModelAndCompileAgentYAML(

--- a/internal/testutil/storagefixture/provider.go
+++ b/internal/testutil/storagefixture/provider.go
@@ -1,0 +1,56 @@
+package storagefixture
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/omnara-ai/omnara/internal/modelprotocol"
+	"github.com/omnara-ai/omnara/internal/secrets"
+	"github.com/omnara-ai/omnara/internal/storage/identitystore"
+	"github.com/omnara-ai/omnara/internal/storage/modelstore"
+	"github.com/omnara-ai/omnara/internal/storage/secretstore"
+	"github.com/omnara-ai/omnara/internal/storage/storeerr"
+	"github.com/stretchr/testify/require"
+)
+
+type ModelProviderInput struct {
+	OrgID, UserID uuid.UUID
+	Name          string
+}
+
+// EnsureModelProvider reuses a provider or creates one with a usable test credential.
+// Call during fixture setup, with an existing org and a user authorized to create its secrets.
+func EnsureModelProvider(
+	t testing.TB,
+	ctx context.Context,
+	models *modelstore.Store,
+	credentials *secretstore.Store,
+	input ModelProviderInput,
+) modelstore.ModelProviderConfigRecord {
+	t.Helper()
+	provider, err := models.GetModelProviderConfigByName(ctx, input.OrgID, input.Name)
+	if !storeerr.IsNotFound(err) {
+		require.NoError(t, err, "load test provider %q", input.Name)
+		return provider
+	}
+	credentialName := input.Name + "-credential"
+	credential, err := credentials.GetSecretByOwnerName(
+		ctx, input.OrgID, secretstore.SecretOwnerOrg, uuid.Nil, uuid.Nil, credentialName,
+	)
+	if storeerr.IsNotFound(err) {
+		credential, _, err = credentials.CreateSecret(ctx, secretstore.CreateSecretInput{
+			OrgID: input.OrgID, OwnerKind: secretstore.SecretOwnerOrg, Name: credentialName,
+			Material: secrets.GenericMaterial{Value: "test-key"},
+			Actor:    identitystore.PrincipalRecord{Type: identitystore.PrincipalTypeUser, ID: input.UserID},
+		})
+	}
+	require.NoError(t, err, "ensure test provider credential %q", credentialName)
+	provider, err = models.CreateModelProviderConfig(ctx, modelstore.CreateModelProviderConfigInput{
+		OrgID: input.OrgID, Name: input.Name,
+		APIFormat: modelprotocol.APIFormatOpenAIResponses, APIVariant: modelprotocol.APIVariantDefault,
+		BaseURL: "https://api.openai.com/v1", CredentialSecretID: credential.ID,
+	})
+	require.NoError(t, err, "create test provider %q", input.Name)
+	return provider
+}


### PR DESCRIPTION
Repeated model setup across kernel, HTTP API, tools, and worker tests duplicated provider credentials, configured-model defaults, and project grants. Move that setup into the existing storagefixture package, keeping scenario-specific limits and managed-model behavior explicit at callers.

Move override validation matrices to modelstore and retain two focused configuration-to-Anthropic-wire cases. Share repeated kernel scheduler queries and remove two redundant E2E database assertions while retaining the tool-execution journey and persistence checks. This changes only tests and test support, removing 321 net lines.

Validation: full unit and static checks; model/provider unit tests and six affected integration packages under race detection; output-recovery service E2E; compilation with all test tags.

Stacked on #488; the diff is relative to that branch.
