### PR TITLE
fix: recover queued agent work and tolerate daemon log failures

### DIFF
--- a/cmd/maintenance/main.go
+++ b/cmd/maintenance/main.go
@@ -375,12 +375,12 @@ func runCoreMaintenanceTick(
 	if expireDaemonRuntimesErr == nil {
 		expiredDaemonRuntimes = len(records)
 	}
-	expiredUnreachableTools, expireUnreachableToolsErr :=
-		store.Execution().ExpireMachineUnreachableProcessToolCallsForAllProjects(
+	expiredProcessTools, expireProcessToolsErr :=
+		store.Execution().ExpireProcessToolCallsForAllProjects(
 			ctx,
 			executionstore.ProcessToolMachineUnreachableGrace,
 		)
-	expireUnreachableToolsOutcome := completedMaintenanceOutcome(ctx, expireUnreachableToolsErr)
+	expireProcessToolsOutcome := completedMaintenanceOutcome(ctx, expireProcessToolsErr)
 	authCleanup, authCleanupErr := store.Identity().CleanupInactiveAuthState(ctx)
 	authCleanupOutcome := completedMaintenanceOutcome(ctx, authCleanupErr)
 	authCleanupDeleted := authCleanup.DeletedInactiveTokens > 0 ||
@@ -389,7 +389,7 @@ func runCoreMaintenanceTick(
 		authCleanup.DeletedDeviceFlows > 0
 	worked := reapedRuntimeLocks > 0 ||
 		expiredDaemonRuntimes > 0 ||
-		expiredUnreachableTools > 0 ||
+		expiredProcessTools > 0 ||
 		authCleanupDeleted
 	logent.MaintenanceLoopResult(
 		ctx,
@@ -399,7 +399,7 @@ func runCoreMaintenanceTick(
 		errors.Join(
 			reapRuntimeLocksOutcome.err,
 			expireDaemonRuntimesOutcome.err,
-			expireUnreachableToolsOutcome.err,
+			expireProcessToolsOutcome.err,
 			authCleanupOutcome.err,
 		),
 	)
@@ -408,10 +408,10 @@ func runCoreMaintenanceTick(
 	} else if !expireDaemonRuntimesOutcome.interrupted && expiredDaemonRuntimes > 0 {
 		log.Info("expired daemon runtimes", "count", expiredDaemonRuntimes)
 	}
-	if expireUnreachableToolsOutcome.err != nil {
-		log.Error("expire machine-unreachable process tool calls", "error", expireUnreachableToolsOutcome.err)
-	} else if !expireUnreachableToolsOutcome.interrupted && expiredUnreachableTools > 0 {
-		log.Info("expired machine-unreachable process tool calls", "count", expiredUnreachableTools)
+	if expireProcessToolsOutcome.err != nil {
+		log.Error("expire process tool calls", "error", expireProcessToolsOutcome.err)
+	} else if !expireProcessToolsOutcome.interrupted && expiredProcessTools > 0 {
+		log.Info("expired process tool calls", "count", expiredProcessTools)
 	}
 	if authCleanupOutcome.err != nil {
 		log.Error("cleanup inactive auth state", "error", authCleanupOutcome.err)

--- a/internal/omnarad/supervisor.go
+++ b/internal/omnarad/supervisor.go
@@ -71,10 +71,24 @@ func runForegroundSupervisor(ctx context.Context, home string, log *slog.Logger)
 			log.Warn("close daemon service log failed", "error", err)
 		}
 	}()
-	childStdout := io.MultiWriter(os.Stdout, logFile)
-	childStderr := io.MultiWriter(os.Stderr, logFile)
+	childStdout, childStderr := supervisorChildWriters(os.Stdout, os.Stderr, logFile)
 	log = slog.New(logpkg.NewJSONHandler(childStdout, nil))
 	return runSupervisorLoop(ctx, home, daemonRestartDelay, restart, childStdout, childStderr, log)
+}
+
+func supervisorChildWriters(stdout, stderr, logFile io.Writer) (io.Writer, io.Writer) {
+	serviceLog := bestEffortWriter{w: logFile}
+	return io.MultiWriter(bestEffortWriter{w: stdout}, serviceLog),
+		io.MultiWriter(bestEffortWriter{w: stderr}, serviceLog)
+}
+
+type bestEffortWriter struct {
+	w io.Writer
+}
+
+func (b bestEffortWriter) Write(p []byte) (int, error) {
+	_, _ = b.w.Write(p)
+	return len(p), nil
 }
 
 func runSupervisorLoop(

--- a/internal/omnarad/supervisor_test.go
+++ b/internal/omnarad/supervisor_test.go
@@ -506,3 +506,63 @@ func waitForMarkerLine(t *testing.T, lines <-chan string, want string) {
 		}
 	}
 }
+
+type enospcWriter struct{}
+
+func (enospcWriter) Write([]byte) (int, error) {
+	return 0, syscall.ENOSPC
+}
+
+func TestSupervisorChildSurvivesOutputWriteFailure(t *testing.T) {
+	for _, failedDestination := range []string{"stdout", "stderr", "service_log"} {
+		t.Run(failedDestination, func(t *testing.T) {
+			home := t.TempDir()
+			count := filepath.Join(t.TempDir(), "count")
+			require.NoError(t, os.MkdirAll(filepath.Join(home, "bin"), 0o700))
+			writeTestExecutable(t, canonicalDaemonPath(home), `#!/bin/sh
+printf x >> "$SUPERVISOR_COUNT"
+echo first
+echo first-error >&2
+sleep 0.2
+echo second
+echo second-error >&2
+exit 0
+`)
+			t.Setenv("SUPERVISOR_COUNT", count)
+			var stdout, stderr bytes.Buffer
+			logPath := filepath.Join(t.TempDir(), "service.log")
+			logFile, err := os.Create(logPath)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, logFile.Close()) })
+			var stdoutWriter, stderrWriter, logWriter io.Writer = &stdout, &stderr, logFile
+			switch failedDestination {
+			case "stdout":
+				stdoutWriter = enospcWriter{}
+			case "stderr":
+				stderrWriter = enospcWriter{}
+			case "service_log":
+				logWriter = enospcWriter{}
+			}
+			childStdout, childStderr := supervisorChildWriters(stdoutWriter, stderrWriter, logWriter)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			err = runSupervisorLoop(
+				ctx, home, 10*time.Millisecond, make(chan os.Signal),
+				childStdout, childStderr, discardLogger(),
+			)
+			require.NoError(t, err)
+			require.NoError(t, ctx.Err())
+			require.Equal(t, "x", readTestFile(t, count))
+			if failedDestination != "stdout" {
+				require.Equal(t, "first\nsecond\n", stdout.String())
+			}
+			if failedDestination != "stderr" {
+				require.Equal(t, "first-error\nsecond-error\n", stderr.String())
+			}
+			if failedDestination != "service_log" {
+				require.ElementsMatch(t, []string{"first", "second", "first-error", "second-error"},
+					strings.Fields(readTestFile(t, logPath)))
+			}
+		})
+	}
+}

--- a/internal/storage/executionstore/machine_sleep_integration_test.go
+++ b/internal/storage/executionstore/machine_sleep_integration_test.go
@@ -190,7 +190,7 @@ func TestAsleepMachineUnreachableExpiry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("start process against asleep machine: %v", err)
 	}
