### PR TITLE
fix(model): explicitly disable strict function tool generation

### DIFF
--- a/internal/model/function_tools_wire_test.go
+++ b/internal/model/function_tools_wire_test.go
@@ -1,0 +1,69 @@
+package model_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/omnara-ai/omnara/internal/model"
+	"github.com/omnara-ai/omnara/internal/model/openaichatcompletions"
+	"github.com/omnara-ai/omnara/internal/model/openairesponses"
+	"github.com/omnara-ai/omnara/internal/modelcontext"
+	"github.com/omnara-ai/omnara/internal/modelprotocol"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFunctionToolsPreserveNonStrictSchemas(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"query":{"type":"string"},
+			"limit":{"type":"integer"},
+			"labels":{"type":"object","additionalProperties":{"type":"string"}}
+		},
+		"required":["query"]
+	}`)
+	for _, client := range []model.Client{
+		openaichatcompletions.Client{EndpointPath: "/chat/completions", ProviderModelSlug: "test-model"},
+		openaichatcompletions.Client{
+			EndpointPath: "/chat/completions", ProviderModelSlug: "test-model", APIVariant: modelprotocol.APIVariantOpenRouter,
+		},
+		openaichatcompletions.Client{
+			EndpointPath: "/chat/completions", ProviderModelSlug: "test-model", APIVariant: modelprotocol.APIVariantBedrock,
+		},
+		openairesponses.Client{EndpointPath: "/responses", ProviderModelSlug: "test-model"},
+		openairesponses.Client{
+			EndpointPath: "/responses", ProviderModelSlug: "test-model", APIVariant: modelprotocol.APIVariantBedrock,
+		},
+	} {
+		t.Run(string(client.APIFormat())+"/"+string(client.ModelAPIVariant()), func(t *testing.T) {
+			prepared, err := client.Prepare(t.Context(), model.PrepareInput{
+				Context: modelcontext.Bundle{
+					ToolSpecs: []modelcontext.ToolSpec{
+						{Name: "search", InputSchema: schema},
+						{Name: "ping"},
+					},
+				},
+			})
+			require.NoError(t, err)
+			var payload struct {
+				Tools []map[string]json.RawMessage `json:"tools"`
+			}
+			require.NoError(t, json.Unmarshal(prepared.Body, &payload))
+			require.Len(t, payload.Tools, 2)
+			for i, tool := range payload.Tools {
+				require.Equal(t, `"function"`, string(tool["type"]))
+				if client.APIFormat() == modelprotocol.APIFormatOpenAIChatCompletions {
+					var function map[string]json.RawMessage
+					require.NoError(t, json.Unmarshal(tool["function"], &function))
+					tool = function
+				}
+				require.Equal(t, `false`, string(tool["strict"]))
+				wantSchema := schema
+				if i == 1 {
+					wantSchema = json.RawMessage(`{"type":"object","properties":{}}`)
+				}
+				require.JSONEq(t, string(wantSchema), string(tool["parameters"]))
+			}
+		})
+	}
+}

--- a/internal/model/function_tools_wire_test.go
+++ b/internal/model/function_tools_wire_test.go
@@ -22,19 +22,32 @@ func TestFunctionToolsPreserveNonStrictSchemas(t *testing.T) {
 		},
 		"required":["query"]
 	}`)
