### PR TITLE
docs: add changelog with first entry introducing Omnara

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,136 @@
+# Changelog
+
+Notable changes to Omnara, newest first. This changelog is also published at
+[docs.omnara.com/changelog](https://docs.omnara.com/changelog). For the
+complete list of merged pull requests in each build, see
+[GitHub Releases](https://github.com/omnara-ai/omnara/releases).
+
+## September 9, 2026 — Introducing Omnara: the open-source platform for production-grade agents
+
+On August 5 we relaunched Omnara as an open-source platform for running managed
+agents. Omnara handles execution and state; you choose the models, tools,
+machines, and how people reach each agent — through the dashboard, Slack, or
+your own product via the API. This first entry rounds up what has shipped since
+the relaunch.
+
+[![Introducing Omnara](https://img.youtube.com/vi/6i3ScDe7gcs/maxresdefault.jpg)](https://www.youtube.com/watch?v=6i3ScDe7gcs)
+
+### Durable agents, defined in YAML
+
+An agent is a single durable conversation. Its state is committed atomically to
+Postgres, so agents recover from crashes, restarts, and machine disconnects and
+continue where they left off. You define the instruction, model, tools,
+permissions, and machines in a small YAML or JSON
+[config](https://docs.omnara.com/agents/configuration). Configs are immutable,
+and [profiles](https://docs.omnara.com/agents/configuration#profiles) give a
+config a stable name with revision history — updating a profile changes future
+launches without disturbing agents already running. Launch from the dashboard
+(a Builder form with templates and a live YAML preview, or the YAML editor), the
+[CLI](https://docs.omnara.com/quickstart), or the API, and
+[switch an agent's config mid-conversation](https://docs.omnara.com/events/sending-input#change-the-config-mid-conversation)
+when its job changes.
+
+### Bring your own models
+
+Connect OpenAI, Anthropic, OpenRouter, or Amazon Bedrock, or point Omnara at any
+OpenAI- or Anthropic-compatible endpoint such as LiteLLM, vLLM, or Ollama.
+Omnara discovers the provider's model catalog, keeps
+[configured models](https://docs.omnara.com/organization/model-providers)
+central with revisions, and grants them to projects with optional tighter
+limits. New organizations start with `omnara-openrouter` and frontier models
+ready to use. Prompt caching is handled per provider route so long conversations
+stay fast and inexpensive, and per-call model costs are recorded.
+
+### Machines: bring your own, or sandboxes on demand
+
+Agents run commands on [machines](https://docs.omnara.com/machines/overview).
+Register a laptop, VM, or container by installing the `omnarad` daemon — it
+connects outbound, so there are no inbound ports or SSH keys — or let Omnara
+create sandboxes on demand from Blaxel, Unikraft Cloud, or Daytona
+[pools](https://docs.omnara.com/machines/pools). Omnara-managed pools work out
+of the box; connect your own provider account to use custom images. An agent can
+run with no machine, one, or several, and can create and release pool machines
+mid-conversation. Machines never own the agent: a dropped connection leaves the
+conversation intact, and idle pool machines are deleted automatically.
+
+### Tools, MCP servers, and skills
+
+- **[Built-in tools](https://docs.omnara.com/tools/built-in)** — web search
+  and fetch, shell commands with live process control, machine management,
+  artifact upload and download, questions for humans, and integration
+  messaging.
+- **[Custom tools](https://docs.omnara.com/tools/custom)** — describe an
+  operation your own system performs; Omnara waits for your result.
+- **[MCP servers](https://docs.omnara.com/tools/mcp)** — connect with bearer
+  tokens, OAuth (Omnara runs the whole authorization flow), or AWS SigV4.
+  Browse the MCP registry, search servers, and discover their tools from the
+  dashboard; config changes apply to running agents.
+- **[Skills](https://docs.omnara.com/tools/skills)** — versioned packages of
+  instructions and files that agents load on demand, shareable across projects
+  and editable in the dashboard.
+
+Every tool has a [permission mode](https://docs.omnara.com/tools/permissions) —
+run immediately, ask a person first, or deny — and MCP tools ask by default.
+
+### Humans in the loop
+
+When a tool requires approval or the agent asks a question, it pauses and a card
+appears in the conversation; answer in the dashboard, in Slack, or over the API
+and the agent resumes. While an agent is busy, queue a follow-up or
+[steer](https://docs.omnara.com/events/sending-input#queued-vs-steering) it
+with a correction that lands at the next model call, reorder or cancel waiting
+inputs, or stop the current turn. Attach images, PDFs, spreadsheets, and
+documents to messages; agents return files as
+[artifacts](https://docs.omnara.com/events/artifacts) and can pull them onto
+their machines. Tool calls
+[stream live](https://docs.omnara.com/events/streaming), and messages relayed
+from your own users are attributed to them through actors.
+
+### Agents in Slack
+
+Deploy an agent profile to [Slack](https://docs.omnara.com/integrations/slack)
+in a few clicks — Omnara creates and configures the Slack app for you. Each
+thread or DM gets its own agent with independent history, approvals and
+questions can be answered in Slack, and agents deliver messages and artifacts
+into the conversation.
+
+### Scheduled agents
+
+Cron triggers run on a schedule in your timezone: target a profile to launch a
+fresh agent on each firing, or target a running agent to send it a message with
+queued or steering delivery. Manage them from the dashboard, the CLI, or the
+API. The repository includes complete
+[examples](https://docs.omnara.com/examples/overview) — daily digests from X,
+Reddit, LinkedIn, and PostHog, delivered to Slack.
+
+### CLI, TypeScript SDK, and REST API
+
+`npx omnara` is a full CLI generated from the OpenAPI spec. Sign in through your
+browser with device-flow login (the first command that needs your account
+prompts you), then manage profiles, agents, secrets, models, pools, and grants;
+chat with agents and stream their events from the terminal; authorize MCP OAuth
+servers and set up Slack interactively; and install the daemon on a machine.
+`@omnara/sdk` is the TypeScript SDK, with browser, TanStack Query, and Zod entry
+points. Everything is available over the
+[REST API](https://docs.omnara.com/api/overview) at `/api/v1`, defined in
+OpenAPI with an interactive reference.
+
+### Organizations, projects, and access control
+
+Organizations own shared resources — model providers, machines and pools,
+[secrets](https://docs.omnara.com/organization/secrets), and skills — and
+contain projects. A project uses a resource only through an explicit grant, so
+sharing is deliberate and scoped. Roles on users and API keys separate who
+manages access, configures agents, operates them, or only views them. Secrets
+are versioned and scoped to the org, a project, or a user, so rotating a
+credential never touches a config. Invitations, configurable resource limits,
+and branded transactional emails round out team setup.
+
+### Cloud or self-hosted
+
+Use Omnara Cloud at [app.omnara.com](https://app.omnara.com), or
+[self-host](https://docs.omnara.com/self-hosting/deployment) under Apache 2.0
+with Docker Compose from signed, published images. Self-hosted deployments can
+query agent history directly in Postgres for analytics, evals, and training
+datasets. The dashboard works on mobile, and the source is at
+[github.com/omnara-ai/omnara](https://github.com/omnara-ai/omnara).

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -1,0 +1,77 @@
+---
+title: Changelog
+description: New features, improvements, and fixes in Omnara
+icon: "list"
+mode: "center"
+---
+
+<Update
+  label="September 9, 2026"
+  description="Introducing Omnara"
+  rss={{
+    title: "Introducing Omnara: the open-source platform for production-grade agents",
+    description: "Durable agents from a YAML config, bring-your-own models and machines, tools and MCP, human-in-the-loop controls, Slack, scheduling, CLI and SDK, and self-hosting."
+  }}
+>
+
+## Introducing Omnara: the open-source platform for production-grade agents
+
+On August 5 we relaunched Omnara as an open-source platform for running managed agents. Omnara handles execution and state; you choose the models, tools, machines, and how people reach each agent — through the dashboard, Slack, or your own product via the API. This first entry rounds up what has shipped since the relaunch.
+
+<Frame>
+  <iframe
+    className="w-full aspect-video rounded-xl"
+    src="https://www.youtube.com/embed/6i3ScDe7gcs"
+    title="Introducing Omnara"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+  ></iframe>
+</Frame>
+
+### Durable agents, defined in YAML
+
+An agent is a single durable conversation. Its state is committed atomically to Postgres, so agents recover from crashes, restarts, and machine disconnects and continue where they left off. You define the instruction, model, tools, permissions, and machines in a small YAML or JSON [config](/agents/configuration). Configs are immutable, and [profiles](/agents/configuration#profiles) give a config a stable name with revision history — updating a profile changes future launches without disturbing agents already running. Launch from the dashboard (a Builder form with templates and a live YAML preview, or the YAML editor), the [CLI](/quickstart), or the API, and [switch an agent's config mid-conversation](/events/sending-input#change-the-config-mid-conversation) when its job changes.
+
+### Bring your own models
+
+Connect OpenAI, Anthropic, OpenRouter, or Amazon Bedrock, or point Omnara at any OpenAI- or Anthropic-compatible endpoint such as LiteLLM, vLLM, or Ollama. Omnara discovers the provider's model catalog, keeps [configured models](/organization/model-providers) central with revisions, and grants them to projects with optional tighter limits. New organizations start with `omnara-openrouter` and frontier models ready to use. Prompt caching is handled per provider route so long conversations stay fast and inexpensive, and per-call model costs are recorded.
+
+### Machines: bring your own, or sandboxes on demand
+
+Agents run commands on [machines](/machines/overview). Register a laptop, VM, or container by installing the `omnarad` daemon — it connects outbound, so there are no inbound ports or SSH keys — or let Omnara create sandboxes on demand from Blaxel, Unikraft Cloud, or Daytona [pools](/machines/pools). Omnara-managed pools work out of the box; connect your own provider account to use custom images. An agent can run with no machine, one, or several, and can create and release pool machines mid-conversation. Machines never own the agent: a dropped connection leaves the conversation intact, and idle pool machines are deleted automatically.
+
+### Tools, MCP servers, and skills
+
+- **[Built-in tools](/tools/built-in)** — web search and fetch, shell commands with live process control, machine management, artifact upload and download, questions for humans, and integration messaging.
+- **[Custom tools](/tools/custom)** — describe an operation your own system performs; Omnara waits for your result.
+- **[MCP servers](/tools/mcp)** — connect with bearer tokens, OAuth (Omnara runs the whole authorization flow), or AWS SigV4. Browse the MCP registry, search servers, and discover their tools from the dashboard; config changes apply to running agents.
+- **[Skills](/tools/skills)** — versioned packages of instructions and files that agents load on demand, shareable across projects and editable in the dashboard.
+
+Every tool has a [permission mode](/tools/permissions) — run immediately, ask a person first, or deny — and MCP tools ask by default.
+
+### Humans in the loop
+
+When a tool requires approval or the agent asks a question, it pauses and a card appears in the conversation; answer in the dashboard, in Slack, or over the API and the agent resumes. While an agent is busy, queue a follow-up or [steer](/events/sending-input#queued-vs-steering) it with a correction that lands at the next model call, reorder or cancel waiting inputs, or stop the current turn. Attach images, PDFs, spreadsheets, and documents to messages; agents return files as [artifacts](/events/artifacts) and can pull them onto their machines. Tool calls [stream live](/events/streaming), and messages relayed from your own users are attributed to them through actors.
+
+### Agents in Slack
+
+Deploy an agent profile to [Slack](/integrations/slack) in a few clicks — Omnara creates and configures the Slack app for you. Each thread or DM gets its own agent with independent history, approvals and questions can be answered in Slack, and agents deliver messages and artifacts into the conversation.
+
+### Scheduled agents
+
+Cron triggers run on a schedule in your timezone: target a profile to launch a fresh agent on each firing, or target a running agent to send it a message with queued or steering delivery. Manage them from the dashboard, the CLI, or the API. The repository includes complete [examples](/examples/overview) — daily digests from X, Reddit, LinkedIn, and PostHog, delivered to Slack.
+
+### CLI, TypeScript SDK, and REST API
+
+`npx omnara` is a full CLI generated from the OpenAPI spec. Sign in through your browser with device-flow login (the first command that needs your account prompts you), then manage profiles, agents, secrets, models, pools, and grants; chat with agents and stream their events from the terminal; authorize MCP OAuth servers and set up Slack interactively; and install the daemon on a machine. `@omnara/sdk` is the TypeScript SDK, with browser, TanStack Query, and Zod entry points. Everything is available over the [REST API](/api/overview) at `/api/v1`, defined in OpenAPI with an interactive reference.
+
+### Organizations, projects, and access control
+
+Organizations own shared resources — model providers, machines and pools, [secrets](/organization/secrets), and skills — and contain projects. A project uses a resource only through an explicit grant, so sharing is deliberate and scoped. Roles on users and API keys separate who manages access, configures agents, operates them, or only views them. Secrets are versioned and scoped to the org, a project, or a user, so rotating a credential never touches a config. Invitations, configurable resource limits, and branded transactional emails round out team setup.
+
+### Cloud or self-hosted
+
+Use Omnara Cloud at [app.omnara.com](https://app.omnara.com), or [self-host](/self-hosting/deployment) under Apache 2.0 with Docker Compose from signed, published images. Self-hosted deployments can query agent history directly in Postgres for analytics, evals, and training datasets. The dashboard works on mobile, and the source is at [github.com/omnara-ai/omnara](https://github.com/omnara-ai/omnara).
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -153,6 +153,13 @@
             }
           }
         ]
+      },
+      {
+        "tab": "Changelog",
+        "icon": "list",
+        "pages": [
+          "changelog"
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary

Adds a curated, user-facing changelog to complement the auto-generated GitHub release notes from #489, and publishes the first entry: a roundup of what has shipped since the August 5 relaunch (#293).

## What's in the PR

- **`docs/changelog.mdx`** — new docs page built on Mintlify's `<Update>` component (timeline layout, per-entry anchor links, auto-generated RSS feed). The first entry embeds the launch video and covers, grouped by capability: durable agents and configs/profiles, bring-your-own models, machines (BYO and pools), tools/MCP/skills, human-in-the-loop controls, Slack, cron triggers, CLI/SDK/API, org access control, and cloud vs. self-hosting.
- **`docs/docs.json`** — adds a top-level **Changelog** tab to the docs nav.
- **`CHANGELOG.md`** — the same entry in plain Markdown for readers on GitHub (video as a linked thumbnail, since GitHub doesn't render iframes).

## Format for future entries

Each entry is one `<Update label="<date>" description="<short title>">` block in `docs/changelog.mdx` with a `##` title, a short intro, optional media, and `###` sections per capability — and a matching `## <date> — <title>` section at the top of `CHANGELOG.md`. Entries are curated milestones; the exhaustive PR list lives in GitHub Releases.

## Verification

- `mint broken-links` passes for the new page (the one reported link is pre-existing in `events/sending-input.mdx`).
- Rendered locally with `mint dev`: the timeline label, YouTube embed, headings, and internal links all render correctly.

The page goes live on docs.omnara.com with the next cluster release, which advances `docs-production`.

Made with [Cursor](https://cursor.com)