### PR TITLE
feat: update secret values from the dashboard

### DIFF
--- a/docs/organization/secrets.mdx
+++ b/docs/organization/secrets.mdx
@@ -52,7 +52,7 @@ On both surfaces, reads return the secret's metadata, never its value. If you lo
 
 ## Rotate a secret
 
-Rotation creates a new version while keeping the same secret ID. It is **API-only for now**; the dashboard and CLI show the current version but cannot rotate it.
+Rotation creates a new version while keeping the same secret ID. The CLI shows the current version but cannot rotate it.
 
 <SecretsRotate />
 
@@ -60,7 +60,7 @@ The response has `current_version_number: 2`. Existing references use the new cu
 
 ## Manage secrets
 
-Use the secrets pages or API to search for secrets. **Edit** can change a secret's name and metadata, but not its value; use rotation to change the value.
+Use the secrets pages or API to search for secrets. **Edit** can change a secret's name and value; the API also supports metadata updates.
 
 You cannot delete a secret while a model provider, machine pool, or integration uses it. Replace the secret on that resource — or delete the resource — first.
 

--- a/frontend/apps/web/src/components/org/EditSecretDialog.test.tsx
+++ b/frontend/apps/web/src/components/org/EditSecretDialog.test.tsx
@@ -1,0 +1,366 @@
+/** @vitest-environment happy-dom */
+
+import { OmnaraClientProvider } from '@omnara/react'
+import { createOmnaraClient, type OAuthTokenSetSecretMaterial, type Secret } from '@omnara/sdk'
+import { listProjectAvailableSecretsQueryKey, listSecretsQueryKey } from '@omnara/sdk/tanstack'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+import { EditSecretDialog } from '@/components/org/EditSecretDialog'
+import { fakeApi, jsonResponse } from '@/test/fake-api'
+import { fakeId } from '@/test/fixtures'
+import { enableReactActEnvironment } from '@/test/react-act'
+import { button, enter, field, submit, waitForUI } from '@/test/secret-editor'
+
+const secret: Secret = {
+  id: fakeId('sec'),
+  org_id: fakeId('org'),
+  management_kind: 'tenant',
+  owner: { kind: 'org' },
+  name: 'token',
+  kind: 'generic',
+  metadata: {},
+  current_version_number: 1,
+  payload_keys: ['value'],
+  created_at: '2026-08-03T00:00:00Z',
+  updated_at: '2026-08-03T00:00:00Z',
+}
+let root: Root
+let container: HTMLDivElement
+let restore: () => void
+beforeEach(() => {
+  restore = enableReactActEnvironment()
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+})
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  restore()
+})
+async function render(
+  overrides: Partial<Secret> = {},
+  failFirst = false,
+  gates?: { rename: Promise<void>; value: Promise<void> },
+) {
+  let failures = failFirst ? 1 : 0
+  const path = `/api/v1/orgs/${secret.org_id}/secrets/${secret.id}`
+  const api = fakeApi([
+    {
+      method: 'PATCH',
+      path,
+      respond: async () => {
+        if (gates) await gates.rename
+        return failures-- > 0
+          ? jsonResponse({ code: 'conflict', error: 'Try again' }, 409)
+          : jsonResponse({ ...secret, ...overrides, name: 'renamed', current_version_number: 2 })
+      },
+    },
+    {
+      method: 'POST',
+      path: path + '/versions',
+      respond: async () => {
+        if (gates) await gates.value
+        return failures-- > 0
+          ? jsonResponse({ code: 'conflict', error: 'Try again' }, 409)
+          : jsonResponse({ ...secret, ...overrides, current_version_number: 2 })
+      },
+    },
+  ])
+  const client = createOmnaraClient({ baseUrl: 'https://omnara.test/api/v1' })
+  client.setConfig({ fetch: api.fetch })
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const key = listSecretsQueryKey({ path: { orgID: secret.org_id } })
+  const projectKey = listProjectAvailableSecretsQueryKey({
+    path: { orgID: secret.org_id, projectID: fakeId('prj') },
+  })
+  const otherKey = listSecretsQueryKey({ path: { orgID: 'other' } })
+  for (const k of [key, projectKey, otherKey])
+    queryClient.setQueryData(k, { data: [], next_cursor: null })
+  const closed = vi.fn()
+  await act(async () => {
+    root.render(
+      <OmnaraClientProvider client={client}>
+        <QueryClientProvider client={queryClient}>
+          <EditSecretDialog
+            open
+            onOpenChange={closed}
+            orgId={secret.org_id}
+            secret={{ ...secret, ...overrides }}
+          />
+        </QueryClientProvider>
+      </OmnaraClientProvider>,
+    )
+    await Promise.resolve()
+  })
+  return { api, path, closed, queryClient, key, projectKey, otherKey }
+}
+it('shows a masked stored field immediately and focus does not enable save', async () => {
+  await render()
+  const value = field('Value')
+  expect(value.value).toBe('')
+  expect(value.placeholder).toBe('••••••••••••')
+  act(() => {
+    value.focus()
+  })
+  const save = [...document.querySelectorAll('button')].find(
+    (b) => b.textContent === 'Save changes',
+  )
+  expect(save?.disabled).toBe(true)
+})
+it('saves name and value through existing endpoints and invalidates both secret caches', async () => {
+  const ctx = await render()
+  await enter('Name', 'renamed')
+  await enter('Value', 'new-token')
+  await submit()
+  expect(ctx.api.requestsTo('PATCH', ctx.path).map((r) => r.body)).toEqual([{ name: 'renamed' }])
+  expect(ctx.api.requestsTo('POST', ctx.path + '/versions').map((r) => r.body)).toEqual([
+    { material: { kind: 'generic', value: 'new-token' } },
+  ])
+  expect(ctx.closed).toHaveBeenCalledWith(false)
+  expect(ctx.queryClient.getQueryState(ctx.key)?.isInvalidated).toBe(true)
+  expect(ctx.queryClient.getQueryState(ctx.projectKey)?.isInvalidated).toBe(true)
+  expect(ctx.queryClient.getQueryState(ctx.otherKey)?.isInvalidated).toBe(false)
+})
+it('Undo restores the untouched field and prevents value submission', async () => {
+  const ctx = await render()
+  await enter('Value', 'discard-me')
+  act(() => {
+    button('Undo value change').click()
+  })
+  expect(field('Value').placeholder).toBe('••••••••••••')
+  await enter('Name', 'renamed')
+  await submit()
+  expect(ctx.api.requestsTo('PATCH', ctx.path).map((r) => r.body)).toEqual([{ name: 'renamed' }])
+})
+it('keeps input on failure and retries the value request', async () => {
+  const ctx = await render({}, true)
+  await enter('Value', 'new-token')
+  await submit()
+  expect(ctx.closed).not.toHaveBeenCalled()
+  expect(field('Value').value).toBe('new-token')
+  await submit()
+  expect(ctx.api.requestsTo('POST', ctx.path + '/versions')).toHaveLength(2)
+  expect(ctx.closed).toHaveBeenCalledWith(false)
+})
+it('requires complete AWS credentials', async () => {
+  const ctx = await render({
+    kind: 'aws_credentials',
+    payload_keys: ['access_key_id', 'secret_access_key', 'session_token'],
+  })
+  await enter('Secret access key', 'new-key')
+  await submit()
+  expect(ctx.api.requestsTo('POST', ctx.path + '/versions')).toHaveLength(0)
+  await enter('Access key ID', ' new-id ')
+  await enter('Session token', 'new-session')
+  await submit()
+  expect(ctx.api.requestsTo('POST', ctx.path + '/versions').map((r) => r.body)).toEqual([
+    {
+      material: {
+        kind: 'aws_credentials',
+        access_key_id: 'new-id',
+        secret_access_key: 'new-key',
+        session_token: 'new-session',
+      },
+    },
+  ])
+})
+it('Clear explicitly removes a stored optional field on save', async () => {
+  const ctx = await render({
+    kind: 'aws_credentials',
+    payload_keys: ['access_key_id', 'secret_access_key', 'session_token'],
+  })
+  act(() => {
+    button('Clear session token').click()
+  })
+  expect(field('Session token').value).toBe('')
+  await submit()
+  expect(ctx.api.requestsTo('POST', ctx.path + '/versions')).toHaveLength(0)
+  await enter('Access key ID', ' new-id ')
+  await enter('Secret access key', 'new-key')
+  await submit()
+  expect(ctx.api.requestsTo('POST', ctx.path + '/versions').map((r) => r.body)).toEqual([
+    {
+      material: { kind: 'aws_credentials', access_key_id: 'new-id', secret_access_key: 'new-key' },
+    },
+  ])
+})
+it('Undo restores a cleared field to its unchanged stored state', async () => {
+  const ctx = await render({
+    kind: 'aws_credentials',
+    payload_keys: ['access_key_id', 'secret_access_key', 'session_token'],
+  })
+  act(() => {
+    button('Clear session token').click()
+  })
+  act(() => {
+    button('Undo session token change').click()
+  })
+  expect(field('Session token').placeholder).toBe('••••••••••••')
+  expect(button('Save changes').disabled).toBe(true)
+  await enter('Name', 'renamed')
+  await submit()
+  expect(ctx.api.requestsTo('POST', ctx.path + '/versions')).toHaveLength(0)
+})
+
+it.each([{ kind: 'slack_app_credentials' as const }, { management_kind: 'cluster' as const }])(
+  'hides unsupported value editing %j',
+  async (overrides) => {
+    await render(overrides)
+    expect([...document.querySelectorAll('label')].map((label) => label.textContent)).toEqual([
+      'Name',
+    ])
+  },
+)
+
+it('preserves multiline generic values through reveal and save', async () => {
+  const ctx = await render()
+  const value = 'line one\nline two\nline three'
+  await enter('Value', value)
+  act(() => {
+    button('Show value').click()
+  })
+  expect(field('Value').value).toBe(value)
+  await submit()
+  expect(ctx.api.requestsTo('POST', ctx.path + '/versions').map((r) => r.body)).toEqual([
+    { material: { kind: 'generic', value } },
+  ])
+})
+
+it('masks a new draft after clearing a revealed value', async () => {
+  await render()
+  await enter('Value', 'first')
+  act(() => {
+    button('Show value').click()
+  })
+  await enter('Value', '')
+  await enter('Value', 'second')
+  expect(field('Value').className).toContain('text-security:disc')
+  expect(document.querySelector('button[aria-label="Show value"]')).not.toBeNull()
+})
+
+it.each(['', '3600'])(
+  'submits complete OAuth refresh credentials with lifetime %j',
+  async (lifetime) => {
+    const ctx = await render({
+      kind: 'oauth_token_set',
+      payload_keys: [
+        'access_token',
+        'refresh_token',
+        'client_id',
+        'client_secret',
+        'resource',
+        'token_endpoint',
+        'scopes',
+      ],
+    })
+    for (const [label, value] of Object.entries({
+      'Access token': 'new-access',
+      'Refresh token': 'new-refresh',
+      'Client ID': 'client',
+      'Client secret': 'client-secret',
+      Resource: 'https://example.com/api',
+      'Token endpoint': 'https://example.com/token',
+      Scopes: 'read write',
+    }))
+      await enter(label, value)
+    await enter('Access token lifetime (seconds)', lifetime)
+    await submit()
+    const material: OAuthTokenSetSecretMaterial = {
+      kind: 'oauth_token_set',
+      access_token: 'new-access',
+      scopes: 'read write',
+      refresh: {
+        refresh_token: 'new-refresh',
+        client_id: 'client',
+        client_secret: 'client-secret',
+        resource: 'https://example.com/api',
+        token_endpoint: 'https://example.com/token',
+      },
+    }
+    if (lifetime !== '') material.access_token_expires_in_seconds = 3600
+    expect(
+      ctx.api.requestsTo('POST', ctx.path + '/versions').map((request) => request.body),
+    ).toEqual([{ material }])
+    expect(ctx.api.requestsTo('PATCH', ctx.path)).toHaveLength(0)
+  },
+)
+
+it('blocks resubmission and dismissal throughout both saves', async () => {
+  function gate() {
+    let release: () => void = () => {
+      throw new Error('Gate not initialized')
+    }
+    const promise = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    return { promise, release }
+  }
+  const rename = gate()
+  const value = gate()
+  const ctx = await render({}, false, { rename: rename.promise, value: value.promise })
+  await enter('Name', 'renamed')
+  await enter('Value', 'replacement')
+  const form = document.querySelector('form')
+  if (!form) throw new Error('Missing form')
+  const dispatchSubmit = () =>
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+  act(() => {
+    dispatchSubmit()
+  })
+  await waitForUI(() => {
+    expect(ctx.api.requestsTo('PATCH', ctx.path)).toHaveLength(1)
+  })
+  for (const stage of ['rename', 'value']) {
+    expect(form.querySelector('fieldset')?.disabled).toBe(true)
+    expect(button('Cancel').closest('fieldset')?.disabled).toBe(true)
+    act(() => {
+      dispatchSubmit()
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+    expect(ctx.closed).not.toHaveBeenCalled()
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull()
+    if (stage === 'rename') {
+      await act(async () => {
+        rename.release()
+        await rename.promise
+      })
+      await waitForUI(() => {
+        expect(ctx.api.requestsTo('POST', ctx.path + '/versions')).toHaveLength(1)
+      })
+    }
+  }
+  await act(async () => {
+    value.release()
+    await value.promise
+  })
+  await waitForUI(() => {
+    expect(ctx.closed).toHaveBeenCalledWith(false)
+  })
+  expect(ctx.api.requestsTo('PATCH', ctx.path)).toHaveLength(1)
+  expect(ctx.api.requestsTo('POST', ctx.path + '/versions')).toHaveLength(1)
+})
+
+it.each(['Backspace', 'Delete'])('leaves untouched credentials unchanged on %s', async (key) => {
+  const ctx = await render({
+    kind: 'aws_credentials',
+    payload_keys: ['access_key_id', 'secret_access_key', 'session_token'],
+  })
+  for (const label of ['Access key ID', 'Session token']) {
+    act(() => {
+      field(label).dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }))
+    })
+  }
+  expect(document.querySelector('[role="alert"]')).toBeNull()
+  expect(document.querySelector('button[aria-label^="Undo"]')).toBeNull()
+  expect(button('Save changes').disabled).toBe(true)
+  await enter('Name', 'renamed')
+  await submit()
+  expect(ctx.api.requestsTo('PATCH', ctx.path)).toHaveLength(1)
+  expect(ctx.api.requestsTo('POST', ctx.path + '/versions')).toHaveLength(0)
+})