-	if _, err := fixture.Store.Execution().ExpireMachineUnreachableProcessToolCallsForAllProjects(
+	if _, err := fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(
 		ctx,
 		0,
 	); err != nil {
@@ -562,9 +562,10 @@ func TestAsleepUnreachableExpiryIsPerItemFromWorkArrival(t *testing.T) {
 	if err != nil {
 		t.Fatalf("start second process: %v", err)
 	}
-	eligible, err := fixture.Store.q.ListMachineUnreachableQueuedProcessToolCallsForMachine(
+	eligible, err := fixture.Store.q.ListExpirableQueuedProcessToolCallsForMachine(
 		ctx,
-		dbsqlc.ListMachineUnreachableQueuedProcessToolCallsForMachineParams{
+		dbsqlc.ListExpirableQueuedProcessToolCallsForMachineParams{
+			QueueTimeoutSeconds:            int32(executionstore.ProcessQueueTimeout / time.Second),
 			OrgID:                          fixture.OrgID,
 			MachineID:                      fixture.MachineID,
 			MachineUnreachableGraceSeconds: 1,
@@ -577,7 +578,7 @@ func TestAsleepUnreachableExpiryIsPerItemFromWorkArrival(t *testing.T) {
 	if len(eligible) != 1 || eligible[0].ID != firstProcess.ID {
 		t.Fatalf("eligible queued processes = %v, want only first process", eligible)
 	}
-	if _, err := fixture.Store.Execution().ExpireMachineUnreachableProcessToolCallsForAllProjects(
+	if _, err := fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(
 		ctx,
 		time.Second,
 	); err != nil {

--- a/internal/storage/executionstore/process_actions_store.go
+++ b/internal/storage/executionstore/process_actions_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
@@ -136,6 +137,9 @@ func (t *toolCallTransaction) processActionCreateBlocker(
 	}
 	state := ProcessState(row.State)
 	if isProcessTerminal(state) {
+		if input.ActionKind == ProcessActionKindRead && !row.TerminalReadSupported {
+			return storeerr.ErrProcessTerminal
+		}
 		if input.ActionKind == ProcessActionKindRead && !row.HasOnlineRuntime {
 			return storeerr.ErrNoOnlineDaemonRuntime
 		}
@@ -171,11 +175,12 @@ func (s *Store) ListDaemonProcessOffers(ctx context.Context, input DaemonWorkInp
 	rows, err := s.q.ListDaemonProcessOffers(
 		ctx,
 		dbsqlc.ListDaemonProcessOffersParams{
-			OrgID:           input.Authority.OrgID,
-			MachineID:       input.Authority.MachineID,
-			DaemonRuntimeID: input.Authority.DaemonRuntimeID,
-			DaemonTokenID:   input.Authority.DaemonTokenID,
-			LimitCount:      input.Limit,
+			QueueTimeoutSeconds: int32(ProcessQueueTimeout / time.Second),
+			OrgID:               input.Authority.OrgID,
+			MachineID:           input.Authority.MachineID,
+			DaemonRuntimeID:     input.Authority.DaemonRuntimeID,
+			DaemonTokenID:       input.Authority.DaemonTokenID,
+			LimitCount:          input.Limit,
 		},
 	)
 	if err != nil {
@@ -253,11 +258,12 @@ func (s *Store) AcceptDaemonProcess(
 	row, err := qtx.AcceptDaemonProcess(
 		ctx,
 		dbsqlc.AcceptDaemonProcessParams{
-			OrgID:           input.Authority.OrgID,
-			MachineID:       input.Authority.MachineID,
-			DaemonRuntimeID: input.Authority.DaemonRuntimeID,
-			DaemonTokenID:   input.Authority.DaemonTokenID,
-			ProcessID:       input.ProcessID,
+			QueueTimeoutSeconds: int32(ProcessQueueTimeout / time.Second),
+			OrgID:               input.Authority.OrgID,
+			MachineID:           input.Authority.MachineID,
+			DaemonRuntimeID:     input.Authority.DaemonRuntimeID,
+			DaemonTokenID:       input.Authority.DaemonTokenID,
+			ProcessID:           input.ProcessID,
 		},
 	)
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/storage/executionstore/process_machine_unreachable_integration_test.go
+++ b/internal/storage/executionstore/process_machine_unreachable_integration_test.go
@@ -508,12 +508,12 @@ func TestMachineUnreachableProcessToolCallUnblocksWithoutTerminalizingProcess(t 
 		len(records) != 1 {
 		t.Fatalf("end expired daemon runtime records=%d err=%v", len(records), err)
 	}
-	if expired, err := fixture.Store.Execution().ExpireMachineUnreachableProcessToolCallsForAllProjects(
+	if expired, err := fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(
 		ctx, executionstore.ProcessToolMachineUnreachableGrace); err != nil ||
 		expired != 0 {
 		t.Fatalf("early machine-unreachable expiry count=%d err=%v", expired, err)
 	}
-	if expired, err := fixture.Store.Execution().ExpireMachineUnreachableProcessToolCallsForAllProjects(
+	if expired, err := fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(
 		ctx, 0); err != nil ||
 		expired != 1 {
 		t.Fatalf("machine-unreachable expiry count=%d err=%v", expired, err)
@@ -603,7 +603,7 @@ func TestMachineUnreachableResolvesTerminalProcessActions(t *testing.T) {
 		t.Fatalf("end expired daemon runtime records=%d err=%v", len(records), err)
 	}
 	if expired, err :=
-		fixture.Store.Execution().ExpireMachineUnreachableProcessToolCallsForAllProjects(
+		fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(
 			ctx, 0); err != nil || expired != int64(len(seeded)) {
 		t.Fatalf(
 			"terminal action machine-unreachable expiry count=%d err=%v",
@@ -912,7 +912,7 @@ func TestMachineUnreachableResolvesAcceptedActionsInSequence(t *testing.T) {
 		len(records) != 1 {
 		t.Fatalf("end expired daemon runtime records=%d err=%v", len(records), err)
 	}
-	if expired, err := fixture.Store.Execution().ExpireMachineUnreachableProcessToolCallsForAllProjects(
+	if expired, err := fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(
 		ctx, 0); err != nil ||
 		expired != 2 {
 		t.Fatalf("machine-unreachable action expiry count=%d err=%v", expired, err)
@@ -1056,7 +1056,7 @@ func TestLateAcceptedActionReportAfterMachineUnreachableIsCleanupOnly(t *testing
 		len(records) != 1 {
 		t.Fatalf("end expired daemon runtime records=%d err=%v", len(records), err)
 	}
-	if expired, err := fixture.Store.Execution().ExpireMachineUnreachableProcessToolCallsForAllProjects(
+	if expired, err := fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(
 		ctx, 0); err != nil ||
 		expired != 1 {
 		t.Fatalf("machine-unreachable action expiry count=%d err=%v", expired, err)
@@ -1143,7 +1143,7 @@ SELECT last_activity_at FROM processes WHERE id = $1
 		len(records) != 1 {
 		t.Fatalf("end expired daemon runtime records=%d err=%v", len(records), err)
 	}
-	if expired, err := fixture.Store.Execution().ExpireMachineUnreachableProcessToolCallsForAllProjects(
+	if expired, err := fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(
 		ctx, executionstore.ProcessToolMachineUnreachableGrace); err != nil ||
 		expired != 0 {
 		t.Fatalf(
@@ -1152,7 +1152,7 @@ SELECT last_activity_at FROM processes WHERE id = $1
 			err,
 		)
 	}
-	if expired, err := fixture.Store.Execution().ExpireMachineUnreachableProcessToolCallsForAllProjects(
+	if expired, err := fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(
 		ctx, 0); err != nil ||
 		expired != 1 {
 		t.Fatalf("machine-unreachable queued process expiry count=%d err=%v", expired, err)
@@ -1251,7 +1251,7 @@ WHERE runtime.org_id = $1 AND runtime.machine_id = $2 AND runtime.id = $3
 		)
 	}
 
-	if expired, err := fixture.Store.Execution().ExpireMachineUnreachableProcessToolCallsForAllProjects(
+	if expired, err := fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(
 		ctx,
 		unreachableGrace,
 	); err != nil || expired != 1 {
@@ -1503,7 +1503,7 @@ func TestMachineUnreachableQueuedActionFailsBeforeActionGrant(t *testing.T) {
 		len(records) != 1 {
 		t.Fatalf("end expired daemon runtime records=%d err=%v", len(records), err)
 	}
-	if expired, err := fixture.Store.Execution().ExpireMachineUnreachableProcessToolCallsForAllProjects(
+	if expired, err := fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(
 		ctx, 0); err != nil ||
 		expired != 1 {
 		t.Fatalf("machine-unreachable queued action expiry count=%d err=%v", expired, err)
@@ -1580,9 +1580,10 @@ func TestMachineUnreachableCandidatesAreOfflineMachineFirst(t *testing.T) {
 		len(records) != 1 {
 		t.Fatalf("end expired daemon runtime records=%d err=%v", len(records), err)
 	}
-	candidates, err := offline.Store.q.ListMachineUnreachableMachineCandidates(
+	candidates, err := offline.Store.q.ListProcessToolExpiryMachineCandidates(
 		ctx,
-		dbsqlc.ListMachineUnreachableMachineCandidatesParams{
+		dbsqlc.ListProcessToolExpiryMachineCandidatesParams{
+			QueueTimeoutSeconds:            int32(executionstore.ProcessQueueTimeout / time.Second),
 			MachineUnreachableGraceSeconds: 0,
 			LimitCount:                     10,
 		},
@@ -1593,7 +1594,7 @@ func TestMachineUnreachableCandidatesAreOfflineMachineFirst(t *testing.T) {
 	if len(candidates) != 1 || candidates[0].MachineID != offline.MachineID {
 		t.Fatalf("machine-unreachable candidates = %+v, want only offline machine %s", candidates, offline.MachineID)
 	}
-	if expired, err := offline.Store.Execution().ExpireMachineUnreachableProcessToolCallsForAllProjects(
+	if expired, err := offline.Store.Execution().ExpireProcessToolCallsForAllProjects(
 		ctx, 0); err != nil ||
 		expired != 1 {
 		t.Fatalf("machine-unreachable expiry count=%d err=%v", expired, err)
@@ -1664,9 +1665,10 @@ func TestMachineUnreachableCandidatesUseLatestRuntimeRecency(t *testing.T) {
 		fixture.MachineID,
 		replacementRuntime.ID,
 	)
-	candidates, err := fixture.Store.q.ListMachineUnreachableMachineCandidates(
+	candidates, err := fixture.Store.q.ListProcessToolExpiryMachineCandidates(
 		ctx,
-		dbsqlc.ListMachineUnreachableMachineCandidatesParams{
+		dbsqlc.ListProcessToolExpiryMachineCandidatesParams{
+			QueueTimeoutSeconds:            int32(executionstore.ProcessQueueTimeout / time.Second),
 			MachineUnreachableGraceSeconds: int32(executionstore.ProcessToolMachineUnreachableGrace / time.Second),
 			LimitCount:                     10,
 		},
@@ -1677,9 +1679,10 @@ func TestMachineUnreachableCandidatesUseLatestRuntimeRecency(t *testing.T) {
 	if len(candidates) != 0 {
 		t.Fatalf("early candidates = %+v, want none because latest runtime is not past grace", candidates)
 	}
-	candidates, err = fixture.Store.q.ListMachineUnreachableMachineCandidates(
+	candidates, err = fixture.Store.q.ListProcessToolExpiryMachineCandidates(
 		ctx,
-		dbsqlc.ListMachineUnreachableMachineCandidatesParams{
+		dbsqlc.ListProcessToolExpiryMachineCandidatesParams{
+			QueueTimeoutSeconds:            int32(executionstore.ProcessQueueTimeout / time.Second),
 			MachineUnreachableGraceSeconds: 0,
 			LimitCount:                     10,
 		},
@@ -1729,9 +1732,10 @@ func TestMachineUnreachableCandidatesSkipEarlierWorkWithinLatestRuntimeGrace(t *
 	matureDisconnectedAt := expireDaemonRuntimeForTest(t, ctx, mature)
 	waitForDatabaseTime(t, ctx, recent.Store.pool, matureDisconnectedAt.Add(time.Second))
 	expireDaemonRuntimeForTest(t, ctx, recent)
-	candidates, err := recent.Store.q.ListMachineUnreachableMachineCandidates(
+	candidates, err := recent.Store.q.ListProcessToolExpiryMachineCandidates(
 		ctx,
-		dbsqlc.ListMachineUnreachableMachineCandidatesParams{
+		dbsqlc.ListProcessToolExpiryMachineCandidatesParams{
+			QueueTimeoutSeconds:            int32(executionstore.ProcessQueueTimeout / time.Second),
 			MachineUnreachableGraceSeconds: 1,
 			LimitCount:                     1,
 		},
@@ -1806,9 +1810,10 @@ func TestMachineUnreachableCandidatesIgnoreQueuedMutationsForTerminalProcess(t *
 		}
 	}
 	expireDaemonRuntimeForTest(t, ctx, fixture)
-	candidates, err := fixture.Store.q.ListMachineUnreachableMachineCandidates(
+	candidates, err := fixture.Store.q.ListProcessToolExpiryMachineCandidates(
 		ctx,
-		dbsqlc.ListMachineUnreachableMachineCandidatesParams{
+		dbsqlc.ListProcessToolExpiryMachineCandidatesParams{
+			QueueTimeoutSeconds:            int32(executionstore.ProcessQueueTimeout / time.Second),
 			MachineUnreachableGraceSeconds: 0,
 			LimitCount:                     10,
 		},

--- a/internal/storage/executionstore/process_queue_expiry_integration_test.go
+++ b/internal/storage/executionstore/process_queue_expiry_integration_test.go
@@ -1,0 +1,533 @@
+//go:build integration
+
+package executionstore_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/omnara-ai/omnara/internal/daemonprotocol"
+	"github.com/omnara-ai/omnara/internal/storage/executionstore"
+	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
+	"github.com/omnara-ai/omnara/internal/storage/storeerr"
+	"github.com/omnara-ai/omnara/internal/testutil/integrationdb"
+	"github.com/stretchr/testify/require"
+)
+
+func startQueuedExpiryProcess(
+	t *testing.T,
+	ctx context.Context,
+	fixture processDaemonFixture,
+) executionstore.ProcessRecord {
+	t.Helper()
+	toolID := createToolCallForProcessTest(t, ctx, fixture, t.Name(), "run_command")
+	return startQueuedExpiryProcessForTool(t, ctx, fixture, toolID)
+}
+
+func startQueuedExpiryProcessForTool(
+	t *testing.T,
+	ctx context.Context,
+	fixture processDaemonFixture,
+	toolID ID,
+) executionstore.ProcessRecord {
+	t.Helper()
+	process, err := startProcessForTest(ctx, fixture.Store, executionstore.ExecuteToolCallInput{
+		ProjectID: testProjectID, AgentID: fixture.AgentID, ToolCallID: toolID, RuntimeLockID: fixture.Lock.ID,
+	}, executionstore.CreateProcessInput{
+		AgentMachineBindingID: fixture.BindingID,
+		Command:               "true",
+		ShellSelector:         "sh",
+		Cwd:                   "/work",
+	})
+	require.NoError(t, err)
+	return process
+}
+
+func ageQueuedExpiryProcess(t *testing.T, ctx context.Context, fixture processDaemonFixture, processID ID) {
+	t.Helper()
+	_, err := fixture.Store.pool.Exec(
+		ctx,
+		`UPDATE processes SET created_at = statement_timestamp() - ($2::int * interval '1 second') WHERE id = $1`,
+		processID, int32((executionstore.ProcessQueueTimeout+time.Minute)/time.Second))
+	require.NoError(t, err)
+}
+
+func TestProcessOffersSkipExpiredQueueWithoutMaintenance(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newProcessDaemonFixture(t, ctx, t.Name())
+	ids := createToolCallBatchForProcessTest(t, ctx, fixture, t.Name(), []processToolCallBatchItem{
+		builtInProcessToolCallBatchItem("expired0", "run_command"),
+		builtInProcessToolCallBatchItem("expired1", "run_command"),
+		builtInProcessToolCallBatchItem("expired2", "run_command"),
+		builtInProcessToolCallBatchItem("expired3", "run_command"),
+		builtInProcessToolCallBatchItem("fresh", "run_command"),
+	})
+	var freshID ID
+	for index, toolID := range ids {
+		process := startQueuedExpiryProcessForTool(t, ctx, fixture, toolID)
+		if index < len(ids)-1 {
+			ageQueuedExpiryProcess(t, ctx, fixture, process.ID)
+		} else {
+			freshID = process.ID
+		}
+	}
+	input := executionstore.DaemonWorkInput{Authority: fixture.authority(), Limit: 4}
+	offers, err := fixture.Store.Execution().ListDaemonProcessOffers(ctx, input)
+	require.NoError(t, err)
+	require.Len(t, offers, 1)
+	require.Equal(t, freshID, offers[0].Process.ID)
+	_, granted, err := fixture.Store.Execution().AcceptDaemonProcess(ctx, executionstore.AcceptDaemonProcessInput{
+		Authority: fixture.authority(), ProcessID: freshID,
+	})
+	require.NoError(t, err)
+	require.True(t, granted)
+	offers, err = fixture.Store.Execution().ListDaemonProcessOffers(ctx, input)
+	require.NoError(t, err)
+	require.Empty(t, offers)
+}
+
+func TestProcessQueueExpiryReasonPrecedenceOnOfflineMachine(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name                 string
+		wakeFailure, overdue bool
+		reason               string
+	}{
+		{name: "maintenance_fresh", reason: executionstore.ProcessToolReasonMachineUnreachable},
+		{name: "maintenance_overdue", overdue: true, reason: executionstore.ProcessToolReasonQueueTimeout},
+		{name: "wake_failure_fresh", wakeFailure: true, reason: executionstore.ProcessToolReasonMachineUnreachable},
+		{
+			name: "wake_failure_overdue", wakeFailure: true, overdue: true,
+			reason: executionstore.ProcessToolReasonQueueTimeout,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := newProcessDaemonFixture(t, ctx, t.Name())
+			process := startQueuedExpiryProcess(t, ctx, fixture)
+			if tc.overdue {
+				ageQueuedExpiryProcess(t, ctx, fixture, process.ID)
+			}
+			expireDaemonRuntimeForTest(t, ctx, fixture)
+			if tc.wakeFailure {
+				failed, err := fixture.Store.Execution().FailQueuedProcessAfterWakeFailure(ctx, process)
+				require.NoError(t, err)
+				require.True(t, failed)
+			} else {
+				count, err := fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(ctx, 0)
+				require.NoError(t, err)
+				require.EqualValues(t, 1, count)
+			}
+			current, err := fixture.Store.Execution().GetProcess(ctx, testProjectID, fixture.AgentID, process.ID)
+			require.NoError(t, err)
+			require.Equal(t, tc.reason, current.StateReasonCode)
+			require.Nil(t, current.ExecutionGrantedAt)
+			tool, err := fixture.Store.Execution().GetToolCall(ctx, testProjectID, fixture.AgentID, process.ToolCallID)
+			require.NoError(t, err)
+			assertCompletedToolCallWithResult(t, fixture.Store, fixture.AgentID, tool, tc.reason)
+		})
+	}
+}
+
+func TestTerminalProcessReadRequiresGrantAndAvailableStorage(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name    string
+		granted bool
+		offline bool
+		reason  string
+	}{
+		{name: "unreachable", reason: executionstore.ProcessToolReasonMachineUnreachable},
+		{name: "canceled", reason: "agent_canceled_before_grant"},
+		{name: "queue_timeout", reason: executionstore.ProcessToolReasonQueueTimeout},
+		{name: "storage_exhausted", granted: true, reason: daemonprotocol.ProcessReasonMachineStorageExhausted},
+		{name: "granted", granted: true},
+		{name: "offline_unreachable", offline: true, reason: executionstore.ProcessToolReasonMachineUnreachable},
+		{name: "offline_canceled", offline: true, reason: "agent_canceled_before_grant"},
+		{name: "offline_queue_timeout", offline: true, reason: executionstore.ProcessToolReasonQueueTimeout},
+		{
+			name: "offline_storage_exhausted", offline: true, granted: true,
+			reason: daemonprotocol.ProcessReasonMachineStorageExhausted,
+		},
+		{name: "offline_granted", offline: true, granted: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := newProcessDaemonFixture(t, ctx, t.Name())
+			ids := createToolCallBatchForProcessTest(t, ctx, fixture, t.Name(), []processToolCallBatchItem{
+				builtInProcessToolCallBatchItem("process", "run_command"),
+				builtInProcessToolCallBatchItem("read", "read_process"),
+			})
+			process := startQueuedExpiryProcessForTool(t, ctx, fixture, ids[0])
+			if test.granted {
+				_, granted, err := fixture.Store.Execution().AcceptDaemonProcess(ctx, executionstore.AcceptDaemonProcessInput{
+					Authority: fixture.authority(), ProcessID: process.ID,
+				})
+				require.NoError(t, err)
+				require.True(t, granted)
+			}
+			_, err := fixture.Store.pool.Exec(ctx,
+				`UPDATE processes SET state = 'failed', state_reason_code = $2 WHERE id = $1`, process.ID, test.reason)
+			require.NoError(t, err)
+			if test.offline {
+				expireDaemonRuntimeForTest(t, ctx, fixture)
+			}
+			action, err := createProcessActionForTest(ctx, fixture.Store, executionstore.ExecuteToolCallInput{
+				ProjectID: testProjectID, AgentID: fixture.AgentID, ToolCallID: ids[1], RuntimeLockID: fixture.Lock.ID,
+			}, executionstore.CreateProcessActionInput{
+				ProcessID: process.ID, ActionKind: executionstore.ProcessActionKindRead, Payload: json.RawMessage(`{}`),
+			})
+			if test.granted && test.reason == "" && test.offline {
+				require.ErrorIs(t, err, storeerr.ErrNoOnlineDaemonRuntime)
+			} else if test.granted && test.reason == "" {
+				require.NoError(t, err)
+				require.Equal(t, executionstore.ProcessActionStateQueued, action.State)
+			} else {
+				require.ErrorIs(t, err, storeerr.ErrProcessTerminal)
+			}
+		})
+	}
+}
+
+func TestProcessQueueExpiryRecoversSteeringOnOnlineMachine(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newProcessDaemonFixture(t, ctx, t.Name())
+	process := startQueuedExpiryProcess(t, ctx, fixture)
+	ageQueuedExpiryProcess(t, ctx, fixture, process.ID)
+	require.NoError(
+		t,
+		fixture.Store.Execution().ReleaseAgentRuntimeLock(
+			ctx,
+			testProjectID,
+			fixture.AgentID,
+			fixture.Lock.ID))
+	steering, _, _, err := fixture.Store.Execution().CreateAgentContentInput(
+		ctx,
+		executionstore.CreateAgentContentInputInput{
+			ProjectID: testProjectID, AgentID: fixture.AgentID, Actor: mustOmnaraActorParams(t, fixture.UserID),
+			ContentBlocks: json.RawMessage(`[{"type":"text","text":"please continue"}]`),
+			DeliveryMode:  executionstore.DeliveryModeSteering, IdempotencyKey: t.Name(),
+		})
+	require.NoError(t, err)
+	var inputState string
+	require.NoError(
+		t,
+		fixture.Store.pool.QueryRow(
+			ctx,
+			`SELECT state FROM agent_inputs WHERE id=$1`,
+			steering.ID).Scan(&inputState))
+	require.Equal(t, "received", inputState)
+	for iteration, want := range []int64{1, 0} {
+		expired, expiryErr := fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(
+			ctx,
+			executionstore.ProcessToolMachineUnreachableGrace)
+		require.NoError(t, expiryErr)
+		require.Equal(t, want, expired, "sweep %d", iteration)
+	}
+	current, err := fixture.Store.Execution().GetProcess(ctx, testProjectID, fixture.AgentID, process.ID)
+	require.NoError(t, err)
+	require.Equal(t, executionstore.ProcessStateFailed, current.State)
+	require.Equal(t, executionstore.ProcessToolReasonQueueTimeout, current.StateReasonCode)
+	require.Nil(t, current.ExecutionGrantedAt)
+	require.Nil(t, current.SourceStartedAt)
+	require.Nil(t, current.SourceEndedAt)
+	require.Nil(t, current.ExitCode)
+	tool, err := fixture.Store.Execution().GetToolCall(ctx, testProjectID, fixture.AgentID, process.ToolCallID)
+	require.NoError(t, err)
+	assertCompletedToolCallWithResult(
+		t,
+		fixture.Store,
+		fixture.AgentID,
+		tool,
+		executionstore.ProcessToolReasonQueueTimeout)
+	work, found, err := fixture.Store.Execution().ClaimNextAgentWork(ctx, testClaimNextAgentWorkInput())
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, executionstore.AgentWorkModel, work.Kind)
+	require.NoError(
+		t,
+		fixture.Store.pool.QueryRow(
+			ctx,
+			`SELECT state FROM agent_inputs WHERE id=$1`,
+			steering.ID).Scan(&inputState))
+	require.Equal(t, "resolved", inputState)
+}
+
+func TestProcessQueueExpiryLeavesFreshGrantedAndCanceledWorkAlone(t *testing.T) {
+	t.Parallel()
+	for _, state := range []string{"fresh", "starting", "running", "canceled"} {
+		t.Run(state, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			fixture := newProcessDaemonFixture(t, ctx, t.Name())
+			process := startQueuedExpiryProcess(t, ctx, fixture)
+			if state == "starting" || state == "running" {
+				_, found, err := fixture.Store.Execution().AcceptDaemonProcess(
+					ctx,
+					executionstore.AcceptDaemonProcessInput{Authority: fixture.authority(),
+						ProcessID: process.ID})
+				require.NoError(t, err)
+				require.True(t, found)
+			}
+			if state == "running" {
+				_, err := fixture.Store.pool.Exec(
+					ctx,
+					`UPDATE processes SET state='running', source_started_at=statement_timestamp() WHERE id=$1`,
+					process.ID)
+				require.NoError(t, err)
+			}
+			if state != "fresh" {
+				ageQueuedExpiryProcess(t, ctx, fixture, process.ID)
+			}
+			if state == "canceled" {
+				cancelToolCallForTest(t, ctx, fixture.Store, fixture.AgentID, process.ToolCallID)
+			}
+			before, err := fixture.Store.Execution().GetProcess(ctx, testProjectID, fixture.AgentID, process.ID)
+			require.NoError(t, err)
+			expired, err := fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(
+				ctx,
+				executionstore.ProcessToolMachineUnreachableGrace)
+			require.NoError(t, err)
+			require.Zero(t, expired)
+			after, err := fixture.Store.Execution().GetProcess(ctx, testProjectID, fixture.AgentID, process.ID)
+			require.NoError(t, err)
+			require.Equal(t, before, after)
+		})
+	}
+}
+
+func TestProcessQueueExpiryRejectsLateAcceptanceAndPreservesResult(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newProcessDaemonFixture(t, ctx, t.Name())
+	process := startQueuedExpiryProcess(t, ctx, fixture)
+	ageQueuedExpiryProcess(t, ctx, fixture, process.ID)
+	_, found, err := fixture.Store.Execution().AcceptDaemonProcess(
+		ctx,
+		executionstore.AcceptDaemonProcessInput{Authority: fixture.authority(),
+			ProcessID: process.ID})
+	require.NoError(t, err)
+	require.False(t, found)
+	expired, err := fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(
+		ctx,
+		executionstore.ProcessToolMachineUnreachableGrace)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, expired)
+	before, found, err := fixture.Store.Execution().GetToolCallResultAuthorityByToolCall(
+		ctx,
+		testProjectID,
+		fixture.AgentID,
+		process.ToolCallID)
+	require.NoError(t, err)
+	require.True(t, found)
+	for range 2 {
+		report, reportErr := fixture.Store.Execution().CompleteDaemonProcess(
+			ctx,
+			executionstore.CompleteDaemonProcessInput{
+				Authority: fixture.authority(), ProjectID: testProjectID, AgentID: fixture.AgentID, ID: process.ID,
+				State: executionstore.ProcessStateFailed, StateReasonCode: daemonprotocol.ProcessReasonMachineStorageExhausted,
+				StateReasonMessage: daemonprotocol.ProcessMessageMachineStorageExhausted, StorageExhausted: true,
+			})
+		require.NoError(t, reportErr)
+		require.False(t, report.ToolResultCommitted)
+		require.Equal(t, executionstore.ProcessToolReasonQueueTimeout, report.Process.StateReasonCode)
+	}
+	after, found, err := fixture.Store.Execution().GetToolCallResultAuthorityByToolCall(
+		ctx,
+		testProjectID,
+		fixture.AgentID,
+		process.ToolCallID)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, before, after)
+	registration, err := fixture.Store.Execution().RegisterDaemonRuntimeWithReconciliation(
+		ctx,
+		executionstore.RegisterDaemonRuntimeInput{
+			OrgID: fixture.OrgID, MachineID: fixture.MachineID, DaemonTokenID: fixture.TokenID,
+			DaemonInstanceID: fixture.DaemonID, DaemonVersion: "1.0.0", LeaseTimeout: testDaemonRuntimeLeaseTimeout,
+			ProcessClaims: []executionstore.ProcessReconciliationClaim{{ProcessID: process.ID,
+				SupervisorInstanceID: "prepared-expired",
+				Phase:                daemonprotocol.ProcessPhasePrepared,
+				SupervisorLive:       true}},
+		})
+	require.NoError(t, err)
+	directive := processReconciliationDirectiveForTest(t, registration.Reconciliation, process.ID)
+	require.Equal(t, daemonprotocol.ProcessDispositionClosePreparation, directive.Disposition)
+	readTool := createToolCallForProcessActionTest(t, ctx, fixture, t.Name()+"_read")
+	_, err = createProcessActionForTest(ctx, fixture.Store, executionstore.ExecuteToolCallInput{
+		ProjectID: testProjectID, AgentID: fixture.AgentID, ToolCallID: readTool, RuntimeLockID: fixture.Lock.ID,
+	},
+		executionstore.CreateProcessActionInput{ProcessID: process.ID,
+			ActionKind: executionstore.ProcessActionKindRead,
+			Payload:    json.RawMessage(`{}`)})
+	require.ErrorIs(t, err, storeerr.ErrProcessTerminal)
+}
+
+func TestProcessQueueExpiryAcceptanceRechecksDeadlineAfterLock(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newProcessDaemonFixture(t, ctx, t.Name())
+	process := startQueuedExpiryProcess(t, ctx, fixture)
+	blocker, err := fixture.Store.pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = blocker.Rollback(ctx) }()
+	var pid int32
+	require.NoError(t, blocker.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&pid))
+	var deadline time.Time
+	require.NoError(
+		t,
+		blocker.QueryRow(
+			ctx,
+			`UPDATE processes
+SET created_at=statement_timestamp() - ($2::int * interval '1 second') + interval '1 second'
+WHERE id=$1
+RETURNING created_at + ($2::int * interval '1 second')`,
+			process.ID, int32(executionstore.ProcessQueueTimeout/time.Second)).Scan(&deadline))
+	type result struct {
+		found bool
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		_, found, acceptErr := fixture.Store.Execution().AcceptDaemonProcess(
+			ctx,
+			executionstore.AcceptDaemonProcessInput{Authority: fixture.authority(),
+				ProcessID: process.ID})
+		done <- result{found, acceptErr}
+	}()
+	integrationdb.WaitForLockWaitBlockedBy(t, ctx, fixture.Store.pool, "-- name: LockDaemonProcessForAccept", pid)
+	waitForDatabaseTime(t, ctx, fixture.Store.pool, deadline.Add(time.Millisecond))
+	require.NoError(t, blocker.Commit(ctx))
+	accepted := <-done
+	require.NoError(t, accepted.err)
+	require.False(t, accepted.found)
+	expired, err := fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(
+		ctx,
+		executionstore.ProcessToolMachineUnreachableGrace)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, expired)
+}
+
+func TestProcessQueueExpiryRechecksCancellationAfterMachineLock(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newProcessDaemonFixture(t, ctx, t.Name())
+	process := startQueuedExpiryProcess(t, ctx, fixture)
+	ageQueuedExpiryProcess(t, ctx, fixture, process.ID)
+	blocker, err := fixture.Store.pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = blocker.Rollback(ctx) }()
+	var pid int32
+	require.NoError(t, blocker.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&pid))
+	_,
+		err = dbsqlc.New(blocker).LockMachineForLifecycle(
+		ctx,
+		dbsqlc.LockMachineForLifecycleParams{OrgID: fixture.OrgID,
+			ID: fixture.MachineID})
+	require.NoError(t, err)
+	type result struct {
+		count int64
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		count, expiryErr := fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(
+			ctx,
+			executionstore.ProcessToolMachineUnreachableGrace)
+		done <- result{count, expiryErr}
+	}()
+	integrationdb.WaitForLockWaitBlockedBy(t, ctx, fixture.Store.pool, "-- name: LockMachineForLifecycle", pid)
+	cancelToolCallForTest(t, ctx, fixture.Store, fixture.AgentID, process.ToolCallID)
+	require.NoError(t, blocker.Commit(ctx))
+	expired := <-done
+	require.NoError(t, expired.err)
+	require.Zero(t, expired.count)
+}
+
+func TestProcessQueueExpiryOverridesActiveWakeDeadline(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newProviderRuntimeStorageFixture(t, ctx, "queue-expiry-wake", true)
+	machine := fixture.insertInactiveMachine(t, ctx, "queue-expiry-wake")
+	processFixture, processID, toolID := fixture.createQueuedProcess(t, ctx, machine, "queue-expiry-wake")
+	disposition, err := fixture.store.Execution().BeginMachineWake(
+		ctx,
+		testOrgID,
+		machine.machineID,
+		fixture.machinePool.ID,
+		time.Hour)
+	require.NoError(t, err)
+	require.Equal(t, executionstore.MachineWakeReady, disposition)
+	ageQueuedExpiryProcess(t, ctx, processFixture, processID)
+	expired, err := fixture.store.Execution().ExpireProcessToolCallsForAllProjects(
+		ctx,
+		executionstore.ProcessToolMachineUnreachableGrace)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, expired)
+	tool, err := fixture.store.Execution().GetToolCall(ctx, testProjectID, processFixture.AgentID, toolID)
+	require.NoError(t, err)
+	assertCompletedToolCallWithResult(
+		t,
+		fixture.store,
+		processFixture.AgentID,
+		tool,
+		executionstore.ProcessToolReasonQueueTimeout)
+}
+
+func TestProcessQueueExpiryOnlyExpiresOverdueQueuedWorkOnSelectedMachine(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fixture := newProcessDaemonFixture(t, ctx, t.Name())
+	ids := createToolCallBatchForProcessTest(t, ctx, fixture, t.Name(), []processToolCallBatchItem{
+		builtInProcessToolCallBatchItem("expired", "run_command"),
+		builtInProcessToolCallBatchItem("accepted", "run_command"),
+		builtInProcessToolCallBatchItem("fresh", "run_command"),
+		builtInProcessToolCallBatchItem("read", "read_process"),
+	})
+	var processes []executionstore.ProcessRecord
+	for _, toolID := range ids[:3] {
+		process := startQueuedExpiryProcessForTool(t, ctx, fixture, toolID)
+		processes = append(processes, process)
+	}
+	_, found, err := fixture.Store.Execution().AcceptDaemonProcess(ctx, executionstore.AcceptDaemonProcessInput{
+		Authority: fixture.authority(),
+		ProcessID: processes[1].ID,
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+	action, err := createProcessActionForTest(ctx, fixture.Store, executionstore.ExecuteToolCallInput{
+		ProjectID:     testProjectID,
+		AgentID:       fixture.AgentID,
+		ToolCallID:    ids[3],
+		RuntimeLockID: fixture.Lock.ID,
+	}, executionstore.CreateProcessActionInput{
+		ProcessID:  processes[1].ID,
+		ActionKind: executionstore.ProcessActionKindRead,
+		Payload:    json.RawMessage(`{}`),
+	})
+	require.NoError(t, err)
+	for _, process := range processes[:2] {
+		ageQueuedExpiryProcess(t, ctx, fixture, process.ID)
+	}
+	expired, err := fixture.Store.Execution().ExpireProcessToolCallsForAllProjects(
+		ctx, executionstore.ProcessToolMachineUnreachableGrace,
+	)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, expired)
+	for _, toolID := range ids[1:] {
+		tool, getErr := fixture.Store.Execution().GetToolCall(ctx, testProjectID, fixture.AgentID, toolID)
+		require.NoError(t, getErr)
+		require.Equal(t, executionstore.ToolCallState("waiting"), tool.State)
+	}
+	var state string
+	require.NoError(t, fixture.Store.pool.QueryRow(
+		ctx, `SELECT state FROM process_actions WHERE id=$1`, action.ID,
+	).Scan(&state))
+	require.Equal(t, "queued", state)
+}

--- a/internal/storage/executionstore/process_records.go
+++ b/internal/storage/executionstore/process_records.go
@@ -32,9 +32,11 @@ const (
 
 const (
 	ProcessToolReasonMachineUnreachable = "machine_unreachable"
+	ProcessToolReasonQueueTimeout       = "process_queue_timeout"
 )
 
 const ProcessToolMachineUnreachableGrace = 30 * time.Second
+const ProcessQueueTimeout = 5 * time.Minute
 
 type ProcessActionKind = processaction.Kind
 

--- a/internal/storage/executionstore/process_tool_unreachable_store.go
+++ b/internal/storage/executionstore/process_tool_unreachable_store.go
@@ -15,29 +15,30 @@ import (
 
 const processToolMachineUnreachableBatchSize int32 = 500
 
-func (s *Store) ExpireMachineUnreachableProcessToolCallsForAllProjects(
+func (s *Store) ExpireProcessToolCallsForAllProjects(
 	ctx context.Context,
 	grace time.Duration,
 ) (int64, error) {
 	graceSeconds := int32(grace / time.Second)
 	total := int64(0)
 	for {
-		candidates, err := s.q.ListMachineUnreachableMachineCandidates(
+		candidates, err := s.q.ListProcessToolExpiryMachineCandidates(
 			ctx,
-			dbsqlc.ListMachineUnreachableMachineCandidatesParams{
+			dbsqlc.ListProcessToolExpiryMachineCandidatesParams{
+				QueueTimeoutSeconds:            int32(ProcessQueueTimeout / time.Second),
 				MachineUnreachableGraceSeconds: graceSeconds,
 				LimitCount:                     processToolMachineUnreachableBatchSize,
 			},
 		)
 		if err != nil {
-			return total, fmt.Errorf("list machine-unreachable machine candidates: %w", err)
+			return total, fmt.Errorf("list process tool expiry machine candidates: %w", err)
 		}
 		if len(candidates) == 0 {
 			return total, nil
 		}
 		processed := int64(0)
 		for _, candidate := range candidates {
-			expired, err := s.expireMachineUnreachableProcessToolCallsForMachine(
+			expired, err := s.expireProcessToolCallsForMachine(
 				ctx,
 				candidate.OrgID,
 				candidate.MachineID,
@@ -55,16 +56,17 @@ func (s *Store) ExpireMachineUnreachableProcessToolCallsForAllProjects(
 	}
 }
 
-func (s *Store) expireMachineUnreachableProcessToolCallsForMachine(
+func (s *Store) expireProcessToolCallsForMachine(
 	ctx context.Context,
 	orgID, machineID ID,
 	graceSeconds int32,
 ) (int64, error) {
 	total := int64(0)
 	for {
-		queuedProcesses, err := s.q.ListMachineUnreachableQueuedProcessToolCallsForMachine(
+		queuedProcesses, err := s.q.ListExpirableQueuedProcessToolCallsForMachine(
 			ctx,
-			dbsqlc.ListMachineUnreachableQueuedProcessToolCallsForMachineParams{
+			dbsqlc.ListExpirableQueuedProcessToolCallsForMachineParams{
+				QueueTimeoutSeconds:            int32(ProcessQueueTimeout / time.Second),
 				OrgID:                          orgID,
 				MachineID:                      machineID,
 				MachineUnreachableGraceSeconds: graceSeconds,
@@ -72,7 +74,7 @@ func (s *Store) expireMachineUnreachableProcessToolCallsForMachine(
 			},
 		)
 		if err != nil {
-			return total, fmt.Errorf("list machine-unreachable queued process tool calls for machine: %w", err)
+			return total, fmt.Errorf("list expirable queued process tool calls for machine: %w", err)
 		}
 		acceptedProcesses, err := s.q.ListMachineUnreachableAcceptedProcessToolCallsForMachine(
 			ctx,
@@ -116,7 +118,7 @@ func (s *Store) expireMachineUnreachableProcessToolCallsForMachine(
 		}
 		for _, row := range queuedProcesses {
 			process := processRecordFromSQLC(row)
-			expired, err := s.failMachineUnreachableQueuedProcess(ctx, process, graceSeconds)
+			expired, err := s.expireQueuedProcessToolCall(ctx, process, graceSeconds)
 			if err != nil {
 				return total, err
 			}
@@ -173,7 +175,7 @@ func (s *Store) expireMachineUnreachableProcessToolCallsForMachine(
 	}
 }
 
-func (s *Store) failMachineUnreachableQueuedProcess(
+func (s *Store) expireQueuedProcessToolCall(
 	ctx context.Context,
 	process ProcessRecord,
 	graceSeconds int32,
@@ -181,7 +183,7 @@ func (s *Store) failMachineUnreachableQueuedProcess(
 	txNotifications := s.newTxNotifications()
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
-		return false, fmt.Errorf("begin machine-unreachable queued process expiry: %w", err)
+		return false, fmt.Errorf("begin queued process expiry: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 	qtx := dbsqlc.New(tx)
@@ -196,17 +198,6 @@ func (s *Store) failMachineUnreachableQueuedProcess(
 	if err != nil {
 		return false, err
 	}
-	if !unreachable {
-		if err := s.commitTxWithNotifications(
-			ctx,
-			tx,
-			txNotifications,
-			"skipped machine-unreachable queued process expiry",
-		); err != nil {
-			return false, err
-		}
-		return false, nil
-	}
 	if _, err := qtx.LockAgentInProject(
 		ctx,
 		dbsqlc.LockAgentInProjectParams{
@@ -214,17 +205,18 @@ func (s *Store) failMachineUnreachableQueuedProcess(
 			ID:        process.AgentID,
 		},
 	); err != nil {
-		return false, fmt.Errorf("lock agent for machine-unreachable queued process expiry: %w", err)
+		return false, fmt.Errorf("lock agent for queued process expiry: %w", err)
 	}
-	row, err := qtx.MarkQueuedProcessFailedByMachine(
+	row, err := qtx.ExpireQueuedProcessToolCall(
 		ctx,
-		dbsqlc.MarkQueuedProcessFailedByMachineParams{
-			ProjectID:       process.ProjectID,
-			AgentID:         process.AgentID,
-			ID:              process.ID,
-			OrgID:           process.OrgID,
-			MachineID:       process.MachineID,
-			StateReasonCode: sqlcTextFromEmpty(ProcessToolReasonMachineUnreachable),
+		dbsqlc.ExpireQueuedProcessToolCallParams{
+			ProjectID:           process.ProjectID,
+			AgentID:             process.AgentID,
+			ID:                  process.ID,
+			OrgID:               process.OrgID,
+			MachineID:           process.MachineID,
+			QueueTimeoutSeconds: int32(ProcessQueueTimeout / time.Second),
+			MachineUnreachable:  unreachable,
 		},
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -232,14 +224,14 @@ func (s *Store) failMachineUnreachableQueuedProcess(
 			ctx,
 			tx,
 			txNotifications,
-			"missed machine-unreachable queued process expiry",
+			"missed queued process expiry",
 		); err != nil {
 			return false, err
 		}
 		return false, nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("mark machine-unreachable queued process failed: %w", err)
+		return false, fmt.Errorf("mark queued process failed: %w", err)
 	}
 	record := processRecordFromSQLC(row)
 	if err := completeProcessToolCallFromRecordTx(
@@ -249,7 +241,7 @@ func (s *Store) failMachineUnreachableQueuedProcess(
 		qtx,
 		record,
 		nil,
-		ProcessToolReasonMachineUnreachable,
+		record.StateReasonCode,
 	); err != nil {
 		return false, err
 	}
@@ -257,7 +249,7 @@ func (s *Store) failMachineUnreachableQueuedProcess(
 		ctx,
 		tx,
 		txNotifications,
-		"machine-unreachable queued process expiry",
+		"queued process expiry",
 	); err != nil {
 		return false, err
 	}
@@ -272,7 +264,7 @@ func (s *Store) FailQueuedProcessAfterWakeFailure(
 		isNilID(process.AgentID) || isNilID(process.MachineID) {
 		return false, errors.New("process, org, project, agent, and machine are required")
 	}
-	return s.failMachineUnreachableQueuedProcess(ctx, process, 0)
+	return s.expireQueuedProcessToolCall(ctx, process, 0)
 }
 
 func (s *Store) FailQueuedProcessActionsAfterWakeFailure(

--- a/internal/storage/executionstore/provider_runtime_reconciliation_integration_test.go
+++ b/internal/storage/executionstore/provider_runtime_reconciliation_integration_test.go
@@ -1169,9 +1169,10 @@ func TestMachineWakeDeadlineProtectsQueuedWork(t *testing.T) {
 		t.Fatalf("begin machine wake = (%v, %v), want ready", disposition, err)
 	}
 	workQuery := dbsqlc.New(fixture.pool)
-	queuedDuringWake, err := workQuery.ListMachineUnreachableQueuedProcessToolCallsForMachine(
+	queuedDuringWake, err := workQuery.ListExpirableQueuedProcessToolCallsForMachine(
 		ctx,
-		dbsqlc.ListMachineUnreachableQueuedProcessToolCallsForMachineParams{
+		dbsqlc.ListExpirableQueuedProcessToolCallsForMachineParams{
+			QueueTimeoutSeconds:            int32(executionstore.ProcessQueueTimeout / time.Second),
 			OrgID:                          testOrgID,
 			MachineID:                      machine.machineID,
 			MachineUnreachableGraceSeconds: 0,
@@ -1187,7 +1188,7 @@ func TestMachineWakeDeadlineProtectsQueuedWork(t *testing.T) {
 	); err != nil || failed {
 		t.Fatalf("direct expiry during wake = (%t, %v), want false/nil", failed, err)
 	}
-	if expired, err := fixture.store.Execution().ExpireMachineUnreachableProcessToolCallsForAllProjects(
+	if expired, err := fixture.store.Execution().ExpireProcessToolCallsForAllProjects(
 		ctx,
 		0,
 	); err != nil || expired != 0 {
@@ -1200,9 +1201,10 @@ WHERE org_id = $1 AND id = $2
 `, testOrgID, machine.machineID); err != nil {
 		t.Fatalf("expire wake deadline: %v", err)
 	}
-	queuedAfterWake, err := workQuery.ListMachineUnreachableQueuedProcessToolCallsForMachine(
+	queuedAfterWake, err := workQuery.ListExpirableQueuedProcessToolCallsForMachine(
 		ctx,
-		dbsqlc.ListMachineUnreachableQueuedProcessToolCallsForMachineParams{
+		dbsqlc.ListExpirableQueuedProcessToolCallsForMachineParams{
+			QueueTimeoutSeconds:            int32(executionstore.ProcessQueueTimeout / time.Second),
 			OrgID:                          testOrgID,
 			MachineID:                      machine.machineID,
 			MachineUnreachableGraceSeconds: 0,
@@ -1212,7 +1214,7 @@ WHERE org_id = $1 AND id = $2
 	if err != nil || len(queuedAfterWake) != 1 {
 		t.Fatalf("queued work listed after wake = (%d, %v), want 1/nil", len(queuedAfterWake), err)
 	}
-	if expired, err := fixture.store.Execution().ExpireMachineUnreachableProcessToolCallsForAllProjects(
+	if expired, err := fixture.store.Execution().ExpireProcessToolCallsForAllProjects(
 		ctx,
 		0,
 	); err != nil || expired != 1 {
@@ -1285,7 +1287,7 @@ func TestRuntimeProtectionAndUnreachableExpiryConverge(t *testing.T) {
 			}
 			expireUnreachable := func(want int64) {
 				t.Helper()
-				expired, err := fixture.store.Execution().ExpireMachineUnreachableProcessToolCallsForAllProjects(
+				expired, err := fixture.store.Execution().ExpireProcessToolCallsForAllProjects(
 					ctx,
 					0,
 				)

--- a/internal/storage/internal/dbsqlc/process_actions.sql.go
+++ b/internal/storage/internal/dbsqlc/process_actions.sql.go
@@ -386,6 +386,8 @@ func (q *Queries) GetProcessActionByToolCall(ctx context.Context, arg GetProcess
 
 const getProcessActionCreateBlocker = `-- name: GetProcessActionCreateBlocker :one
 SELECT process.state,
+  coalesce(process.execution_granted_at IS NOT NULL
+    AND process.state_reason_code IS DISTINCT FROM 'machine_storage_exhausted', false)::boolean AS terminal_read_supported,
   EXISTS (
     SELECT 1
     FROM process_actions terminate_action
@@ -414,15 +416,21 @@ type GetProcessActionCreateBlockerParams struct {
 }
 
 type GetProcessActionCreateBlockerRow struct {
-	State              string
-	HasTerminateAction bool
-	HasOnlineRuntime   bool
+	State                 string
+	TerminalReadSupported bool
+	HasTerminateAction    bool
+	HasOnlineRuntime      bool
 }
 
 func (q *Queries) GetProcessActionCreateBlocker(ctx context.Context, arg GetProcessActionCreateBlockerParams) (GetProcessActionCreateBlockerRow, error) {
 	row := q.db.QueryRow(ctx, getProcessActionCreateBlocker, arg.ProjectID, arg.AgentID, arg.ProcessID)
 	var i GetProcessActionCreateBlockerRow
-	err := row.Scan(&i.State, &i.HasTerminateAction, &i.HasOnlineRuntime)
+	err := row.Scan(
+		&i.State,
+		&i.TerminalReadSupported,
+		&i.HasTerminateAction,
+		&i.HasOnlineRuntime,
+	)
 	return i, err
 }
 
@@ -508,6 +516,7 @@ target AS MATERIALIZED (
         AND $3::text = 'read'
         AND process.state IN ('exited', 'failed', 'killed', 'unknown')
         AND process.state_reason_code IS DISTINCT FROM 'machine_storage_exhausted'
+        AND process.execution_granted_at IS NOT NULL
       )
     )
     AND (

--- a/internal/storage/internal/dbsqlc/process_tool_unreachable.sql.go
+++ b/internal/storage/internal/dbsqlc/process_tool_unreachable.sql.go
@@ -57,6 +57,208 @@ func (q *Queries) CheckMachineUnreachableForToolExpiry(ctx context.Context, arg 
 	return unreachable, err
 }
 
+const expireQueuedProcessToolCall = `-- name: ExpireQueuedProcessToolCall :one
+WITH cutoff AS (
+  SELECT statement_timestamp() - ($7::int * interval '1 second') AS queued_before
+)
+UPDATE processes process
+SET state = 'failed',
+    state_reason_code = CASE
+      WHEN process.created_at <= cutoff.queued_before
+      THEN 'process_queue_timeout'
+      ELSE 'machine_unreachable'
+    END,
+    state_reason_message = CASE
+      WHEN process.created_at <= cutoff.queued_before
+      THEN 'machine did not accept the command before its queue deadline; execution was not granted'
+      ELSE ''
+    END,
+    state_changed_at = statement_timestamp(),
+    updated_at = statement_timestamp()
+FROM cutoff
+WHERE process.project_id = $1
+  AND process.agent_id = $2
+  AND process.id = $3
+  AND process.org_id = $4
+  AND process.machine_id = $5
+  AND process.state = 'queued'
+  AND (
+    process.created_at <= cutoff.queued_before
+    OR $6::boolean
+  )
+  AND EXISTS (
+    SELECT 1 FROM machines machine
+    WHERE machine.org_id = process.org_id AND machine.id = process.machine_id
+      AND machine.lifecycle_state = 'active' AND machine.deleted_at IS NULL
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM tool_calls tool_call
+    WHERE tool_call.agent_id = process.agent_id
+      AND tool_call.id = process.tool_call_id
+      AND tool_call.type = 'built_in'
+      AND tool_call.state = 'waiting'
+  )
+RETURNING process.id, process.org_id, process.project_id, process.agent_id, process.tool_call_id, process.runtime_lock_id, process.agent_machine_binding_id, process.machine_id, process.execution_granted_at, process.io_mode, process.command, process.shell_selector, process.cwd, process.env, process.secret_env, process.timeout_seconds, process.initial_wait_ms, process.default_output_cursor, process.state, process.state_reason_code, process.state_reason_message, process.source_started_at, process.source_ended_at, process.state_changed_at, process.exit_code, process.exit_signal, process.created_at, process.updated_at, process.last_activity_at
+`
+
+type ExpireQueuedProcessToolCallParams struct {
+	ProjectID           uuid.UUID
+	AgentID             uuid.UUID
+	ID                  uuid.UUID
+	OrgID               uuid.UUID
+	MachineID           uuid.UUID
+	MachineUnreachable  bool
+	QueueTimeoutSeconds int32
+}
+
+func (q *Queries) ExpireQueuedProcessToolCall(ctx context.Context, arg ExpireQueuedProcessToolCallParams) (Process, error) {
+	row := q.db.QueryRow(ctx, expireQueuedProcessToolCall,
+		arg.ProjectID,
+		arg.AgentID,
+		arg.ID,
+		arg.OrgID,
+		arg.MachineID,
+		arg.MachineUnreachable,
+		arg.QueueTimeoutSeconds,
+	)
+	var i Process
+	err := row.Scan(
+		&i.ID,
+		&i.OrgID,
+		&i.ProjectID,
+		&i.AgentID,
+		&i.ToolCallID,
+		&i.RuntimeLockID,
+		&i.AgentMachineBindingID,
+		&i.MachineID,
+		&i.ExecutionGrantedAt,
+		&i.IoMode,
+		&i.Command,
+		&i.ShellSelector,
+		&i.Cwd,
+		&i.Env,
+		&i.SecretEnv,
+		&i.TimeoutSeconds,
+		&i.InitialWaitMs,
+		&i.DefaultOutputCursor,
+		&i.State,
+		&i.StateReasonCode,
+		&i.StateReasonMessage,
+		&i.SourceStartedAt,
+		&i.SourceEndedAt,
+		&i.StateChangedAt,
+		&i.ExitCode,
+		&i.ExitSignal,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.LastActivityAt,
+	)
+	return i, err
+}
+
+const listExpirableQueuedProcessToolCallsForMachine = `-- name: ListExpirableQueuedProcessToolCallsForMachine :many
+SELECT process.id, process.org_id, process.project_id, process.agent_id, process.tool_call_id, process.runtime_lock_id, process.agent_machine_binding_id, process.machine_id, process.execution_granted_at, process.io_mode, process.command, process.shell_selector, process.cwd, process.env, process.secret_env, process.timeout_seconds, process.initial_wait_ms, process.default_output_cursor, process.state, process.state_reason_code, process.state_reason_message, process.source_started_at, process.source_ended_at, process.state_changed_at, process.exit_code, process.exit_signal, process.created_at, process.updated_at, process.last_activity_at
+FROM processes process
+JOIN tool_calls tool_call ON tool_call.agent_id = process.agent_id
+  AND tool_call.id = process.tool_call_id
+JOIN machines machine ON machine.org_id = process.org_id
+  AND machine.id = process.machine_id
+LEFT JOIN LATERAL (
+  SELECT runtime.effective_end_at AS unreachable_at
+  FROM daemon_runtime_connection_facts runtime
+  WHERE runtime.org_id = process.org_id
+    AND runtime.machine_id = process.machine_id
+  ORDER BY runtime.effective_end_at DESC, runtime.id DESC
+  LIMIT 1
+) latest_runtime ON true
+LEFT JOIN online_daemon_runtimes online ON online.org_id = process.org_id
+  AND online.machine_id = process.machine_id
+WHERE process.org_id = $1
+  AND process.machine_id = $2
+  AND process.state = 'queued'
+  AND process.tool_call_id IS NOT NULL
+  AND tool_call.type = 'built_in'
+  AND tool_call.state = 'waiting'
+  AND machine.lifecycle_state = 'active'
+  AND machine.deleted_at IS NULL
+  AND (
+    process.created_at <= transaction_timestamp() - ($3::int * interval '1 second')
+    OR (
+      (machine.wake_attempt_expires_at IS NULL
+        OR machine.wake_attempt_expires_at <= transaction_timestamp())
+      AND online.id IS NULL
+      AND greatest(latest_runtime.unreachable_at, process.created_at) <= transaction_timestamp() - ($4::int * interval '1 second')
+    )
+  )
+ORDER BY process.created_at, process.id
+LIMIT $5
+`
+
+type ListExpirableQueuedProcessToolCallsForMachineParams struct {
+	OrgID                          uuid.UUID
+	MachineID                      uuid.UUID
+	QueueTimeoutSeconds            int32
+	MachineUnreachableGraceSeconds int32
+	LimitCount                     int32
+}
+
+func (q *Queries) ListExpirableQueuedProcessToolCallsForMachine(ctx context.Context, arg ListExpirableQueuedProcessToolCallsForMachineParams) ([]Process, error) {
+	rows, err := q.db.Query(ctx, listExpirableQueuedProcessToolCallsForMachine,
+		arg.OrgID,
+		arg.MachineID,
+		arg.QueueTimeoutSeconds,
+		arg.MachineUnreachableGraceSeconds,
+		arg.LimitCount,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Process{}
+	for rows.Next() {
+		var i Process
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrgID,
+			&i.ProjectID,
+			&i.AgentID,
+			&i.ToolCallID,
+			&i.RuntimeLockID,
+			&i.AgentMachineBindingID,
+			&i.MachineID,
+			&i.ExecutionGrantedAt,
+			&i.IoMode,
+			&i.Command,
+			&i.ShellSelector,
+			&i.Cwd,
+			&i.Env,
+			&i.SecretEnv,
+			&i.TimeoutSeconds,
+			&i.InitialWaitMs,
+			&i.DefaultOutputCursor,
+			&i.State,
+			&i.StateReasonCode,
+			&i.StateReasonMessage,
+			&i.SourceStartedAt,
+			&i.SourceEndedAt,
+			&i.StateChangedAt,
+			&i.ExitCode,
+			&i.ExitSignal,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.LastActivityAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listMachineUnreachableAcceptedProcessActionToolCallsForMachine = `-- name: ListMachineUnreachableAcceptedProcessActionToolCallsForMachine :many
 SELECT action.id, action.org_id, action.project_id, action.agent_id, action.process_id, action.tool_call_id, action.runtime_lock_id, action.action_kind, action.seq, action.payload, action.state, action.created_at, action.updated_at, action.state_reason_code, action.state_reason_message
 FROM process_actions action
@@ -239,157 +441,6 @@ func (q *Queries) ListMachineUnreachableAcceptedProcessToolCallsForMachine(ctx c
 	return items, nil
 }
 
-const listMachineUnreachableMachineCandidates = `-- name: ListMachineUnreachableMachineCandidates :many
-WITH cutoff AS MATERIALIZED (
-  SELECT transaction_timestamp() AS observed_at,
-         transaction_timestamp()
-           - ($2::int * interval '1 second') AS unreachable_before
-), process_work AS MATERIALIZED (
-  SELECT process.org_id, process.machine_id, process.created_at AS work_at
-  FROM processes process
-  JOIN tool_calls tool_call ON tool_call.agent_id = process.agent_id
-    AND tool_call.id = process.tool_call_id
-  JOIN machines machine ON machine.org_id = process.org_id
-    AND machine.id = process.machine_id
-  LEFT JOIN LATERAL (
-    SELECT runtime.effective_end_at AS unreachable_at
-    FROM daemon_runtime_connection_facts runtime
-    WHERE runtime.org_id = process.org_id
-      AND runtime.machine_id = process.machine_id
-    ORDER BY runtime.effective_end_at DESC, runtime.id DESC
-    LIMIT 1
-  ) latest_runtime ON true
-  CROSS JOIN cutoff
-  WHERE process.state IN ('queued', 'starting', 'running')
-    AND process.created_at <= cutoff.unreachable_before
-    AND coalesce(latest_runtime.unreachable_at, process.created_at) <= cutoff.unreachable_before
-    AND tool_call.type = 'built_in'
-    AND tool_call.state = 'waiting'
-    AND machine.lifecycle_state = 'active'
-    AND machine.deleted_at IS NULL
-    AND (
-      machine.wake_attempt_expires_at IS NULL
-      OR machine.wake_attempt_expires_at <= cutoff.observed_at
-    )
-    AND NOT EXISTS (
-      SELECT 1
-      FROM online_daemon_runtimes online
-      WHERE online.org_id = process.org_id
-        AND online.machine_id = process.machine_id
-    )
-  ORDER BY process.created_at, process.id
-  LIMIT $1
-), action_work AS MATERIALIZED (
-  SELECT action.org_id, process.machine_id, action.created_at AS work_at
-  FROM process_actions action
-  JOIN processes process ON process.org_id = action.org_id
-    AND process.project_id = action.project_id
-    AND process.agent_id = action.agent_id
-    AND process.id = action.process_id
-  JOIN tool_calls tool_call ON tool_call.agent_id = action.agent_id
-    AND tool_call.id = action.tool_call_id
-  JOIN machines machine ON machine.org_id = action.org_id
-    AND machine.id = process.machine_id
-  LEFT JOIN LATERAL (
-    SELECT runtime.effective_end_at AS unreachable_at
-    FROM daemon_runtime_connection_facts runtime
-    WHERE runtime.org_id = action.org_id
-      AND runtime.machine_id = process.machine_id
-    ORDER BY runtime.effective_end_at DESC, runtime.id DESC
-    LIMIT 1
-  ) latest_runtime ON true
-  CROSS JOIN cutoff
-  WHERE action.state IN ('queued', 'accepted')
-    AND action.created_at <= cutoff.unreachable_before
-    AND coalesce(latest_runtime.unreachable_at, action.created_at) <= cutoff.unreachable_before
-    AND (
-      action.state = 'accepted'
-      OR process.state IN ('starting', 'running')
-      OR (
-        action.action_kind = 'read'
-        AND process.state IN ('exited', 'failed', 'killed', 'unknown')
-      )
-    )
-    AND tool_call.type = 'built_in'
-    AND tool_call.state = 'waiting'
-    AND machine.lifecycle_state = 'active'
-    AND machine.deleted_at IS NULL
-    AND (
-      machine.wake_attempt_expires_at IS NULL
-      OR machine.wake_attempt_expires_at <= cutoff.observed_at
-    )
-    AND NOT EXISTS (
-      SELECT 1
-      FROM online_daemon_runtimes online
-      WHERE online.org_id = action.org_id
-        AND online.machine_id = process.machine_id
-    )
-  ORDER BY action.created_at, action.id
-  LIMIT $1
-), machine_work AS MATERIALIZED (
-  SELECT work.org_id, work.machine_id, min(work.work_at)::timestamptz AS earliest_work_at
-  FROM (
-    SELECT org_id, machine_id, work_at FROM process_work
-    UNION ALL
-    SELECT org_id, machine_id, work_at FROM action_work
-  ) work
-  GROUP BY work.org_id, work.machine_id
-), candidates AS (
-  SELECT work.org_id,
-         work.machine_id,
-         greatest(
-           work.earliest_work_at,
-           coalesce(latest_runtime.unreachable_at, work.earliest_work_at)
-         )::timestamptz AS unreachable_at
-  FROM machine_work work
-  LEFT JOIN LATERAL (
-    SELECT runtime.effective_end_at AS unreachable_at
-    FROM daemon_runtime_connection_facts runtime
-    WHERE runtime.org_id = work.org_id
-      AND runtime.machine_id = work.machine_id
-    ORDER BY runtime.effective_end_at DESC, runtime.id DESC
-    LIMIT 1
-  ) latest_runtime ON true
-)
-SELECT candidates.org_id, candidates.machine_id, candidates.unreachable_at
-FROM candidates
-CROSS JOIN cutoff
-WHERE candidates.unreachable_at <= cutoff.unreachable_before
-ORDER BY candidates.unreachable_at, candidates.org_id, candidates.machine_id
-LIMIT $1
-`
-
-type ListMachineUnreachableMachineCandidatesParams struct {
-	LimitCount                     int32
-	MachineUnreachableGraceSeconds int32
-}
-
-type ListMachineUnreachableMachineCandidatesRow struct {
-	OrgID         uuid.UUID
-	MachineID     uuid.UUID
-	UnreachableAt time.Time
-}
-
-func (q *Queries) ListMachineUnreachableMachineCandidates(ctx context.Context, arg ListMachineUnreachableMachineCandidatesParams) ([]ListMachineUnreachableMachineCandidatesRow, error) {
-	rows, err := q.db.Query(ctx, listMachineUnreachableMachineCandidates, arg.LimitCount, arg.MachineUnreachableGraceSeconds)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []ListMachineUnreachableMachineCandidatesRow{}
-	for rows.Next() {
-		var i ListMachineUnreachableMachineCandidatesRow
-		if err := rows.Scan(&i.OrgID, &i.MachineID, &i.UnreachableAt); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listMachineUnreachableQueuedProcessActionToolCallsForMachine = `-- name: ListMachineUnreachableQueuedProcessActionToolCallsForMachine :many
 SELECT action.id, action.org_id, action.project_id, action.agent_id, action.process_id, action.tool_call_id, action.runtime_lock_id, action.action_kind, action.seq, action.payload, action.state, action.created_at, action.updated_at, action.state_reason_code, action.state_reason_message
 FROM process_actions action
@@ -482,93 +533,143 @@ func (q *Queries) ListMachineUnreachableQueuedProcessActionToolCallsForMachine(c
 	return items, nil
 }
 
-const listMachineUnreachableQueuedProcessToolCallsForMachine = `-- name: ListMachineUnreachableQueuedProcessToolCallsForMachine :many
-SELECT process.id, process.org_id, process.project_id, process.agent_id, process.tool_call_id, process.runtime_lock_id, process.agent_machine_binding_id, process.machine_id, process.execution_granted_at, process.io_mode, process.command, process.shell_selector, process.cwd, process.env, process.secret_env, process.timeout_seconds, process.initial_wait_ms, process.default_output_cursor, process.state, process.state_reason_code, process.state_reason_message, process.source_started_at, process.source_ended_at, process.state_changed_at, process.exit_code, process.exit_signal, process.created_at, process.updated_at, process.last_activity_at
-FROM processes process
-JOIN tool_calls tool_call ON tool_call.agent_id = process.agent_id
-  AND tool_call.id = process.tool_call_id
-JOIN machines machine ON machine.org_id = process.org_id
-  AND machine.id = process.machine_id
-LEFT JOIN LATERAL (
-  SELECT runtime.effective_end_at AS unreachable_at
-  FROM daemon_runtime_connection_facts runtime
-  WHERE runtime.org_id = process.org_id
-    AND runtime.machine_id = process.machine_id
-  ORDER BY runtime.effective_end_at DESC, runtime.id DESC
-  LIMIT 1
-) latest_runtime ON true
-LEFT JOIN online_daemon_runtimes online ON online.org_id = process.org_id
-  AND online.machine_id = process.machine_id
-WHERE process.org_id = $1
-  AND process.machine_id = $2
-  AND process.state = 'queued'
-  AND process.tool_call_id IS NOT NULL
-  AND tool_call.type = 'built_in'
-  AND tool_call.state = 'waiting'
-  AND machine.lifecycle_state = 'active'
-  AND machine.deleted_at IS NULL
-  AND (
-    machine.wake_attempt_expires_at IS NULL
-    OR machine.wake_attempt_expires_at <= transaction_timestamp()
-  )
-  AND online.id IS NULL
-  AND greatest(latest_runtime.unreachable_at, process.created_at) <= transaction_timestamp() - ($3::int * interval '1 second')
-ORDER BY process.created_at, process.id
-LIMIT $4
+const listProcessToolExpiryMachineCandidates = `-- name: ListProcessToolExpiryMachineCandidates :many
+WITH cutoff AS MATERIALIZED (
+  SELECT transaction_timestamp() AS observed_at,
+         transaction_timestamp()
+           - ($2::int * interval '1 second') AS unreachable_before,
+         transaction_timestamp()
+           - ($3::int * interval '1 second') AS queued_before
+), process_work AS MATERIALIZED (
+  SELECT process.org_id, process.machine_id,
+         CASE
+           WHEN process.state = 'queued' AND process.created_at <= cutoff.queued_before
+           THEN process.created_at + ($3::int * interval '1 second')
+           ELSE greatest(process.created_at, latest_runtime.unreachable_at)
+             + ($2::int * interval '1 second')
+         END AS expires_at
+  FROM processes process
+  JOIN tool_calls tool_call ON tool_call.agent_id = process.agent_id
+    AND tool_call.id = process.tool_call_id
+  JOIN machines machine ON machine.org_id = process.org_id
+    AND machine.id = process.machine_id
+  LEFT JOIN LATERAL (
+    SELECT runtime.effective_end_at AS unreachable_at
+    FROM daemon_runtime_connection_facts runtime
+    WHERE runtime.org_id = process.org_id
+      AND runtime.machine_id = process.machine_id
+    ORDER BY runtime.effective_end_at DESC, runtime.id DESC
+    LIMIT 1
+  ) latest_runtime ON true
+  CROSS JOIN cutoff
+  WHERE process.state IN ('queued', 'starting', 'running')
+    AND process.created_at <= greatest(cutoff.unreachable_before, cutoff.queued_before)
+    AND tool_call.type = 'built_in'
+    AND tool_call.state = 'waiting'
+    AND machine.lifecycle_state = 'active'
+    AND machine.deleted_at IS NULL
+    AND (
+      (process.state = 'queued'
+        AND process.created_at <= cutoff.queued_before)
+      OR (
+        process.created_at <= cutoff.unreachable_before
+        AND coalesce(latest_runtime.unreachable_at, process.created_at) <= cutoff.unreachable_before
+        AND (machine.wake_attempt_expires_at IS NULL
+          OR machine.wake_attempt_expires_at <= cutoff.observed_at)
+        AND NOT EXISTS (
+          SELECT 1 FROM online_daemon_runtimes online
+          WHERE online.org_id = process.org_id AND online.machine_id = process.machine_id
+        )
+      )
+    )
+  ORDER BY process.created_at, process.id
+  LIMIT $1
+), action_work AS MATERIALIZED (
+  SELECT action.org_id, process.machine_id,
+         greatest(action.created_at, latest_runtime.unreachable_at)
+           + ($2::int * interval '1 second') AS expires_at
+  FROM process_actions action
+  JOIN processes process ON process.org_id = action.org_id
+    AND process.project_id = action.project_id
+    AND process.agent_id = action.agent_id
+    AND process.id = action.process_id
+  JOIN tool_calls tool_call ON tool_call.agent_id = action.agent_id
+    AND tool_call.id = action.tool_call_id
+  JOIN machines machine ON machine.org_id = action.org_id
+    AND machine.id = process.machine_id
+  LEFT JOIN LATERAL (
+    SELECT runtime.effective_end_at AS unreachable_at
+    FROM daemon_runtime_connection_facts runtime
+    WHERE runtime.org_id = action.org_id
+      AND runtime.machine_id = process.machine_id
+    ORDER BY runtime.effective_end_at DESC, runtime.id DESC
+    LIMIT 1
+  ) latest_runtime ON true
+  CROSS JOIN cutoff
+  WHERE action.state IN ('queued', 'accepted')
+    AND action.created_at <= cutoff.unreachable_before
+    AND coalesce(latest_runtime.unreachable_at, action.created_at) <= cutoff.unreachable_before
+    AND (
+      action.state = 'accepted'
+      OR process.state IN ('starting', 'running')
+      OR (
+        action.action_kind = 'read'
+        AND process.state IN ('exited', 'failed', 'killed', 'unknown')
+      )
+    )
+    AND tool_call.type = 'built_in'
+    AND tool_call.state = 'waiting'
+    AND machine.lifecycle_state = 'active'
+    AND machine.deleted_at IS NULL
+    AND (
+      machine.wake_attempt_expires_at IS NULL
+      OR machine.wake_attempt_expires_at <= cutoff.observed_at
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM online_daemon_runtimes online
+      WHERE online.org_id = action.org_id
+        AND online.machine_id = process.machine_id
+    )
+  ORDER BY action.created_at, action.id
+  LIMIT $1
+), machine_work AS (
+  SELECT work.org_id, work.machine_id, min(work.expires_at)::timestamptz AS expires_at
+  FROM (
+    SELECT org_id, machine_id, expires_at FROM process_work
+    UNION ALL
+    SELECT org_id, machine_id, expires_at FROM action_work
+  ) work
+  GROUP BY work.org_id, work.machine_id
+)
+SELECT org_id, machine_id, expires_at
+FROM machine_work
+ORDER BY expires_at, org_id, machine_id
+LIMIT $1
 `
 
-type ListMachineUnreachableQueuedProcessToolCallsForMachineParams struct {
-	OrgID                          uuid.UUID
-	MachineID                      uuid.UUID
-	MachineUnreachableGraceSeconds int32
+type ListProcessToolExpiryMachineCandidatesParams struct {
 	LimitCount                     int32
+	MachineUnreachableGraceSeconds int32
+	QueueTimeoutSeconds            int32
 }
 
-func (q *Queries) ListMachineUnreachableQueuedProcessToolCallsForMachine(ctx context.Context, arg ListMachineUnreachableQueuedProcessToolCallsForMachineParams) ([]Process, error) {
-	rows, err := q.db.Query(ctx, listMachineUnreachableQueuedProcessToolCallsForMachine,
-		arg.OrgID,
-		arg.MachineID,
-		arg.MachineUnreachableGraceSeconds,
-		arg.LimitCount,
-	)
+type ListProcessToolExpiryMachineCandidatesRow struct {
+	OrgID     uuid.UUID
+	MachineID uuid.UUID
+	ExpiresAt time.Time
+}
+
+func (q *Queries) ListProcessToolExpiryMachineCandidates(ctx context.Context, arg ListProcessToolExpiryMachineCandidatesParams) ([]ListProcessToolExpiryMachineCandidatesRow, error) {
+	rows, err := q.db.Query(ctx, listProcessToolExpiryMachineCandidates, arg.LimitCount, arg.MachineUnreachableGraceSeconds, arg.QueueTimeoutSeconds)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []Process{}
+	items := []ListProcessToolExpiryMachineCandidatesRow{}
 	for rows.Next() {
-		var i Process
-		if err := rows.Scan(
-			&i.ID,
-			&i.OrgID,
-			&i.ProjectID,
-			&i.AgentID,
-			&i.ToolCallID,
-			&i.RuntimeLockID,
-			&i.AgentMachineBindingID,
-			&i.MachineID,
-			&i.ExecutionGrantedAt,
-			&i.IoMode,
-			&i.Command,
-			&i.ShellSelector,
-			&i.Cwd,
-			&i.Env,
-			&i.SecretEnv,
-			&i.TimeoutSeconds,
-			&i.InitialWaitMs,
-			&i.DefaultOutputCursor,
-			&i.State,
-			&i.StateReasonCode,
-			&i.StateReasonMessage,
-			&i.SourceStartedAt,
-			&i.SourceEndedAt,
-			&i.StateChangedAt,
-			&i.ExitCode,
-			&i.ExitSignal,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.LastActivityAt,
-		); err != nil {
+		var i ListProcessToolExpiryMachineCandidatesRow
+		if err := rows.Scan(&i.OrgID, &i.MachineID, &i.ExpiresAt); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/storage/internal/dbsqlc/processes.sql.go
+++ b/internal/storage/internal/dbsqlc/processes.sql.go
@@ -17,10 +17,10 @@ const acceptDaemonProcess = `-- name: AcceptDaemonProcess :one
 WITH runtime AS MATERIALIZED (
   SELECT runtime.org_id, runtime.machine_id
   FROM online_daemon_runtimes runtime
-  WHERE runtime.id = $2::uuid
-    AND runtime.org_id = $3
-    AND runtime.machine_id = $4
-    AND runtime.daemon_token_id = $5::uuid
+  WHERE runtime.id = $3::uuid
+    AND runtime.org_id = $4
+    AND runtime.machine_id = $5
+    AND runtime.daemon_token_id = $6::uuid
 )
 UPDATE processes process
 SET execution_granted_at = statement_timestamp(),
@@ -33,6 +33,7 @@ WHERE process.org_id = runtime.org_id
   AND process.machine_id = runtime.machine_id
   AND process.id = $1
   AND process.state = 'queued'
+  AND process.created_at > statement_timestamp() - ($2::int * interval '1 second')
   AND EXISTS (
     SELECT 1
     FROM agent_machine_bindings binding
@@ -48,11 +49,12 @@ RETURNING process.id, process.org_id, process.project_id, process.agent_id, proc
 `
 
 type AcceptDaemonProcessParams struct {
-	ProcessID       uuid.UUID
-	DaemonRuntimeID uuid.UUID
-	OrgID           uuid.UUID
-	MachineID       uuid.UUID
-	DaemonTokenID   uuid.UUID
+	ProcessID           uuid.UUID
+	QueueTimeoutSeconds int32
+	DaemonRuntimeID     uuid.UUID
+	OrgID               uuid.UUID
+	MachineID           uuid.UUID
+	DaemonTokenID       uuid.UUID
 }
 
 type AcceptDaemonProcessRow struct {
@@ -87,6 +89,7 @@ type AcceptDaemonProcessRow struct {
 func (q *Queries) AcceptDaemonProcess(ctx context.Context, arg AcceptDaemonProcessParams) (AcceptDaemonProcessRow, error) {
 	row := q.db.QueryRow(ctx, acceptDaemonProcess,
 		arg.ProcessID,
+		arg.QueueTimeoutSeconds,
 		arg.DaemonRuntimeID,
 		arg.OrgID,
 		arg.MachineID,
@@ -1128,10 +1131,10 @@ const listDaemonProcessOffers = `-- name: ListDaemonProcessOffers :many
 WITH runtime AS MATERIALIZED (
   SELECT runtime.org_id, runtime.machine_id
   FROM online_daemon_runtimes runtime
-  WHERE runtime.id = $4::uuid
+  WHERE runtime.id = $5::uuid
     AND runtime.org_id = $1
     AND runtime.machine_id = $2
-    AND runtime.daemon_token_id = $5::uuid
+    AND runtime.daemon_token_id = $6::uuid
 )
 SELECT process.id, process.org_id, process.project_id, process.agent_id, process.tool_call_id, process.runtime_lock_id, process.agent_machine_binding_id, process.machine_id, process.execution_granted_at, process.io_mode, process.command, process.shell_selector, process.cwd, process.env, process.secret_env, process.timeout_seconds, process.initial_wait_ms, process.default_output_cursor, process.state, process.state_reason_code, process.state_reason_message, process.source_started_at, process.source_ended_at, process.state_changed_at, process.exit_code, process.exit_signal, process.created_at, process.updated_at, process.last_activity_at
 FROM processes process
@@ -1147,22 +1150,25 @@ JOIN project_machine_grants pmgrant ON pmgrant.project_id = binding.project_id
 WHERE process.org_id = $1
   AND process.machine_id = $2
   AND process.state = 'queued'
+  AND process.created_at > statement_timestamp() - ($3::int * interval '1 second')
 ORDER BY process.created_at, process.id
-LIMIT $3
+LIMIT $4
 `
 
 type ListDaemonProcessOffersParams struct {
-	OrgID           uuid.UUID
-	MachineID       uuid.UUID
-	LimitCount      int32
-	DaemonRuntimeID uuid.UUID
-	DaemonTokenID   uuid.UUID
+	OrgID               uuid.UUID
+	MachineID           uuid.UUID
+	QueueTimeoutSeconds int32
+	LimitCount          int32
+	DaemonRuntimeID     uuid.UUID
+	DaemonTokenID       uuid.UUID
 }
 
 func (q *Queries) ListDaemonProcessOffers(ctx context.Context, arg ListDaemonProcessOffersParams) ([]Process, error) {
 	rows, err := q.db.Query(ctx, listDaemonProcessOffers,
 		arg.OrgID,
 		arg.MachineID,
+		arg.QueueTimeoutSeconds,
 		arg.LimitCount,
 		arg.DaemonRuntimeID,
 		arg.DaemonTokenID,

--- a/internal/storage/queries/process_actions.sql
+++ b/internal/storage/queries/process_actions.sql
@@ -36,6 +36,7 @@ target AS MATERIALIZED (
         AND sqlc.arg(action_kind)::text = 'read'
         AND process.state IN ('exited', 'failed', 'killed', 'unknown')
         AND process.state_reason_code IS DISTINCT FROM 'machine_storage_exhausted'
+        AND process.execution_granted_at IS NOT NULL
       )
     )
     AND (
@@ -59,6 +60,8 @@ RETURNING id, org_id, project_id, agent_id, process_id, tool_call_id, runtime_lo
 
 -- name: GetProcessActionCreateBlocker :one
 SELECT process.state,
+  coalesce(process.execution_granted_at IS NOT NULL
+    AND process.state_reason_code IS DISTINCT FROM 'machine_storage_exhausted', false)::boolean AS terminal_read_supported,
   EXISTS (
     SELECT 1
     FROM process_actions terminate_action

--- a/internal/storage/queries/process_tool_unreachable.sql
+++ b/internal/storage/queries/process_tool_unreachable.sql
@@ -1,10 +1,18 @@
--- name: ListMachineUnreachableMachineCandidates :many
+-- name: ListProcessToolExpiryMachineCandidates :many
 WITH cutoff AS MATERIALIZED (
   SELECT transaction_timestamp() AS observed_at,
          transaction_timestamp()
-           - (sqlc.arg(machine_unreachable_grace_seconds)::int * interval '1 second') AS unreachable_before
+           - (sqlc.arg(machine_unreachable_grace_seconds)::int * interval '1 second') AS unreachable_before,
+         transaction_timestamp()
+           - (sqlc.arg(queue_timeout_seconds)::int * interval '1 second') AS queued_before
 ), process_work AS MATERIALIZED (
-  SELECT process.org_id, process.machine_id, process.created_at AS work_at
+  SELECT process.org_id, process.machine_id,
+         CASE
+           WHEN process.state = 'queued' AND process.created_at <= cutoff.queued_before
+           THEN process.created_at + (sqlc.arg(queue_timeout_seconds)::int * interval '1 second')
+           ELSE greatest(process.created_at, latest_runtime.unreachable_at)
+             + (sqlc.arg(machine_unreachable_grace_seconds)::int * interval '1 second')
+         END AS expires_at
   FROM processes process
   JOIN tool_calls tool_call ON tool_call.agent_id = process.agent_id
     AND tool_call.id = process.tool_call_id
@@ -20,26 +28,31 @@ WITH cutoff AS MATERIALIZED (
   ) latest_runtime ON true
   CROSS JOIN cutoff
   WHERE process.state IN ('queued', 'starting', 'running')
-    AND process.created_at <= cutoff.unreachable_before
-    AND coalesce(latest_runtime.unreachable_at, process.created_at) <= cutoff.unreachable_before
+    AND process.created_at <= greatest(cutoff.unreachable_before, cutoff.queued_before)
     AND tool_call.type = 'built_in'
     AND tool_call.state = 'waiting'
     AND machine.lifecycle_state = 'active'
     AND machine.deleted_at IS NULL
     AND (
-      machine.wake_attempt_expires_at IS NULL
-      OR machine.wake_attempt_expires_at <= cutoff.observed_at
-    )
-    AND NOT EXISTS (
-      SELECT 1
-      FROM online_daemon_runtimes online
-      WHERE online.org_id = process.org_id
-        AND online.machine_id = process.machine_id
+      (process.state = 'queued'
+        AND process.created_at <= cutoff.queued_before)
+      OR (
+        process.created_at <= cutoff.unreachable_before
+        AND coalesce(latest_runtime.unreachable_at, process.created_at) <= cutoff.unreachable_before
+        AND (machine.wake_attempt_expires_at IS NULL
+          OR machine.wake_attempt_expires_at <= cutoff.observed_at)
+        AND NOT EXISTS (
+          SELECT 1 FROM online_daemon_runtimes online
+          WHERE online.org_id = process.org_id AND online.machine_id = process.machine_id
+        )
+      )
     )
   ORDER BY process.created_at, process.id
   LIMIT sqlc.arg(limit_count)
 ), action_work AS MATERIALIZED (
-  SELECT action.org_id, process.machine_id, action.created_at AS work_at
+  SELECT action.org_id, process.machine_id,
+         greatest(action.created_at, latest_runtime.unreachable_at)
+           + (sqlc.arg(machine_unreachable_grace_seconds)::int * interval '1 second') AS expires_at
   FROM process_actions action
   JOIN processes process ON process.org_id = action.org_id
     AND process.project_id = action.project_id
@@ -85,39 +98,21 @@ WITH cutoff AS MATERIALIZED (
     )
   ORDER BY action.created_at, action.id
   LIMIT sqlc.arg(limit_count)
-), machine_work AS MATERIALIZED (
-  SELECT work.org_id, work.machine_id, min(work.work_at)::timestamptz AS earliest_work_at
+), machine_work AS (
+  SELECT work.org_id, work.machine_id, min(work.expires_at)::timestamptz AS expires_at
   FROM (
-    SELECT org_id, machine_id, work_at FROM process_work
+    SELECT org_id, machine_id, expires_at FROM process_work
     UNION ALL
-    SELECT org_id, machine_id, work_at FROM action_work
+    SELECT org_id, machine_id, expires_at FROM action_work
   ) work
   GROUP BY work.org_id, work.machine_id
-), candidates AS (
-  SELECT work.org_id,
-         work.machine_id,
-         greatest(
-           work.earliest_work_at,
-           coalesce(latest_runtime.unreachable_at, work.earliest_work_at)
-         )::timestamptz AS unreachable_at
-  FROM machine_work work
-  LEFT JOIN LATERAL (
-    SELECT runtime.effective_end_at AS unreachable_at
-    FROM daemon_runtime_connection_facts runtime
-    WHERE runtime.org_id = work.org_id
-      AND runtime.machine_id = work.machine_id
-    ORDER BY runtime.effective_end_at DESC, runtime.id DESC
-    LIMIT 1
-  ) latest_runtime ON true
 )
-SELECT candidates.org_id, candidates.machine_id, candidates.unreachable_at
-FROM candidates
-CROSS JOIN cutoff
-WHERE candidates.unreachable_at <= cutoff.unreachable_before
-ORDER BY candidates.unreachable_at, candidates.org_id, candidates.machine_id
+SELECT org_id, machine_id, expires_at
+FROM machine_work
+ORDER BY expires_at, org_id, machine_id
 LIMIT sqlc.arg(limit_count);
 
--- name: ListMachineUnreachableQueuedProcessToolCallsForMachine :many
+-- name: ListExpirableQueuedProcessToolCallsForMachine :many
 SELECT process.id, process.org_id, process.project_id, process.agent_id, process.tool_call_id, process.runtime_lock_id, process.agent_machine_binding_id, process.machine_id, process.execution_granted_at, process.io_mode, process.command, process.shell_selector, process.cwd, process.env, process.secret_env, process.timeout_seconds, process.initial_wait_ms, process.default_output_cursor, process.state, process.state_reason_code, process.state_reason_message, process.source_started_at, process.source_ended_at, process.state_changed_at, process.exit_code, process.exit_signal, process.created_at, process.updated_at, process.last_activity_at
 FROM processes process
 JOIN tool_calls tool_call ON tool_call.agent_id = process.agent_id
@@ -143,11 +138,14 @@ WHERE process.org_id = sqlc.arg(org_id)
   AND machine.lifecycle_state = 'active'
   AND machine.deleted_at IS NULL
   AND (
-    machine.wake_attempt_expires_at IS NULL
-    OR machine.wake_attempt_expires_at <= transaction_timestamp()
+    process.created_at <= transaction_timestamp() - (sqlc.arg(queue_timeout_seconds)::int * interval '1 second')
+    OR (
+      (machine.wake_attempt_expires_at IS NULL
+        OR machine.wake_attempt_expires_at <= transaction_timestamp())
+      AND online.id IS NULL
+      AND greatest(latest_runtime.unreachable_at, process.created_at) <= transaction_timestamp() - (sqlc.arg(machine_unreachable_grace_seconds)::int * interval '1 second')
+    )
   )
-  AND online.id IS NULL
-  AND greatest(latest_runtime.unreachable_at, process.created_at) <= transaction_timestamp() - (sqlc.arg(machine_unreachable_grace_seconds)::int * interval '1 second')
 ORDER BY process.created_at, process.id
 LIMIT sqlc.arg(limit_count);
 
@@ -203,6 +201,50 @@ WHERE process.project_id = sqlc.arg(project_id)
   AND process.org_id = sqlc.arg(org_id)
   AND process.machine_id = sqlc.arg(machine_id)
   AND process.state = 'queued'
+  AND EXISTS (
+    SELECT 1
+    FROM tool_calls tool_call
+    WHERE tool_call.agent_id = process.agent_id
+      AND tool_call.id = process.tool_call_id
+      AND tool_call.type = 'built_in'
+      AND tool_call.state = 'waiting'
+  )
+RETURNING process.id, process.org_id, process.project_id, process.agent_id, process.tool_call_id, process.runtime_lock_id, process.agent_machine_binding_id, process.machine_id, process.execution_granted_at, process.io_mode, process.command, process.shell_selector, process.cwd, process.env, process.secret_env, process.timeout_seconds, process.initial_wait_ms, process.default_output_cursor, process.state, process.state_reason_code, process.state_reason_message, process.source_started_at, process.source_ended_at, process.state_changed_at, process.exit_code, process.exit_signal, process.created_at, process.updated_at, process.last_activity_at;
+
+-- name: ExpireQueuedProcessToolCall :one
+WITH cutoff AS (
+  SELECT statement_timestamp() - (sqlc.arg(queue_timeout_seconds)::int * interval '1 second') AS queued_before
+)
+UPDATE processes process
+SET state = 'failed',
+    state_reason_code = CASE
+      WHEN process.created_at <= cutoff.queued_before
+      THEN 'process_queue_timeout'
+      ELSE 'machine_unreachable'
+    END,
+    state_reason_message = CASE
+      WHEN process.created_at <= cutoff.queued_before
+      THEN 'machine did not accept the command before its queue deadline; execution was not granted'
+      ELSE ''
+    END,
+    state_changed_at = statement_timestamp(),
+    updated_at = statement_timestamp()
+FROM cutoff
+WHERE process.project_id = sqlc.arg(project_id)
+  AND process.agent_id = sqlc.arg(agent_id)
+  AND process.id = sqlc.arg(id)
+  AND process.org_id = sqlc.arg(org_id)
+  AND process.machine_id = sqlc.arg(machine_id)
+  AND process.state = 'queued'
+  AND (
+    process.created_at <= cutoff.queued_before
+    OR sqlc.arg(machine_unreachable)::boolean
+  )
+  AND EXISTS (
+    SELECT 1 FROM machines machine
+    WHERE machine.org_id = process.org_id AND machine.id = process.machine_id
+      AND machine.lifecycle_state = 'active' AND machine.deleted_at IS NULL
+  )
   AND EXISTS (
     SELECT 1
     FROM tool_calls tool_call

--- a/internal/storage/queries/processes.sql
+++ b/internal/storage/queries/processes.sql
@@ -329,6 +329,7 @@ JOIN project_machine_grants pmgrant ON pmgrant.project_id = binding.project_id
 WHERE process.org_id = sqlc.arg(org_id)
   AND process.machine_id = sqlc.arg(machine_id)
   AND process.state = 'queued'
+  AND process.created_at > statement_timestamp() - (sqlc.arg(queue_timeout_seconds)::int * interval '1 second')
 ORDER BY process.created_at, process.id
 LIMIT sqlc.arg(limit_count);
 
@@ -360,6 +361,7 @@ WHERE process.org_id = runtime.org_id
   AND process.machine_id = runtime.machine_id
   AND process.id = sqlc.arg(process_id)
   AND process.state = 'queued'
+  AND process.created_at > statement_timestamp() - (sqlc.arg(queue_timeout_seconds)::int * interval '1 second')
   AND EXISTS (
     SELECT 1
     FROM agent_machine_bindings binding


### PR DESCRIPTION
- Expire commands queued for five minutes through existing maintenance, complete their waiting tool calls, and let agents resume even when machines appear online or are waking.
- Filter overdue commands from daemon offers and reject late acceptance; preserve execution that was already granted.
- Reject reads of terminal processes that never received execution permission, with a terminal error even when the machine is offline.
- Make supervisor stdout, stderr, and service-log destinations independently best effort so returned write errors do not interrupt child output forwarding or healthy destinations.
- Rename maintenance expiry log messages to cover both queue timeouts and unreachable-machine recovery.