-	for _, client := range []model.Client{
-		openaichatcompletions.Client{EndpointPath: "/chat/completions", ProviderModelSlug: "test-model"},
-		openaichatcompletions.Client{
-			EndpointPath: "/chat/completions", ProviderModelSlug: "test-model", APIVariant: modelprotocol.APIVariantOpenRouter,
+	for _, tc := range []struct {
+		client          model.Client
+		wantStrictField bool
+	}{
+		{client: openaichatcompletions.Client{EndpointPath: "/chat/completions", ProviderModelSlug: "test-model"}},
+		{
+			client: openaichatcompletions.Client{
+				EndpointPath: "/chat/completions", ProviderModelSlug: "test-model", APIVariant: modelprotocol.APIVariantOpenRouter,
+			},
+			wantStrictField: true,
 		},
-		openaichatcompletions.Client{
+		{client: openaichatcompletions.Client{
 			EndpointPath: "/chat/completions", ProviderModelSlug: "test-model", APIVariant: modelprotocol.APIVariantBedrock,
+		}},
+		{
+			client:          openairesponses.Client{EndpointPath: "/responses", ProviderModelSlug: "test-model"},
+			wantStrictField: true,
 		},
-		openairesponses.Client{EndpointPath: "/responses", ProviderModelSlug: "test-model"},
-		openairesponses.Client{
-			EndpointPath: "/responses", ProviderModelSlug: "test-model", APIVariant: modelprotocol.APIVariantBedrock,
+		{
+			client: openairesponses.Client{
+				EndpointPath: "/responses", ProviderModelSlug: "test-model", APIVariant: modelprotocol.APIVariantBedrock,
+			},
+			wantStrictField: true,
 		},
 	} {
+		client := tc.client
 		t.Run(string(client.APIFormat())+"/"+string(client.ModelAPIVariant()), func(t *testing.T) {
 			prepared, err := client.Prepare(t.Context(), model.PrepareInput{
 				Context: modelcontext.Bundle{
@@ -57,7 +70,11 @@ func TestFunctionToolsPreserveNonStrictSchemas(t *testing.T) {
 					require.NoError(t, json.Unmarshal(tool["function"], &function))
 					tool = function
 				}
-				require.Equal(t, `false`, string(tool["strict"]))
+				if tc.wantStrictField {
+					require.Equal(t, `false`, string(tool["strict"]))
+				} else {
+					require.NotContains(t, tool, "strict")
+				}
 				wantSchema := schema
 				if i == 1 {
 					wantSchema = json.RawMessage(`{"type":"object","properties":{}}`)

--- a/internal/model/openaichatcompletions/compat.go
+++ b/internal/model/openaichatcompletions/compat.go
@@ -23,6 +23,7 @@ const (
 
 type compat struct {
 	sendsStoreFalse              bool
+	sendsStrictFalse             bool
 	reasoningFormat              reasoningFormat
 	conversationKeyField         conversationKeyField
 	usageViaStreamOptions        bool
@@ -38,6 +39,7 @@ func compatFor(route model.ProviderRoute) compat {
 	switch route.APIVariant {
 	case modelprotocol.APIVariantOpenRouter:
 		return compat{
+			sendsStrictFalse:             true,
 			reasoningFormat:              reasoningFormatOpenRouter,
 			conversationKeyField:         conversationKeyFieldSessionID,
 			refinesErrorsFromRawDetails:  true,

--- a/internal/model/openaichatcompletions/compat_test.go
+++ b/internal/model/openaichatcompletions/compat_test.go
@@ -19,7 +19,8 @@ func TestCompatForVariant(t *testing.T) {
 			usageChunkCompletesStream: true,
 		},
 		modelprotocol.APIVariantOpenRouter: {
-			reasoningFormat: reasoningFormatOpenRouter, conversationKeyField: conversationKeyFieldSessionID,
+			sendsStrictFalse: true,
+			reasoningFormat:  reasoningFormatOpenRouter, conversationKeyField: conversationKeyFieldSessionID,
 			refinesErrorsFromRawDetails:  true,
 			reportsNativeFinishReason:    true,
 			reportsServedProviderAndCost: true, parsesPDFDocuments: true, routesFallbackModels: true,

--- a/internal/model/openaichatcompletions/request.go
+++ b/internal/model/openaichatcompletions/request.go
@@ -40,13 +40,13 @@ func (p protocol) BuildRequest(ctx context.Context, input model.PrepareInput) (j
 	if err != nil {
 		return nil, err
 	}
+	compat := c.compat()
 	payload := chatCompletionsRequest{
 		Model:    providerModelSlug,
 		Messages: messages,
-		Tools:    buildTools(input.Context.ToolSpecs),
+		Tools:    buildTools(input.Context.ToolSpecs, compat),
 		N:        1,
 	}
-	compat := c.compat()
 	if compat.sendsStoreFalse {
 		store := false
 		payload.Store = &store
@@ -164,7 +164,7 @@ type chatFunctionDefinition struct {
 	Name        string          `json:"name"`
 	Description string          `json:"description,omitempty"`
 	Parameters  json.RawMessage `json:"parameters"`
-	Strict      bool            `json:"strict"`
+	Strict      *bool           `json:"strict,omitempty"`
 }
 
 type chatToolCall struct {
@@ -274,7 +274,11 @@ func messageFromContext(
 	}
 }
 
-func buildTools(specs []modelcontext.ToolSpec) []chatToolDefinition {
+func buildTools(specs []modelcontext.ToolSpec, compat compat) []chatToolDefinition {
+	var strict *bool
+	if compat.sendsStrictFalse {
+		strict = new(false)
+	}
 	tools := make([]chatToolDefinition, 0, len(specs))
 	for _, spec := range specs {
 		parameters := spec.InputSchema
@@ -287,7 +291,7 @@ func buildTools(specs []modelcontext.ToolSpec) []chatToolDefinition {
 				Name:        spec.Name,
 				Description: spec.Description,
 				Parameters:  parameters,
-				Strict:      false,
+				Strict:      strict,
 			},
 		})
 	}

--- a/internal/model/openaichatcompletions/request.go
+++ b/internal/model/openaichatcompletions/request.go
@@ -156,8 +156,15 @@ func (m chatMessage) MarshalJSON() ([]byte, error) {
 }
 
 type chatToolDefinition struct {
-	Type     string       `json:"type"`
-	Function chatFunction `json:"function"`
+	Type     string                 `json:"type"`
+	Function chatFunctionDefinition `json:"function"`
+}
+
+type chatFunctionDefinition struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters"`
+	Strict      bool            `json:"strict"`
 }
 
 type chatToolCall struct {
@@ -167,10 +174,8 @@ type chatToolCall struct {
 }
 
 type chatFunction struct {
-	Name        string                   `json:"name,omitempty"`
-	Description string                   `json:"description,omitempty"`
-	Parameters  json.RawMessage          `json:"parameters,omitempty"`
-	Arguments   model.ToolArgumentString `json:"arguments,omitempty"`
+	Name      string                   `json:"name,omitempty"`
+	Arguments model.ToolArgumentString `json:"arguments,omitempty"`
 }
 
 func buildMessages(
@@ -278,10 +283,11 @@ func buildTools(specs []modelcontext.ToolSpec) []chatToolDefinition {
 		}
 		tools = append(tools, chatToolDefinition{
 			Type: "function",
-			Function: chatFunction{
+			Function: chatFunctionDefinition{
 				Name:        spec.Name,
 				Description: spec.Description,
 				Parameters:  parameters,
+				Strict:      false,
 			},
 		})
 	}

--- a/internal/model/openaichatcompletions/request_test.go
+++ b/internal/model/openaichatcompletions/request_test.go
@@ -930,6 +930,9 @@ func TestPrepareSuppressesRejectedReplayAndRebuildsCanonicalToolExchange(t *test
 		t.Fatalf("prepare with replay suppressed: %v", err)
 	}
 	body := string(prepared.Body)
+	if strings.Contains(body, `"strict"`) {
+		t.Fatalf("tool declaration field leaked into rebuilt history: %s", body)
+	}
 	if strings.Contains(body, "private reasoning") ||
 		strings.Contains(body, "reasoning_content") {
 		t.Fatalf("suppressed replay leaked provider-only reasoning: %s", body)

--- a/internal/model/openaichatcompletions/response_test.go
+++ b/internal/model/openaichatcompletions/response_test.go
@@ -150,7 +150,7 @@ func TestParseResponseStoresRequestValidAssistantReplay(t *testing.T) {
 		`"annotations":[{"type":"url_citation"}],"provider_debug":"drop-me",` +
 		`"tool_calls":[{"id":"call_1","type":"function",` +
 		`"function":{"name":"parameterless_tool","arguments":"{}",` +
-		`"description":"drop-me","parameters":{}}}]},` +
+		`"description":"drop-me","parameters":{},"strict":false}}]},` +
 		`"finish_reason":"tool_calls"}]}`)
 	resp, err := (protocol{}).ParseResponse(context.Background(), route.Response{
 		StatusCode: http.StatusOK,

--- a/internal/model/openairesponses/request.go
+++ b/internal/model/openairesponses/request.go
@@ -130,6 +130,7 @@ type responsesTool struct {
 	Name        string          `json:"name"`
 	Description string          `json:"description,omitempty"`
 	Parameters  json.RawMessage `json:"parameters"`
+	Strict      bool            `json:"strict"`
 }
 
 func buildTools(specs []modelcontext.ToolSpec) []responsesTool {
@@ -141,7 +142,9 @@ func buildTools(specs []modelcontext.ToolSpec) []responsesTool {
 		}
 		tools = append(
 			tools,
-			responsesTool{Type: "function", Name: spec.Name, Description: spec.Description, Parameters: parameters},
+			responsesTool{
+				Type: "function", Name: spec.Name, Description: spec.Description, Parameters: parameters, Strict: false,
+			},
 		)
 	}
 	return tools


### PR DESCRIPTION
Preserve optional properties and general JSON Schemas in function-tool declarations by explicitly sending `strict: false` for Responses requests and OpenRouter Chat Completions. Responses can otherwise normalize schemas into strict mode. Other Chat Completions variants retain their existing omission behavior.

Use the existing Chat compatibility policy to select field emission. Separate function definitions from function calls so declaration-only fields stay out of conversation replay.

Validation:

- Shared request tests cover explicit false versus omission across all five supported format/variant combinations, schema preservation, and parameterless tools. Existing history and replay tests cover declaration-field isolation.
- Model and model-context unit tests, race tests, vet, formatting, and targeted repository lint.
- The existing live OpenRouter tool-call smoke test confirms request acceptance and a returned tool call.