--- a/frontend/apps/web/src/components/org/EditSecretDialog.test.tsx
+++ b/frontend/apps/web/src/components/org/EditSecretDialog.test.tsx
@@ -98,7 +98,7 @@ async function render(
     )
     await Promise.resolve()
   })
-  return { api, path, closed, queryClient, key, projectKey, otherKey }
+  return { api, client, path, closed, queryClient, key, projectKey, otherKey }
 }
 it('shows a masked stored field immediately and focus does not enable save', async () => {
   await render()
@@ -290,6 +290,60 @@ it.each(['', '3600'])(
     expect(ctx.api.requestsTo('PATCH', ctx.path)).toHaveLength(0)
   },
 )
+
+it('retains the last successful name after a later rename fails', async () => {
+  const ctx = await render()
+  let renames = 0
+  let replacements = 0
+  const api = fakeApi([
+    {
+      method: 'PATCH',
+      path: ctx.path,
+      respond: () =>
+        ++renames === 1
+          ? jsonResponse({ ...secret, name: 'saved-name' })
+          : jsonResponse({ code: 'conflict', error: 'Rename failed' }, 409),
+    },
+    {
+      method: 'POST',
+      path: ctx.path + '/versions',
+      respond: () =>
+        ++replacements === 1
+          ? jsonResponse({ code: 'conflict', error: 'Replacement failed' }, 409)
+          : jsonResponse({ ...secret, name: 'saved-name', current_version_number: 2 }),
+    },
+  ])
+  ctx.client.setConfig({ fetch: api.fetch })
+  await enter('Name', 'saved-name')
+  await enter('Value', 'replacement')
+  await submit()
+  expect(document.body.textContent).toContain('Name saved, but the value update failed.')
+  await enter('Name', 'rejected-name')
+  await submit()
+  expect(document.querySelector('[role="alert"]')?.textContent).toBe('Rename failed')
+  expect(replacements).toBe(1)
+  expect(field('Value').value).toBe('replacement')
+  await enter('Name', 'saved-name')
+  await submit()
+  expect(api.requestsTo('PATCH', ctx.path).map((request) => request.body)).toEqual([
+    { name: 'saved-name' },
+    { name: 'rejected-name' },
+  ])
+  expect(replacements).toBe(2)
+  expect(ctx.closed).toHaveBeenCalledWith(false)
+})
+
+it('resets token lifetime when its credential change is undone', async () => {
+  await render({ kind: 'oauth_token_set', payload_keys: ['access_token'] })
+  await enter('Access token', 'replacement')
+  await enter('Access token lifetime (seconds)', '3600')
+  act(() => {
+    button('Undo access token change').click()
+  })
+  expect(button('Save changes').disabled).toBe(true)
+  await enter('Access token', 'another-token')
+  expect(field('Access token lifetime (seconds)').value).toBe('')
+})
 
 it('blocks resubmission and dismissal throughout both saves', async () => {
   function gate() {

--- a/frontend/apps/web/src/components/org/EditSecretDialog.tsx
+++ b/frontend/apps/web/src/components/org/EditSecretDialog.tsx
@@ -1,4 +1,4 @@
-import { useUpdateSecret } from '@omnara/react'
+import { useCreateSecretVersion, useUpdateSecret } from '@omnara/react'
 import { ApiError, type Secret } from '@omnara/sdk'
 import { type SyntheticEvent, useState } from 'react'
 
@@ -6,14 +6,18 @@ import { Button } from '@/components/ui/button'
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { Field, FieldGroup, FieldLabel } from '@/components/ui/field'
+import { Field, FieldDescription, FieldGroup, FieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import { ResourceNameFieldError } from '@/components/ui/resource-name-error'
-import { resourceNameValid } from '@/lib/resource-name'
+import { normalizeResourceName, resourceNameValid } from '@/lib/resource-name'
+
+import { SecretValueEditor } from './SecretValueEditor'
+import { prepareSecretReplacement, requiredSecretKeys } from './secretValueUpdates'
 
 export function EditSecretDialog({
   open,
@@ -26,50 +30,135 @@ export function EditSecretDialog({
   orgId: string
   secret: Secret
 }) {
-  const mutation = useUpdateSecret(orgId)
+  const updateSecret = useUpdateSecret(orgId)
+  const createVersion = useCreateSecretVersion(orgId, secret.id)
+  const [savedName, setSavedName] = useState(secret.name)
   const [name, setName] = useState(secret.name)
+  const [updates, setUpdates] = useState<Record<string, string>>({})
+  const [lifetime, setLifetime] = useState('')
   const [error, setError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const canEditValue =
+    secret.management_kind === 'tenant' && requiredSecretKeys(secret.kind) !== undefined
+  const changingToken = secret.kind === 'oauth_token_set' && updates.access_token !== undefined
+  const replacement = prepareSecretReplacement(secret, updates, lifetime)
+  const nameChanged = normalizeResourceName(name) !== savedName
+  const hasUpdates = Object.keys(updates).length > 0
+  const valid = resourceNameValid(name) && !replacement.error && (nameChanged || hasUpdates)
 
   async function submit(event: SyntheticEvent<HTMLFormElement>) {
     event.preventDefault()
+    if (submitting || !valid) return
+    setSubmitting(true)
     setError('')
+    let renamed = false
     try {
-      await mutation.mutateAsync({ secretID: secret.id, name })
+      if (nameChanged) {
+        const updated = await updateSecret.mutateAsync({
+          secretID: secret.id,
+          name: normalizeResourceName(name),
+        })
+        setSavedName(updated.name)
+        renamed = true
+      }
+      if (replacement.material) await createVersion.mutateAsync({ material: replacement.material })
       onOpenChange(false)
-    } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Could not update secret')
+    } catch (error) {
+      const message = error instanceof ApiError ? error.message : 'Could not update secret'
+      setError(renamed ? `Name saved, but the value update failed. ${message}` : message)
+    } finally {
+      setSubmitting(false)
     }
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!submitting) onOpenChange(nextOpen)
+      }}
+    >
+      <DialogContent showCloseButton={!submitting}>
         <DialogHeader>
           <DialogTitle>Edit secret</DialogTitle>
+          <DialogDescription>
+            {!canEditValue
+              ? 'Only the name can be edited here.'
+              : secret.kind === 'generic'
+                ? 'Stored values stay hidden. Enter a new value to replace it.'
+                : 'Stored values stay hidden. To update credentials, enter the complete replacement set.'}
+          </DialogDescription>
         </DialogHeader>
-        <form onSubmit={(event) => void submit(event)}>
-          <FieldGroup>
-            <Field>
-              <FieldLabel>Name</FieldLabel>
-              <Input
-                value={name}
-                onChange={(event) => {
-                  setName(event.target.value)
-                }}
-              />
-              <ResourceNameFieldError value={name} />
-            </Field>
-            {error && <p className="text-destructive text-sm">{error}</p>}
-            <DialogFooter>
-              <Button
-                type="submit"
-                disabled={mutation.isPending || name === secret.name || !resourceNameValid(name)}
-                loading={mutation.isPending}
-              >
-                Save changes
-              </Button>
-            </DialogFooter>
-          </FieldGroup>
+        <form autoComplete="off" onSubmit={(event) => void submit(event)}>
+          <fieldset disabled={submitting}>
+            <FieldGroup className="gap-4">
+              <Field>
+                <FieldLabel htmlFor="edit-secret-name">Name</FieldLabel>
+                <Input
+                  id="edit-secret-name"
+                  required
+                  value={name}
+                  onChange={(event) => {
+                    setName(event.target.value)
+                  }}
+                />
+                <ResourceNameFieldError value={name} />
+              </Field>
+              {canEditValue && (
+                <SecretValueEditor
+                  secret={secret}
+                  updates={updates}
+                  onChange={(next) => {
+                    if (next.access_token === undefined) setLifetime('')
+                    setUpdates(next)
+                  }}
+                />
+              )}
+              {changingToken && (
+                <Field>
+                  <FieldLabel htmlFor="token-lifetime">Access token lifetime (seconds)</FieldLabel>
+                  <Input
+                    id="token-lifetime"
+                    type="number"
+                    min={1}
+                    max={2147483647}
+                    value={lifetime}
+                    onChange={(event) => {
+                      setLifetime(event.target.value)
+                    }}
+                    placeholder="No expiry"
+                  />
+                  <FieldDescription>
+                    Applies to the replacement token. Leave blank for no expiry.
+                  </FieldDescription>
+                </Field>
+              )}
+              {replacement.error && (
+                <p role="alert" className="text-destructive text-sm">
+                  {replacement.error}
+                </p>
+              )}
+              {error && (
+                <p role="alert" className="text-destructive text-sm">
+                  {error}
+                </p>
+              )}
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    onOpenChange(false)
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={submitting || !valid} loading={submitting}>
+                  Save changes
+                </Button>
+              </DialogFooter>
+            </FieldGroup>
+          </fieldset>
         </form>
       </DialogContent>
     </Dialog>

--- a/frontend/apps/web/src/components/org/EditSecretDialog.tsx
+++ b/frontend/apps/web/src/components/org/EditSecretDialog.tsx
@@ -1,6 +1,6 @@
 import { useCreateSecretVersion, useUpdateSecret } from '@omnara/react'
 import { ApiError, type Secret } from '@omnara/sdk'
-import { type SyntheticEvent, useState } from 'react'
+import { type SyntheticEvent, useReducer } from 'react'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -32,42 +32,47 @@ export function EditSecretDialog({
 }) {
   const updateSecret = useUpdateSecret(orgId)
   const createVersion = useCreateSecretVersion(orgId, secret.id)
-  const [savedName, setSavedName] = useState(secret.name)
-  const [name, setName] = useState(secret.name)
-  const [updates, setUpdates] = useState<Record<string, string>>({})
-  const [lifetime, setLifetime] = useState('')
-  const [error, setError] = useState('')
-  const [submitting, setSubmitting] = useState(false)
+  const [state, dispatch] = useReducer(editSecretReducer, {
+    draftName: secret.name,
+    persistedName: secret.name,
+    updates: {},
+    lifetime: '',
+    error: '',
+    submitting: false,
+  })
+  const { draftName, persistedName, updates, lifetime, error, submitting } = state
   const canEditValue =
     secret.management_kind === 'tenant' && requiredSecretKeys(secret.kind) !== undefined
   const changingToken = secret.kind === 'oauth_token_set' && updates.access_token !== undefined
   const replacement = prepareSecretReplacement(secret, updates, lifetime)
-  const nameChanged = normalizeResourceName(name) !== savedName
+  const nameChanged = normalizeResourceName(draftName) !== persistedName
   const hasUpdates = Object.keys(updates).length > 0
-  const valid = resourceNameValid(name) && !replacement.error && (nameChanged || hasUpdates)
+  const valid = resourceNameValid(draftName) && !replacement.error && (nameChanged || hasUpdates)
 
   async function submit(event: SyntheticEvent<HTMLFormElement>) {
     event.preventDefault()
     if (submitting || !valid) return
-    setSubmitting(true)
-    setError('')
+    dispatch({ type: 'submit-started' })
     let renamed = false
     try {
       if (nameChanged) {
         const updated = await updateSecret.mutateAsync({
           secretID: secret.id,
-          name: normalizeResourceName(name),
+          name: normalizeResourceName(draftName),
         })
-        setSavedName(updated.name)
+        dispatch({ type: 'name-saved', name: updated.name })
         renamed = true
       }
       if (replacement.material) await createVersion.mutateAsync({ material: replacement.material })
+      dispatch({ type: 'submit-finished' })
       onOpenChange(false)
     } catch (error) {
       const message = error instanceof ApiError ? error.message : 'Could not update secret'
-      setError(renamed ? `Name saved, but the value update failed. ${message}` : message)
+      dispatch({
+        type: 'submit-failed',
+        message: renamed ? `Name saved, but the value update failed. ${message}` : message,
+      })
     }
-    setSubmitting(false)
   }
 
   return (
@@ -96,20 +101,19 @@ export function EditSecretDialog({
                 <Input
                   id="edit-secret-name"
                   required
-                  value={name}
+                  value={draftName}
                   onChange={(event) => {
-                    setName(event.target.value)
+                    dispatch({ type: 'name-changed', name: event.target.value })
                   }}
                 />
-                <ResourceNameFieldError value={name} />
+                <ResourceNameFieldError value={draftName} />
               </Field>
               {canEditValue && (
                 <SecretValueEditor
                   secret={secret}
                   updates={updates}
                   onChange={(next) => {
-                    if (next.access_token === undefined) setLifetime('')
-                    setUpdates(next)
+                    dispatch({ type: 'credentials-changed', updates: next })
                   }}
                 />
               )}
@@ -123,7 +127,7 @@ export function EditSecretDialog({
                     max={2147483647}
                     value={lifetime}
                     onChange={(event) => {
-                      setLifetime(event.target.value)
+                      dispatch({ type: 'lifetime-changed', lifetime: event.target.value })
                     }}
                     placeholder="No expiry"
                   />
@@ -162,4 +166,45 @@ export function EditSecretDialog({
       </DialogContent>
     </Dialog>
   )
+}
+
+interface EditSecretState {
+  draftName: string
+  persistedName: string
+  updates: Record<string, string>
+  lifetime: string
+  error: string
+  submitting: boolean
+}
+
+type EditSecretAction =
+  | { type: 'name-changed'; name: string }
+  | { type: 'name-saved'; name: string }
+  | { type: 'credentials-changed'; updates: Record<string, string> }
+  | { type: 'lifetime-changed'; lifetime: string }
+  | { type: 'submit-started' }
+  | { type: 'submit-failed'; message: string }
+  | { type: 'submit-finished' }
+
+function editSecretReducer(state: EditSecretState, action: EditSecretAction): EditSecretState {
+  switch (action.type) {
+    case 'name-changed':
+      return { ...state, draftName: action.name }
+    case 'name-saved':
+      return { ...state, persistedName: action.name }
+    case 'credentials-changed':
+      return {
+        ...state,
+        updates: action.updates,
+        lifetime: action.updates.access_token === undefined ? '' : state.lifetime,
+      }
+    case 'lifetime-changed':
+      return { ...state, lifetime: action.lifetime }
+    case 'submit-started':
+      return { ...state, submitting: true, error: '' }
+    case 'submit-failed':
+      return { ...state, submitting: false, error: action.message }
+    case 'submit-finished':
+      return { ...state, submitting: false }
+  }
 }

--- a/frontend/apps/web/src/components/org/EditSecretDialog.tsx
+++ b/frontend/apps/web/src/components/org/EditSecretDialog.tsx
@@ -66,9 +66,8 @@ export function EditSecretDialog({
     } catch (error) {
       const message = error instanceof ApiError ? error.message : 'Could not update secret'
       setError(renamed ? `Name saved, but the value update failed. ${message}` : message)
-    } finally {
-      setSubmitting(false)
     }
+    setSubmitting(false)
   }
 
   return (

--- a/frontend/apps/web/src/components/org/SecretValueEditor.tsx
+++ b/frontend/apps/web/src/components/org/SecretValueEditor.tsx
@@ -1,5 +1,5 @@
 import type { Secret } from '@omnara/sdk'
-import { useId, useState } from 'react'
+import { type ChangeEvent, useId, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Field, FieldDescription, FieldLabel } from '@/components/ui/field'
@@ -44,12 +44,23 @@ function StoredValueField({
   const id = useId()
   const [revealed, setRevealed] = useState(false)
   const edited = value !== undefined
+  const clearable = stored && !required
+  const visibilityLabel = revealed ? 'Hide' : 'Show'
+  const inputProps = {
+    id,
+    value: value ?? '',
+    placeholder: stored && !edited ? '••••••••••••' : undefined,
+    onChange: (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      if (event.target.value === '') setRevealed(false)
+      onChange(event.target.value)
+    },
+  }
   return (
     <Field>
       <div className="flex items-center justify-between">
         <FieldLabel htmlFor={id}>{label}</FieldLabel>
         <div className="flex items-center gap-3">
-          {stored && !required && value !== '' && (
+          {clearable && value !== '' && (
             <Button
               type="button"
               variant="link"
@@ -84,45 +95,33 @@ function StoredValueField({
       <div className="flex gap-2">
         {multiline ? (
           <Textarea
-            id={id}
+            {...inputProps}
             autoComplete="off"
             spellCheck={false}
-            value={value ?? ''}
-            placeholder={stored && !edited ? '••••••••••••' : undefined}
             className={revealed ? undefined : '[-webkit-text-security:disc]'}
-            onChange={(event) => {
-              if (event.target.value === '') setRevealed(false)
-              onChange(event.target.value)
-            }}
           />
         ) : (
           <Input
-            id={id}
+            {...inputProps}
             type={revealed ? 'text' : 'password'}
             autoComplete="new-password"
-            value={value ?? ''}
-            placeholder={stored && !edited ? '••••••••••••' : undefined}
-            onChange={(event) => {
-              if (event.target.value === '') setRevealed(false)
-              onChange(event.target.value)
-            }}
           />
         )}
-        {edited && value !== '' && (
+        {Boolean(value) && (
           <Button
             type="button"
             variant="ghost"
             size="sm"
-            aria-label={`${revealed ? 'Hide' : 'Show'} ${label.toLowerCase()}`}
+            aria-label={`${visibilityLabel} ${label.toLowerCase()}`}
             onClick={() => {
               setRevealed(!revealed)
             }}
           >
-            {revealed ? 'Hide' : 'Show'}
+            {visibilityLabel}
           </Button>
         )}
       </div>
-      {stored && value === '' && !required && (
+      {clearable && value === '' && (
         <FieldDescription>Will be removed when you save.</FieldDescription>
       )}
     </Field>
@@ -145,15 +144,13 @@ export function SecretValueEditor({
       : secret.kind === 'aws_credentials'
         ? awsFields
         : oauthKeys.filter((field) => field.value !== 'access_token_expires_in_seconds')
-  const required = requiredSecretKeys(secret.kind)
-  if (!required) return null
-  const visible = fields.filter(
-    (field) =>
-      required.includes(field.value) ||
-      secret.payload_keys.includes(field.value) ||
-      added.includes(field.value),
-  )
-  const available = fields.filter((field) => !visible.some((item) => item.value === field.value))
+  const requiredKeys = requiredSecretKeys(secret.kind)
+  if (!requiredKeys) return null
+  const required = new Set(requiredKeys)
+  const stored = new Set(secret.payload_keys)
+  const visibleKeys = new Set([...required, ...stored, ...added])
+  const visible = fields.filter((field) => visibleKeys.has(field.value))
+  const available = fields.filter((field) => !visibleKeys.has(field.value))
   return (
     <>
       {visible.map((field) => (
@@ -161,8 +158,8 @@ export function SecretValueEditor({
           key={field.value}
           label={field.label}
           multiline={secret.kind === 'generic'}
-          required={required.includes(field.value)}
-          stored={secret.payload_keys.includes(field.value)}
+          required={required.has(field.value)}
+          stored={stored.has(field.value)}
           value={updates[field.value]}
           onChange={(value) => {
             onChange({ ...updates, [field.value]: value })

--- a/frontend/apps/web/src/components/org/SecretValueEditor.tsx
+++ b/frontend/apps/web/src/components/org/SecretValueEditor.tsx
@@ -1,0 +1,200 @@
+import type { Secret } from '@omnara/sdk'
+import { useId, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Field, FieldDescription, FieldLabel } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+import { oauthKeys } from '@/lib/oauthEntries'
+
+import { requiredSecretKeys } from './secretValueUpdates'
+
+const awsFields = [
+  { value: 'access_key_id', label: 'Access key ID' },
+  { value: 'secret_access_key', label: 'Secret access key' },
+  { value: 'session_token', label: 'Session token' },
+  { value: 'role_arn', label: 'Role ARN' },
+  { value: 'external_id', label: 'External ID' },
+]
+
+function StoredValueField({
+  label,
+  stored,
+  required,
+  multiline,
+  value,
+  onChange,
+  onUndo,
+}: {
+  label: string
+  stored: boolean
+  required: boolean
+  multiline: boolean
+  value: string | undefined
+  onChange: (value: string) => void
+  onUndo: () => void
+}) {
+  const id = useId()
+  const [revealed, setRevealed] = useState(false)
+  const edited = value !== undefined
+  return (
+    <Field>
+      <div className="flex items-center justify-between">
+        <FieldLabel htmlFor={id}>{label}</FieldLabel>
+        <div className="flex items-center gap-3">
+          {stored && !required && value !== '' && (
+            <Button
+              type="button"
+              variant="link"
+              size="sm"
+              className="type-control-small h-auto p-0"
+              aria-label={`Clear ${label.toLowerCase()}`}
+              onClick={() => {
+                setRevealed(false)
+                onChange('')
+              }}
+            >
+              Clear
+            </Button>
+          )}
+          {edited && (
+            <Button
+              type="button"
+              variant="link"
+              size="sm"
+              className="type-control-small h-auto p-0"
+              onClick={() => {
+                setRevealed(false)
+                onUndo()
+              }}
+              aria-label={`Undo ${label.toLowerCase()} change`}
+            >
+              Undo
+            </Button>
+          )}
+        </div>
+      </div>
+      <div className="flex gap-2">
+        {multiline ? (
+          <Textarea
+            id={id}
+            autoComplete="off"
+            spellCheck={false}
+            value={value ?? ''}
+            placeholder={stored && !edited ? '••••••••••••' : undefined}
+            className={revealed ? undefined : '[-webkit-text-security:disc]'}
+            onChange={(event) => {
+              if (event.target.value === '') setRevealed(false)
+              onChange(event.target.value)
+            }}
+          />
+        ) : (
+          <Input
+            id={id}
+            type={revealed ? 'text' : 'password'}
+            autoComplete="new-password"
+            value={value ?? ''}
+            placeholder={stored && !edited ? '••••••••••••' : undefined}
+            onChange={(event) => {
+              if (event.target.value === '') setRevealed(false)
+              onChange(event.target.value)
+            }}
+          />
+        )}
+        {edited && value !== '' && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-label={`${revealed ? 'Hide' : 'Show'} ${label.toLowerCase()}`}
+            onClick={() => {
+              setRevealed(!revealed)
+            }}
+          >
+            {revealed ? 'Hide' : 'Show'}
+          </Button>
+        )}
+      </div>
+      {stored && value === '' && !required && (
+        <FieldDescription>Will be removed when you save.</FieldDescription>
+      )}
+    </Field>
+  )
+}
+
+export function SecretValueEditor({
+  secret,
+  updates,
+  onChange,
+}: {
+  secret: Secret
+  updates: Record<string, string>
+  onChange: (updates: Record<string, string>) => void
+}) {
+  const [added, setAdded] = useState<string[]>([])
+  const fields =
+    secret.kind === 'generic'
+      ? [{ value: 'value', label: 'Value' }]
+      : secret.kind === 'aws_credentials'
+        ? awsFields
+        : oauthKeys.filter((field) => field.value !== 'access_token_expires_in_seconds')
+  const required = requiredSecretKeys(secret.kind)
+  if (!required) return null
+  const visible = fields.filter(
+    (field) =>
+      required.includes(field.value) ||
+      secret.payload_keys.includes(field.value) ||
+      added.includes(field.value),
+  )
+  const available = fields.filter((field) => !visible.some((item) => item.value === field.value))
+  return (
+    <>
+      {visible.map((field) => (
+        <StoredValueField
+          key={field.value}
+          label={field.label}
+          multiline={secret.kind === 'generic'}
+          required={required.includes(field.value)}
+          stored={secret.payload_keys.includes(field.value)}
+          value={updates[field.value]}
+          onChange={(value) => {
+            onChange({ ...updates, [field.value]: value })
+          }}
+          onUndo={() => {
+            const next = Object.fromEntries(
+              Object.entries(updates).filter(([key]) => key !== field.value),
+            )
+            onChange(next)
+            setAdded(added.filter((key) => key !== field.value))
+          }}
+        />
+      ))}
+      {available.length > 0 && (
+        <Select
+          value=""
+          onValueChange={(key) => {
+            setAdded([...added, key])
+          }}
+        >
+          <SelectTrigger aria-label="Add credential field">
+            <SelectValue placeholder="Add field">Add field</SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {available.map((field) => (
+              <SelectItem key={field.value} value={field.value}>
+                {field.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+    </>
+  )
+}

--- a/frontend/apps/web/src/components/org/secretValueUpdates.test.ts
+++ b/frontend/apps/web/src/components/org/secretValueUpdates.test.ts
@@ -1,0 +1,114 @@
+import type { Secret } from '@omnara/sdk'
+import { describe, expect, it } from 'vitest'
+
+import { prepareSecretReplacement, requiredSecretKeys } from './secretValueUpdates'
+
+function secretValueUpdatesError(current: Secret, values: Record<string, string>) {
+  return prepareSecretReplacement(current, values).error
+}
+
+function secret(kind: Secret['kind'], payload_keys: string[]): Secret {
+  return {
+    id: 'sec_1',
+    org_id: 'org_1',
+    name: 'test',
+    kind,
+    payload_keys,
+    management_kind: 'tenant',
+    owner: { kind: 'org' },
+    metadata: {},
+    current_version_number: 1,
+    created_at: '',
+    updated_at: '',
+  }
+}
+
+describe('secret value field edits', () => {
+  it('requires a complete replacement and explicit removal of stored optional fields', () => {
+    const current = secret('aws_credentials', [
+      'access_key_id',
+      'secret_access_key',
+      'session_token',
+    ])
+    expect(secretValueUpdatesError(current, { secret_access_key: 'new-key' })).toBeDefined()
+    expect(
+      secretValueUpdatesError(current, {
+        access_key_id: 'new-id',
+        secret_access_key: 'new-key',
+        session_token: '',
+      }),
+    ).toBeUndefined()
+    expect(
+      secretValueUpdatesError(current, {
+        access_key_id: '',
+        secret_access_key: 'new-key',
+        session_token: '',
+      }),
+    ).toBeDefined()
+  })
+  it('rejects incomplete OAuth refresh credentials', () => {
+    const current = secret('oauth_token_set', ['access_token'])
+    expect(
+      secretValueUpdatesError(current, { access_token: 'new', refresh_token: 'refresh' }),
+    ).toBeDefined()
+  })
+  it('distinguishes unchanged from explicitly cleared generic values', () => {
+    const current = secret('generic', ['value'])
+    expect(secretValueUpdatesError(current, {})).toBeUndefined()
+    expect(secretValueUpdatesError(current, { value: '' })).toBeDefined()
+  })
+})
+
+it('validates AWS dependencies and normalized required fields', () => {
+  const current = secret('aws_credentials', ['access_key_id', 'secret_access_key'])
+  const values = { access_key_id: ' id ', secret_access_key: ' key ' }
+  expect(secretValueUpdatesError(current, values)).toBeUndefined()
+  expect(prepareSecretReplacement(current, values).material).toEqual({
+    kind: 'aws_credentials',
+    access_key_id: 'id',
+    secret_access_key: 'key',
+  })
+  expect(secretValueUpdatesError(current, { ...values, access_key_id: ' ' })).toBeDefined()
+  expect(secretValueUpdatesError(current, { ...values, external_id: 'external' })).toBeDefined()
+  expect(
+    secretValueUpdatesError(current, { ...values, external_id: 'external', role_arn: 'role' }),
+  ).toBeUndefined()
+})
+it('accepts a complete OAuth refresh set', () => {
+  expect(
+    secretValueUpdatesError(secret('oauth_token_set', ['access_token']), {
+      access_token: 'access',
+      refresh_token: 'refresh',
+      token_endpoint: 'https://example.com/token',
+      client_id: 'client',
+      resource: 'resource',
+    }),
+  ).toBeUndefined()
+})
+
+it.each(['0', '1.5', '2147483648'])(
+  'rejects invalid OAuth lifetime %s before building material',
+  (lifetime) => {
+    const result = prepareSecretReplacement(
+      secret('oauth_token_set', ['access_token']),
+      { access_token: 'access' },
+      lifetime,
+    )
+    expect(result.error).toBeDefined()
+    expect(result.material).toBeUndefined()
+  },
+)
+
+it('rejects unsupported credentials before validating their fields', () => {
+  const current = secret('slack_app_credentials', [
+    'access_token',
+    'client_id',
+    'client_secret',
+    'signing_secret',
+  ])
+  expect(requiredSecretKeys(current.kind)).toBeUndefined()
+  expect(prepareSecretReplacement(current, {})).toEqual({})
+  expect(prepareSecretReplacement(current, { access_token: 'replacement' })).toEqual({
+    error: 'These credentials cannot be replaced here.',
+  })
+})

--- a/frontend/apps/web/src/components/org/secretValueUpdates.ts
+++ b/frontend/apps/web/src/components/org/secretValueUpdates.ts
@@ -1,0 +1,86 @@
+import type { Secret, SecretMaterial } from '@omnara/sdk'
+
+import { isOAuthKey, oauthTokenSetMaterialFromValues } from '@/lib/oauthEntries'
+
+export function requiredSecretKeys(kind: Secret['kind']): string[] | undefined {
+  switch (kind) {
+    case 'generic':
+      return ['value']
+    case 'aws_credentials':
+      return ['access_key_id', 'secret_access_key']
+    case 'oauth_token_set':
+      return ['access_token']
+    default:
+      return undefined
+  }
+}
+
+function normalizeSecretValues(
+  kind: Secret['kind'],
+  values: Record<string, string>,
+): Record<string, string> {
+  return kind === 'aws_credentials'
+    ? Object.fromEntries(Object.entries(values).map(([key, value]) => [key, value.trim()]))
+    : values
+}
+
+export function prepareSecretReplacement(
+  secret: Secret,
+  updates: Record<string, string>,
+  lifetime = '',
+): { material?: SecretMaterial; error?: never } | { material?: never; error: string } {
+  updates = normalizeSecretValues(secret.kind, updates)
+  if (Object.keys(updates).length === 0) return {}
+  const required = requiredSecretKeys(secret.kind)
+  if (!required) return { error: 'These credentials cannot be replaced here.' }
+  if (secret.payload_keys.some((key) => updates[key] === undefined))
+    return {
+      error:
+        'Changing or clearing a field requires re-entering all stored values you want to keep.',
+    }
+  const present = (key: string) => Boolean(updates[key])
+  if (required.some((key) => !present(key)))
+    return { error: 'Required credential fields cannot be empty.' }
+  if (secret.kind === 'aws_credentials' && present('external_id') && !present('role_arn'))
+    return { error: 'An external ID requires a role ARN.' }
+  const refresh = ['refresh_token', 'token_endpoint', 'client_id', 'resource']
+  if (
+    secret.kind === 'oauth_token_set' &&
+    [...refresh, 'client_secret'].some(present) &&
+    !refresh.every(present)
+  ) {
+    return {
+      error:
+        'Refresh credentials require a refresh token, token endpoint, client ID, and resource.',
+    }
+  }
+  if (secret.kind === 'generic')
+    return { material: { kind: 'generic', value: updates.value ?? '' } }
+  if (secret.kind === 'aws_credentials') {
+    const material: SecretMaterial = {
+      kind: 'aws_credentials',
+      access_key_id: updates.access_key_id ?? '',
+      secret_access_key: updates.secret_access_key ?? '',
+    }
+    if (updates.session_token) material.session_token = updates.session_token
+    if (updates.role_arn) material.role_arn = updates.role_arn
+    if (updates.external_id) material.external_id = updates.external_id
+    return { material }
+  }
+  if (secret.kind === 'oauth_token_set') {
+    const material = oauthTokenSetMaterialFromValues(
+      Object.fromEntries(
+        Object.entries({ ...updates, access_token_expires_in_seconds: lifetime }).filter(
+          ([key, value]) => isOAuthKey(key) && value !== '',
+        ),
+      ),
+    )
+    return material
+      ? { material }
+      : {
+          error:
+            'Enter a whole-number token lifetime between 1 and 2147483647 seconds, or leave it blank.',
+        }
+  }
+  return { error: 'These credentials cannot be replaced here.' }
+}

--- a/frontend/apps/web/src/components/overview/SecretsSection.test.tsx
+++ b/frontend/apps/web/src/components/overview/SecretsSection.test.tsx
@@ -1,0 +1,142 @@
+/** @vitest-environment happy-dom */
+
+import { OmnaraClientProvider } from '@omnara/react'
+import { createOmnaraClient, type Secret } from '@omnara/sdk'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, expect, it } from 'vitest'
+
+import { SecretsSection } from '@/components/overview/SecretsSection'
+import { ActiveOrgContext } from '@/lib/active-org-context'
+import { fakeApi, jsonResponse } from '@/test/fake-api'
+import { fakeId } from '@/test/fixtures'
+import { enableReactActEnvironment } from '@/test/react-act'
+import { button, enter, field, submit, waitForUI } from '@/test/secret-editor'
+
+const secret: Secret = {
+  id: fakeId('sec'),
+  org_id: fakeId('org'),
+  management_kind: 'tenant',
+  owner: { kind: 'org' },
+  name: 'token',
+  kind: 'generic',
+  metadata: {},
+  current_version_number: 1,
+  payload_keys: ['value'],
+  created_at: '2026-08-03T00:00:00Z',
+  updated_at: '2026-08-03T00:00:00Z',
+}
+let root: Root
+let container: HTMLDivElement
+let restore: () => void
+beforeEach(() => {
+  restore = enableReactActEnvironment()
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+})
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  restore()
+})
+it('retains the editor and retries value-only after rename removes the filtered row', async () => {
+  const path = `/api/v1/orgs/${secret.org_id}/secrets/${secret.id}`
+  let renamed = false
+  let attempts = 0
+  const api = fakeApi([
+    {
+      method: 'GET',
+      path: `/api/v1/orgs/${secret.org_id}/secrets`,
+      respond: () =>
+        jsonResponse({ data: renamed ? [] : [secret], next_cursor: renamed ? null : 'next' }),
+    },
+    {
+      method: 'PATCH',
+      path,
+      respond: () => {
+        renamed = true
+        return jsonResponse({ ...secret, name: 'renamed' })
+      },
+    },
+    {
+      method: 'POST',
+      path: path + '/versions',
+      respond: () =>
+        ++attempts === 1
+          ? jsonResponse({ code: 'conflict', error: 'Try again' }, 409)
+          : jsonResponse({ ...secret, name: 'renamed', current_version_number: 2 }),
+    },
+  ])
+  const client = createOmnaraClient({ baseUrl: 'https://omnara.test/api/v1' })
+  client.setConfig({ fetch: api.fetch })
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  await act(async () => {
+    root.render(
+      <OmnaraClientProvider client={client}>
+        <QueryClientProvider client={queryClient}>
+          <ActiveOrgContext
+            value={{
+              orgs: [],
+              activeOrg: {
+                id: secret.org_id,
+                name: 'Test',
+                role: 'owner',
+                created_at: secret.created_at,
+              },
+              setActiveOrgId: () => undefined,
+            }}
+          >
+            <SecretsSection />
+          </ActiveOrgContext>
+        </QueryClientProvider>
+      </OmnaraClientProvider>,
+    )
+    await Promise.resolve()
+  })
+  await waitForUI(() => {
+    expect(button('Secret actions')).toBeDefined()
+  })
+  await enter('Search secrets by name…', 'token')
+  await waitForUI(() => {
+    expect(
+      api
+        .requestsTo('GET', `/api/v1/orgs/${secret.org_id}/secrets`)
+        .some((request) => request.url.search.includes('token')),
+    ).toBe(true)
+    expect(button('Secret actions')).toBeDefined()
+  })
+  act(() => {
+    button('Secret actions').dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+    )
+  })
+  await waitForUI(() => {
+    expect(document.querySelector('[role="menuitem"]')).not.toBeNull()
+  })
+  act(() => {
+    const edit = [...document.querySelectorAll<HTMLElement>('[role="menuitem"]')].find(
+      (item) => item.textContent.trim() === 'Edit',
+    )
+    if (!edit) throw new Error('Missing Edit action')
+    edit.click()
+  })
+  await waitForUI(() => {
+    expect(field('Name')).toBeDefined()
+  })
+  await enter('Name', 'renamed')
+  await enter('Value', 'replacement')
+  await submit()
+  expect(document.querySelector('button[aria-label="Secret actions"]')).toBeNull()
+  expect(document.querySelector('[role="dialog"]')).not.toBeNull()
+  expect(document.body.textContent).toContain('Name saved, but the value update failed.')
+  expect(field('Value').value).toBe('replacement')
+  await submit()
+  expect(api.requestsTo('PATCH', path)).toHaveLength(1)
+  expect(api.requestsTo('POST', path + '/versions')).toHaveLength(2)
+  expect(document.querySelector('[role="dialog"]')).toBeNull()
+  queryClient.clear()
+})

--- a/frontend/apps/web/src/components/overview/SecretsSection.tsx
+++ b/frontend/apps/web/src/components/overview/SecretsSection.tsx
@@ -1,4 +1,5 @@
 import { type SecretListSort, type SecretOwnerScope, useSecrets } from '@omnara/react'
+import type { Secret } from '@omnara/sdk'
 import { useState } from 'react'
 
 import { DataTable } from '@/components/data-table/DataTable'
@@ -6,6 +7,7 @@ import { DetailList } from '@/components/data-table/DetailList'
 import { ResourceListToolbar } from '@/components/data-table/ResourceListToolbar'
 import { SearchHeader } from '@/components/layout/SearchHeader'
 import { CreateSecretDialog } from '@/components/org/CreateSecretDialog'
+import { EditSecretDialog } from '@/components/org/EditSecretDialog'
 import { McpOAuthOutcomeDialog } from '@/components/secrets/McpOAuthOutcomeDialog'
 import { SecretRowActions } from '@/components/secrets/SecretRowActions'
 import { Button } from '@/components/ui/button'
@@ -58,6 +60,7 @@ function SecretsList({ owner, canManage }: { owner: SecretOwnerScope; canManage:
   const paged = usePagedQuery(query, list.queryKey)
   const showToolbar = useListToolbarVisibility(list, paged.pagination, query.isSuccess)
   const [open, setOpen] = useState(false)
+  const [editingSecret, setEditingSecret] = useState<Secret | null>(null)
 
   const newSecretButton = () =>
     canManage ? (
@@ -122,7 +125,7 @@ function SecretsList({ owner, canManage }: { owner: SecretOwnerScope; canManage:
                   orgId={activeOrg.id}
                   secret={secret}
                   canDelete={canManage}
-                  canEdit={canManage}
+                  onEdit={canManage ? setEditingSecret : undefined}
                   canGrant={canManage}
                 />
               ),
@@ -158,6 +161,16 @@ function SecretsList({ owner, canManage }: { owner: SecretOwnerScope; canManage:
       </div>
       {canManage && (
         <CreateSecretDialog open={open} onOpenChange={setOpen} orgId={activeOrg.id} owner={owner} />
+      )}
+      {editingSecret && (
+        <EditSecretDialog
+          open
+          orgId={activeOrg.id}
+          secret={editingSecret}
+          onOpenChange={(nextOpen) => {
+            if (!nextOpen) setEditingSecret(null)
+          }}
+        />
       )}
       <McpOAuthOutcomeDialog />
     </>

--- a/frontend/apps/web/src/components/secrets/SecretRowActions.tsx
+++ b/frontend/apps/web/src/components/secrets/SecretRowActions.tsx
@@ -3,7 +3,6 @@ import { ApiError, type ProjectSecretAccess, type Secret } from '@omnara/sdk'
 import { useState } from 'react'
 
 import { Ellipsis } from '@/components/icons'
-import { EditSecretDialog } from '@/components/org/EditSecretDialog'
 import { GrantToProjectDialog } from '@/components/projects/GrantToProjectDialog'
 import { Button } from '@/components/ui/button'
 import {
@@ -19,7 +18,7 @@ export function SecretRowActions({
   availability,
   projectName,
   canDelete,
-  canEdit = false,
+  onEdit,
   canGrant = false,
 }: {
   orgId: string
@@ -27,20 +26,16 @@ export function SecretRowActions({
   availability?: ProjectSecretAccess['availability']
   projectName?: string
   canDelete: boolean
-  canEdit?: boolean
+  onEdit?: (secret: Secret) => void
   canGrant?: boolean
 }) {
-  const deleteSecretMutation = useDeleteSecret(orgId)
-  const deleteSecretGrantMutation = useDeleteSecretGrant(orgId)
   const grantSecretMutation = useGrantSecretToProject(orgId)
-  const [editOpen, setEditOpen] = useState(false)
   const [grantOpen, setGrantOpen] = useState(false)
   const mcpUrl = secret.metadata.mcp_url
-  const canCopyMcpConfig = mcpUrl !== undefined && mcpUrl !== ''
-  const isGrant = availability?.source === 'grant'
+  const canCopyMcpConfig = Boolean(mcpUrl)
   const tenantManaged = secret.management_kind === 'tenant'
   const allowDelete = canDelete && tenantManaged
-  const allowEdit = canEdit && tenantManaged
+  const allowEdit = onEdit !== undefined && tenantManaged
   const allowGrant = canGrant && tenantManaged
 
   if (!allowDelete && !canCopyMcpConfig && !allowEdit && !allowGrant) {
@@ -67,25 +62,6 @@ export function SecretRowActions({
     }
   }
 
-  async function deleteSecret() {
-    const message = isGrant ? 'Remove this secret grant?' : 'Delete this secret?'
-    if (!window.confirm(message)) {
-      return
-    }
-    try {
-      if (availability?.source === 'grant') {
-        await deleteSecretGrantMutation.mutateAsync({
-          secretID: secret.id,
-          grantID: availability.grant_id,
-        })
-      } else {
-        await deleteSecretMutation.mutateAsync(secret.id)
-      }
-    } catch (err) {
-      window.alert(err instanceof ApiError ? err.message : 'Could not delete secret')
-    }
-  }
-
   return (
     <>
       <DropdownMenu>
@@ -98,7 +74,7 @@ export function SecretRowActions({
           {allowEdit && (
             <DropdownMenuItem
               onSelect={() => {
-                setEditOpen(true)
+                onEdit(secret)
               }}
             >
               Edit
@@ -123,38 +99,15 @@ export function SecretRowActions({
             </DropdownMenuItem>
           )}
           {allowDelete && (
-            <DropdownMenuItem
-              variant="destructive"
-              className={isGrant ? 'items-start' : undefined}
-              onSelect={() => {
-                void deleteSecret()
-              }}
-            >
-              {isGrant ? (
-                <span className="flex flex-col gap-0.5">
-                  <span>Remove secret grant</span>
-                  <span className="text-muted-foreground text-xs font-normal">
-                    Removes {projectName ?? 'this project'}&rsquo;s access to this secret
-                  </span>
-                </span>
-              ) : (
-                'Delete'
-              )}
-            </DropdownMenuItem>
+            <SecretDeleteAction
+              orgId={orgId}
+              secret={secret}
+              availability={availability}
+              projectName={projectName}
+            />
           )}
         </DropdownMenuContent>
       </DropdownMenu>
-      {/* Mounted only while open so the dialogs seed fresh state each time. */}
-      {allowEdit && editOpen && (
-        <EditSecretDialog
-          open
-          onOpenChange={(nextOpen) => {
-            if (!nextOpen) setEditOpen(false)
-          }}
-          orgId={orgId}
-          secret={secret}
-        />
-      )}
       {allowGrant && grantOpen && (
         <GrantToProjectDialog
           open
@@ -171,5 +124,61 @@ export function SecretRowActions({
         />
       )}
     </>
+  )
+}
+
+function SecretDeleteAction({
+  orgId,
+  secret,
+  availability,
+  projectName,
+}: {
+  orgId: string
+  secret: Secret
+  availability?: ProjectSecretAccess['availability']
+  projectName?: string
+}) {
+  const deleteSecretMutation = useDeleteSecret(orgId)
+  const deleteSecretGrantMutation = useDeleteSecretGrant(orgId)
+  const isGrant = availability?.source === 'grant'
+
+  async function deleteSecret() {
+    const message = isGrant ? 'Remove this secret grant?' : 'Delete this secret?'
+    if (!window.confirm(message)) {
+      return
+    }
+    try {
+      if (availability?.source === 'grant') {
+        await deleteSecretGrantMutation.mutateAsync({
+          secretID: secret.id,
+          grantID: availability.grant_id,
+        })
+      } else {
+        await deleteSecretMutation.mutateAsync(secret.id)
+      }
+    } catch (err) {
+      window.alert(err instanceof ApiError ? err.message : 'Could not delete secret')
+    }
+  }
+
+  return (
+    <DropdownMenuItem
+      variant="destructive"
+      className={isGrant ? 'items-start' : undefined}
+      onSelect={() => {
+        void deleteSecret()
+      }}
+    >
+      {isGrant ? (
+        <span className="flex flex-col gap-0.5">
+          <span>Remove secret grant</span>
+          <span className="text-muted-foreground text-xs font-normal">
+            Removes {projectName ?? 'this project'}&rsquo;s access to this secret
+          </span>
+        </span>
+      ) : (
+        'Delete'
+      )}
+    </DropdownMenuItem>
   )
 }

--- a/frontend/apps/web/src/lib/oauthEntries.ts
+++ b/frontend/apps/web/src/lib/oauthEntries.ts
@@ -41,6 +41,12 @@ export function oauthTokenSetMaterial(
   for (const entry of entries) {
     if (entry.value !== '') values[entry.key] = entry.value
   }
+  return oauthTokenSetMaterialFromValues(values)
+}
+
+export function oauthTokenSetMaterialFromValues(
+  values: Partial<Record<OAuthKey, string>>,
+): OAuthTokenSetSecretMaterial | undefined {
   if (!values.access_token) return undefined
 
   let accessTokenExpiresInSeconds: number | undefined

--- a/frontend/apps/web/src/test/secret-editor.ts
+++ b/frontend/apps/web/src/test/secret-editor.ts
@@ -1,0 +1,60 @@
+import { act } from 'react'
+import { expect, vi } from 'vitest'
+
+export function field(labelText: string) {
+  const label = [...document.querySelectorAll('label')].find(
+    (item) => item.textContent === labelText,
+  )
+  const element = label
+    ? document.getElementById(label.htmlFor)
+    : [...document.querySelectorAll('input, textarea')].find(
+        (item) => item.getAttribute('aria-label') === labelText,
+      )
+  if (!(element instanceof HTMLInputElement) && !(element instanceof HTMLTextAreaElement))
+    throw new Error(`Missing field: ${labelText}`)
+  return element
+}
+
+export function button(name: string) {
+  const element = [...document.querySelectorAll('button')].find(
+    (item) => (item.getAttribute('aria-label') ?? item.textContent.trim()) === name,
+  )
+  if (!element) throw new Error(`Missing button: ${name}`)
+  return element
+}
+
+export async function enter(label: string, value: string) {
+  await act(async () => {
+    const element = field(label)
+    const prototype =
+      element instanceof HTMLTextAreaElement
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, 'value')
+    if (!descriptor?.set) throw new Error('Missing native field setter')
+    descriptor.set.call(element, value)
+    element.dispatchEvent(new Event('input', { bubbles: true }))
+    await Promise.resolve()
+  })
+}
+
+export async function waitForUI(assertion: () => void) {
+  await vi.waitFor(async () => {
+    await act(async () => {
+      await Promise.resolve()
+    })
+    assertion()
+  })
+}
+
+export async function submit() {
+  const form = document.querySelector('form')
+  if (!form) throw new Error('Missing secret form')
+  act(() => {
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+  })
+  await waitForUI(() => {
+    if (!form.isConnected) return
+    expect(form.querySelector('fieldset')?.disabled).toBe(false)
+  })
+}

--- a/frontend/packages/react/src/domains/secrets.ts
+++ b/frontend/packages/react/src/domains/secrets.ts
@@ -218,6 +218,19 @@ export function useUpdateSecret(orgID: string) {
   })
 }
 
+export function useCreateSecretVersion(orgID: string, secretID: string) {
+  const queryClient = useQueryClient()
+  return useScopedMutation(
+    sdk.createSecretVersion,
+    { orgID, secretID },
+    {
+      onSuccess: async () => {
+        await invalidateSecretQueries(queryClient, orgID)
+      },
+    },
+  )
+}
+
 export function useGrantSecretToProject(orgID: string) {
   const client = useOmnaraClient()
   const queryClient = useQueryClient()

--- a/frontend/packages/react/src/index.ts
+++ b/frontend/packages/react/src/index.ts
@@ -206,6 +206,7 @@ export {
   type SecretListSort,
   type SecretOwnerScope,
   useCreateSecret,
+  useCreateSecretVersion,
   useDeleteSecret,
   useDeleteSecretGrant,
   useGrantSecretToProject,


### PR DESCRIPTION
- Allow renaming secrets and replacing generic, AWS, and OAuth credentials from one Edit dialog using the existing APIs.
- Keep stored values hidden and require complete credential replacements, with Clear and Undo controls for field changes.
- Preserve replacement drafts across list refreshes and partial failures so retries do not repeat a successful rename.
