### PR TITLE
fix: retry browser-session authentication after safe connection failures

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -44,7 +44,7 @@ services:
       - postgres18-data:/var/lib/postgresql
 
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z
     command: server /data
     environment:
       MINIO_ROOT_USER: omnara
@@ -61,7 +61,7 @@ services:
 
   # One-shot bucket provisioning: the application assumes buckets exist.
   minio-init:
-    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    image: quay.io/minio/mc:RELEASE.2025-04-16T18-13-26Z
     depends_on:
       minio:
         condition: service_healthy

--- a/internal/httpapi/middleware.go
+++ b/internal/httpapi/middleware.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/omnara-ai/omnara/internal/bearertoken"
 	"github.com/omnara-ai/omnara/internal/daemonprotocol"
+	"github.com/omnara-ai/omnara/internal/errutil"
 	"github.com/omnara-ai/omnara/internal/httpapi/apierror"
 	httpauth "github.com/omnara-ai/omnara/internal/httpapi/auth"
 	"github.com/omnara-ai/omnara/internal/httpapi/openapi"
@@ -185,6 +186,9 @@ func (s *Server) auth(next http.Handler) http.Handler {
 						logent.AuthResultUnavailable,
 						err,
 					)
+					if errors.Is(r.Context().Err(), context.Canceled) && errutil.OnlyMatches(err, context.Canceled) {
+						return
+					}
 					apierror.Write(w, openapi.ErrorCodeAuthenticationUnavailable)
 					return
 				}

--- a/internal/httpapi/public_api_identity_workflow_integration_test.go
+++ b/internal/httpapi/public_api_identity_workflow_integration_test.go
@@ -6,9 +6,11 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -20,9 +22,12 @@ import (
 	"time"
 
 	jose "github.com/go-jose/go-jose/v4"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/omnara-ai/omnara/internal/authn"
 	"github.com/omnara-ai/omnara/internal/bearertoken"
 	httpauth "github.com/omnara-ai/omnara/internal/httpapi/auth"
+	logpkg "github.com/omnara-ai/omnara/internal/log"
 	"github.com/omnara-ai/omnara/internal/publicid"
 	"github.com/omnara-ai/omnara/internal/storage"
 	"github.com/omnara-ai/omnara/internal/storage/executionstore"
@@ -4098,4 +4103,188 @@ func TestMachineRoutesRequireMachineAuthority(t *testing.T) {
 		http.StatusGone,
 		authHeaders(otherDaemonToken),
 	)
+}
+
+func TestBrowserSessionConnectionFailureHandling(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		cached            bool
+		cancelDuringWrite bool
+		partialWrite      bool
+		cancelBefore      bool
+		failAcquire       bool
+	}{
+		{name: "live write timeout retries"},
+		{name: "cached live write timeout retries", cached: true},
+		{name: "canceled prepare write", cancelDuringWrite: true},
+		{name: "canceled cached write", cached: true, cancelDuringWrite: true},
+		{name: "canceled partial write", cached: true, cancelDuringWrite: true, partialWrite: true},
+		{name: "already canceled", cancelBefore: true},
+		{name: "canceled request with acquisition failure", failAcquire: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, stop := context.WithTimeout(context.Background(), 10*time.Second)
+			defer stop()
+			basePool := openIntegrationDB(t, ctx)
+			user, err := storagetest.CreateVerifiedUser(ctx, basePool, storagetest.CreateVerifiedUserInput{
+				Email: "browser-connection@example.com", DisplayName: "Browser Connection",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			requestCtx, cancelRequest := context.WithCancel(ctx)
+			defer cancelRequest()
+			cfg := basePool.Config()
+			cfg.MaxConns = 1
+			cfg.ShouldPing = func(context.Context, pgxpool.ShouldPingParams) bool { return false }
+			var failAcquire atomic.Bool
+			cfg.PrepareConn = func(context.Context, *pgx.Conn) (bool, error) {
+				if failAcquire.Load() {
+					cancelRequest()
+					return true, errors.New("database acquisition failed")
+				}
+				return true, nil
+			}
+			cfg.ConnConfig.DialFunc = func(ctx context.Context, network, address string) (net.Conn, error) {
+				conn, err := (&net.Dialer{}).DialContext(ctx, network, address)
+				if err != nil {
+					return nil, err
+				}
+				observed := &browserAuthWriteConn{Conn: conn, deadlineSet: make(chan struct{}), partialWrite: tc.partialWrite}
+				if tc.cancelDuringWrite {
+					observed.cancel = cancelRequest
+				}
+				return observed, nil
+			}
+			pool, err := pgxpool.NewWithConfig(ctx, cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer pool.Close()
+			store := storage.NewStore(pool)
+			session, err := store.Identity().CreateBrowserSession(ctx, identitystore.CreateBrowserSessionInput{
+				UserID: user.ID, Token: "browser-connection-token", CSRFToken: "csrf", TTL: time.Hour,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.cached {
+				if _, _, err := store.Identity().AuthenticateBrowserSession(ctx, "browser-connection-token"); err != nil {
+					t.Fatal(err)
+				}
+			}
+			acquired, err := pool.Acquire(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer acquired.Release()
+			netConn := acquired.Conn().PgConn().Conn()
+			if tlsConn, ok := netConn.(*tls.Conn); ok {
+				netConn = tlsConn.NetConn()
+			}
+			conn := testutil.RequireType[*browserAuthWriteConn](t, netConn)
+			conn.armed.Store(!tc.cancelBefore && !tc.failAcquire)
+			acquired.Release()
+			failAcquire.Store(tc.failAcquire)
+			if tc.cancelBefore {
+				cancelRequest()
+			}
+			server := &Server{store: store}
+			buffer, logger := newRequestEventCapture()
+			handlerCalls := 0
+			handler := requestLog(logger)(server.auth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handlerCalls++
+				principal, ok := r.Context().Value(principalContextKey{}).(identitystore.PrincipalRecord)
+				if !ok || principal.ID != user.ID || principal.BrowserSessionID != session.ID {
+					t.Fatalf("unexpected authenticated principal: %+v", principal)
+				}
+				w.WriteHeader(http.StatusNoContent)
+			})))
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil).WithContext(requestCtx)
+			req.AddCookie(&http.Cookie{Name: httpauth.BrowserSessionCookieName, Value: "browser-connection-token"})
+			rec := httptest.NewRecorder()
+			tracked := logpkg.NewResponseRecorder(rec)
+			handler.ServeHTTP(tracked, req)
+			conn.armed.Store(false)
+			event := decodeRequestEvent(t, buffer)
+			canceled := tc.cancelDuringWrite || tc.cancelBefore
+			switch {
+			case tc.failAcquire:
+				if handlerCalls != 0 || rec.Code != http.StatusServiceUnavailable || event["http.status_code"] != float64(503) {
+					t.Fatalf("pool failure was suppressed: calls=%d response=%d event=%+v", handlerCalls, rec.Code, event)
+				}
+			case canceled:
+				if handlerCalls != 0 || rec.Body.Len() != 0 || tracked.Started() {
+					t.Fatalf(
+						"canceled auth produced a response or ran handler: calls=%d response=%d body=%s",
+						handlerCalls, rec.Code, rec.Body.String(),
+					)
+				}
+				if event["http.status_code"] != float64(499) || event["level"] != "info" {
+					t.Fatalf("canceled auth misclassified: %+v", event)
+				}
+				if tc.cancelDuringWrite && !strings.Contains(fmt.Sprint(event["auth.error"]), "i/o timeout") {
+					t.Fatalf("missing actual socket timeout: %+v", event)
+				}
+			default:
+				if handlerCalls != 1 || rec.Code != http.StatusNoContent || event["http.status_code"] != float64(204) {
+					t.Fatalf("retry did not authenticate once: calls=%d response=%d event=%+v", handlerCalls, rec.Code, event)
+				}
+			}
+			if tc.partialWrite && conn.bytesWritten.Load() == 0 {
+				t.Fatal("partial write did not send any bytes")
+			}
+			if !tc.cancelBefore && !tc.failAcquire && !conn.triggered.Load() {
+				t.Fatal("socket write failure was not exercised")
+			}
+		})
+	}
+}
+
+type browserAuthWriteConn struct {
+	net.Conn
+	partialWrite bool
+	bytesWritten atomic.Int64
+	armed        atomic.Bool
+	triggered    atomic.Bool
+	signaled     atomic.Bool
+	cancel       context.CancelFunc
+	deadlineSet  chan struct{}
+}
+
+func (c *browserAuthWriteConn) SetDeadline(deadline time.Time) error {
+	err := c.Conn.SetDeadline(deadline)
+	if !deadline.IsZero() && !deadline.After(time.Now()) && c.signaled.CompareAndSwap(false, true) {
+		close(c.deadlineSet)
+	}
+	return err
+}
+
+func (c *browserAuthWriteConn) Write(p []byte) (int, error) {
+	if !c.armed.CompareAndSwap(true, false) {
+		return c.Conn.Write(p)
+	}
+	c.triggered.Store(true)
+	written := 0
+	if c.partialWrite {
+		n, err := c.Conn.Write(p[:1])
+		if err != nil {
+			return n, err
+		}
+		written = n
+		p = p[n:]
+	}
+	if c.cancel != nil {
+		c.cancel()
+		select {
+		case <-c.deadlineSet:
+		case <-time.After(time.Second):
+			return written, errors.New("pgx did not set cancellation deadline")
+		}
+	} else if err := c.Conn.SetWriteDeadline(time.Now().Add(-time.Second)); err != nil {
+		return 0, err
+	}
+	n, err := c.Conn.Write(p)
+	c.bytesWritten.Store(int64(written + n))
+	return written + n, err
 }

--- a/internal/httpapi/public_api_identity_workflow_integration_test.go
+++ b/internal/httpapi/public_api_identity_workflow_integration_test.go
@@ -4109,6 +4109,7 @@ func TestBrowserSessionConnectionFailureHandling(t *testing.T) {
 	for _, tc := range []struct {
 		name              string
 		cached            bool
+		staleConnections  int
 		cancelDuringWrite bool
 		partialWrite      bool
 		cancelBefore      bool
@@ -4116,6 +4117,8 @@ func TestBrowserSessionConnectionFailureHandling(t *testing.T) {
 	}{
 		{name: "live write timeout retries"},
 		{name: "cached live write timeout retries", cached: true},
+		{name: "two stale connections recover", staleConnections: 2},
+		{name: "two cached stale connections recover", cached: true, staleConnections: 2},
 		{name: "canceled prepare write", cancelDuringWrite: true},
 		{name: "canceled cached write", cached: true, cancelDuringWrite: true},
 		{name: "canceled partial write", cached: true, cancelDuringWrite: true, partialWrite: true},
@@ -4135,7 +4138,7 @@ func TestBrowserSessionConnectionFailureHandling(t *testing.T) {
 			requestCtx, cancelRequest := context.WithCancel(ctx)
 			defer cancelRequest()
 			cfg := basePool.Config()
-			cfg.MaxConns = 1
+			cfg.MaxConns = int32(max(1, tc.staleConnections))
 			cfg.ShouldPing = func(context.Context, pgxpool.ShouldPingParams) bool { return false }
 			var failAcquire atomic.Bool
 			cfg.PrepareConn = func(context.Context, *pgx.Conn) (bool, error) {
@@ -4168,23 +4171,31 @@ func TestBrowserSessionConnectionFailureHandling(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if tc.cached {
-				if _, _, err := store.Identity().AuthenticateBrowserSession(ctx, "browser-connection-token"); err != nil {
+			var acquired []*pgxpool.Conn
+			var conns []*browserAuthWriteConn
+			for range max(1, tc.staleConnections) {
+				if tc.cached {
+					if _, _, err := store.Identity().AuthenticateBrowserSession(ctx, "browser-connection-token"); err != nil {
+						t.Fatal(err)
+					}
+				}
+				c, err := pool.Acquire(ctx)
+				if err != nil {
 					t.Fatal(err)
 				}
+				defer c.Release()
+				acquired = append(acquired, c)
+				netConn := c.Conn().PgConn().Conn()
+				if tlsConn, ok := netConn.(*tls.Conn); ok {
+					netConn = tlsConn.NetConn()
+				}
+				conn := testutil.RequireType[*browserAuthWriteConn](t, netConn)
+				conn.armed.Store(!tc.cancelBefore && !tc.failAcquire)
+				conns = append(conns, conn)
 			}
-			acquired, err := pool.Acquire(ctx)
-			if err != nil {
-				t.Fatal(err)
+			for _, c := range acquired {
+				c.Release()
 			}
-			defer acquired.Release()
-			netConn := acquired.Conn().PgConn().Conn()
-			if tlsConn, ok := netConn.(*tls.Conn); ok {
-				netConn = tlsConn.NetConn()
-			}
-			conn := testutil.RequireType[*browserAuthWriteConn](t, netConn)
-			conn.armed.Store(!tc.cancelBefore && !tc.failAcquire)
-			acquired.Release()
 			failAcquire.Store(tc.failAcquire)
 			if tc.cancelBefore {
 				cancelRequest()
@@ -4205,7 +4216,9 @@ func TestBrowserSessionConnectionFailureHandling(t *testing.T) {
 			rec := httptest.NewRecorder()
 			tracked := logpkg.NewResponseRecorder(rec)
 			handler.ServeHTTP(tracked, req)
-			conn.armed.Store(false)
+			for _, conn := range conns {
+				conn.armed.Store(false)
+			}
 			event := decodeRequestEvent(t, buffer)
 			canceled := tc.cancelDuringWrite || tc.cancelBefore
 			switch {
@@ -4231,11 +4244,13 @@ func TestBrowserSessionConnectionFailureHandling(t *testing.T) {
 					t.Fatalf("retry did not authenticate once: calls=%d response=%d event=%+v", handlerCalls, rec.Code, event)
 				}
 			}
-			if tc.partialWrite && conn.bytesWritten.Load() == 0 {
-				t.Fatal("partial write did not send any bytes")
-			}
-			if !tc.cancelBefore && !tc.failAcquire && !conn.triggered.Load() {
-				t.Fatal("socket write failure was not exercised")
+			for _, conn := range conns {
+				if tc.partialWrite && conn.bytesWritten.Load() == 0 {
+					t.Fatal("partial write did not send any bytes")
+				}
+				if !tc.cancelBefore && !tc.failAcquire && !conn.triggered.Load() {
+					t.Fatal("socket write failure was not exercised")
+				}
 			}
 		})
 	}

--- a/internal/storage/identitystore/browser_sessions_store.go
+++ b/internal/storage/identitystore/browser_sessions_store.go
@@ -78,7 +78,20 @@ func (s *Store) AuthenticateBrowserSession(
 		TouchIntervalSeconds: int64(browserSessionTouchInterval / time.Second),
 	}
 	row, err := s.q.AuthenticateBrowserSession(ctx, params)
-	if err != nil && ctx.Err() == nil && pgconn.SafeToRetry(err) {
+	for _, delay := range [...]time.Duration{25 * time.Millisecond, 50 * time.Millisecond} {
+		if err == nil || ctx.Err() != nil || !pgconn.SafeToRetry(err) {
+			break
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+		case <-timer.C:
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = fmt.Errorf("%s: %w", err.Error(), ctxErr)
+			break
+		}
 		row, err = s.q.AuthenticateBrowserSession(ctx, params)
 	}
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/storage/identitystore/browser_sessions_store.go
+++ b/internal/storage/identitystore/browser_sessions_store.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
 	"github.com/omnara-ai/omnara/internal/storage/internal/storeutil"
 	"github.com/omnara-ai/omnara/internal/storage/storeerr"
@@ -70,18 +72,25 @@ func (s *Store) AuthenticateBrowserSession(
 	if token == "" {
 		return PrincipalRecord{}, "", storeerr.ErrUnauthorized
 	}
-	row, err := s.q.AuthenticateBrowserSession(
-		ctx,
-		dbsqlc.AuthenticateBrowserSessionParams{
-			TokenHash:            HashBearerToken(token),
-			IdleTimeoutSeconds:   int64(browserSessionIdleDuration / time.Second),
-			TouchIntervalSeconds: int64(browserSessionTouchInterval / time.Second),
-		},
-	)
+	params := dbsqlc.AuthenticateBrowserSessionParams{
+		TokenHash:            HashBearerToken(token),
+		IdleTimeoutSeconds:   int64(browserSessionIdleDuration / time.Second),
+		TouchIntervalSeconds: int64(browserSessionTouchInterval / time.Second),
+	}
+	row, err := s.q.AuthenticateBrowserSession(ctx, params)
+	if err != nil && ctx.Err() == nil && pgconn.SafeToRetry(err) {
+		row, err = s.q.AuthenticateBrowserSession(ctx, params)
+	}
 	if errors.Is(err, pgx.ErrNoRows) {
 		return PrincipalRecord{}, "", storeerr.ErrUnauthorized
 	}
 	if err != nil {
+		var timeoutErr net.Error
+		var connectErr *pgconn.ConnectError
+		if errors.Is(ctx.Err(), context.Canceled) &&
+			!errors.As(err, &connectErr) && errors.As(err, &timeoutErr) && timeoutErr.Timeout() {
+			err = fmt.Errorf("%s: %w", err.Error(), context.Canceled)
+		}
 		return PrincipalRecord{}, "", fmt.Errorf("authenticate browser session: %w", err)
 	}
 	return NewBrowserSessionPrincipal(row.UserID, row.BrowserSessionID), row.CsrfTokenHash, nil

--- a/internal/storage/identitystore/browser_sessions_store_test.go
+++ b/internal/storage/identitystore/browser_sessions_store_test.go
@@ -1,0 +1,172 @@
+package identitystore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/omnara-ai/omnara/internal/storage/internal/dbsqlc"
+	"github.com/omnara-ai/omnara/internal/storage/storeerr"
+	"github.com/omnara-ai/omnara/internal/testutil"
+)
+
+func TestAuthenticateBrowserSessionRetry(t *testing.T) {
+	retryable := &browserSessionRetryError{cause: errors.New("write timeout"), safe: true}
+	partialWrite := &browserSessionRetryError{cause: errors.New("partial write timeout")}
+	writeTimeout := &browserSessionRetryError{cause: &net.OpError{Op: "write", Err: os.ErrDeadlineExceeded}, safe: true}
+	readTimeout := &browserSessionRetryError{cause: &net.OpError{Op: "read", Err: os.ErrDeadlineExceeded}, safe: true}
+	partialTimeout := &browserSessionRetryError{cause: &net.OpError{Op: "write", Err: os.ErrDeadlineExceeded}}
+	queryError := &pgconn.PgError{Code: "42601", Message: "syntax error"}
+	cfg, err := pgconn.ParseConfig("postgres://user:pass@127.0.0.1:1,127.0.0.2:1/db?sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dialCalls := 0
+	acquireFailure := errors.New("connection refused")
+	cfg.DialFunc = func(context.Context, string, string) (net.Conn, error) {
+		dialCalls++
+		if dialCalls == 1 {
+			return nil, &net.OpError{Op: "dial", Err: os.ErrDeadlineExceeded}
+		}
+		return nil, &net.OpError{Op: "dial", Err: acquireFailure}
+	}
+	_, connectErr := pgconn.ConnectConfig(context.Background(), cfg)
+	var connectTimeout net.Error
+	if dialCalls != 2 || !errors.Is(connectErr, acquireFailure) ||
+		!errors.As(connectErr, &connectTimeout) || !connectTimeout.Timeout() {
+		t.Fatalf("expected mixed timeout and acquisition failure, got %v (%d dials)", connectErr, dialCalls)
+	}
+	userID, sessionID := uuid.New(), uuid.New()
+	wantPrincipal := NewBrowserSessionPrincipal(userID, sessionID)
+	for _, tt := range []struct {
+		name       string
+		errs       []error
+		cancel     bool
+		emptyToken bool
+		expired    bool
+		wantErr    error
+	}{
+		{name: "success", errs: []error{nil}},
+		{name: "retry succeeds", errs: []error{retryable, nil}},
+		{name: "wrapped retryable error", errs: []error{fmt.Errorf("wrapped: %w", retryable), nil}},
+		{name: "retry exhausted", errs: []error{retryable, retryable}, wantErr: retryable},
+		{name: "retry returns different error", errs: []error{retryable, queryError}, wantErr: queryError},
+		{name: "retry returns unauthorized", errs: []error{retryable, pgx.ErrNoRows}, wantErr: storeerr.ErrUnauthorized},
+		{name: "unauthorized", errs: []error{pgx.ErrNoRows}, wantErr: storeerr.ErrUnauthorized},
+		{name: "query error", errs: []error{queryError}, wantErr: queryError},
+		{name: "partial write", errs: []error{partialWrite}, wantErr: partialWrite},
+		{name: "canceled during first attempt", errs: []error{retryable}, cancel: true, wantErr: retryable},
+		{name: "deadline exceeded", errs: []error{context.DeadlineExceeded}, wantErr: context.DeadlineExceeded},
+		{name: "canceled write timeout", errs: []error{writeTimeout}, cancel: true, wantErr: context.Canceled},
+		{name: "canceled write after retry", errs: []error{retryable, writeTimeout}, cancel: true, wantErr: context.Canceled},
+		{name: "active write timeout recovers", errs: []error{writeTimeout, nil}},
+		{name: "canceled partial write", errs: []error{partialTimeout}, cancel: true, wantErr: context.Canceled},
+		{name: "canceled read timeout", errs: []error{readTimeout}, cancel: true, wantErr: context.Canceled},
+		{name: "canceled postgres failure", errs: []error{queryError}, cancel: true, wantErr: queryError},
+		{name: "canceled mixed acquisition failure", errs: []error{connectErr}, cancel: true, wantErr: connectErr},
+		{
+			name: "canceled non-timeout write", errs: []error{&net.OpError{Op: "write", Err: os.ErrClosed}},
+			cancel: true, wantErr: os.ErrClosed,
+		},
+		{
+			name: "canceled non-timeout dial", errs: []error{&net.OpError{Op: "dial", Err: os.ErrPermission}},
+			cancel: true, wantErr: os.ErrPermission,
+		},
+		{name: "canceled success", errs: []error{nil}, cancel: true},
+		{name: "expired write timeout", errs: []error{writeTimeout}, expired: true, wantErr: writeTimeout},
+		{name: "empty token", emptyToken: true, wantErr: storeerr.ErrUnauthorized},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tt.expired {
+				expiredCtx, expireCancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
+				defer expireCancel()
+				ctx = expiredCtx
+			}
+			calls := 0
+			token := "session-token"
+			if tt.emptyToken {
+				token = ""
+			}
+			wantArgs := []any{HashBearerToken(token), int64(7 * 24 * 60 * 60), int64(5 * 60)}
+			db := browserSessionQueryDB{queryRow: func(gotCtx context.Context, _ string, args ...any) pgx.Row {
+				if gotCtx != ctx {
+					t.Fatal("query did not preserve request context")
+				}
+				if !reflect.DeepEqual(args, wantArgs) {
+					t.Fatalf("query args = %v, want %v", args, wantArgs)
+				}
+				if calls >= len(tt.errs) {
+					t.Fatalf("unexpected query attempt %d", calls+1)
+				}
+				err := tt.errs[calls]
+				calls++
+				return browserSessionQueryRow(func(dest ...any) error {
+					if tt.cancel && calls == len(tt.errs) {
+						cancel()
+					}
+					if err != nil {
+						return err
+					}
+					*testutil.RequireType[*uuid.UUID](t, dest[0]) = userID
+					*testutil.RequireType[*uuid.UUID](t, dest[1]) = sessionID
+					*testutil.RequireType[*string](t, dest[2]) = "csrf-hash"
+					*testutil.RequireType[*time.Time](t, dest[3]) = time.Now()
+					return nil
+				})
+			}}
+			s := &Store{q: dbsqlc.New(db)}
+			principal, csrfHash, err := s.AuthenticateBrowserSession(ctx, token)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+			}
+			if errors.Is(tt.wantErr, context.Canceled) && !strings.Contains(err.Error(), tt.errs[len(tt.errs)-1].Error()) {
+				t.Fatalf("cancellation lost socket error detail: %v", err)
+			}
+			if calls != len(tt.errs) {
+				t.Fatalf("query attempts = %d, want %d", calls, len(tt.errs))
+			}
+			if err == nil {
+				if !reflect.DeepEqual(principal, wantPrincipal) || csrfHash != "csrf-hash" {
+					t.Fatalf("authentication = %+v, %q; want %+v, csrf-hash", principal, csrfHash, wantPrincipal)
+				}
+			} else if !reflect.DeepEqual(principal, PrincipalRecord{}) || csrfHash != "" {
+				t.Fatalf("failed authentication returned credentials: %+v, %q", principal, csrfHash)
+			}
+		})
+	}
+}
+
+type browserSessionRetryError struct {
+	cause error
+	safe  bool
+}
+
+func (e *browserSessionRetryError) Error() string { return e.cause.Error() }
+
+func (e *browserSessionRetryError) Unwrap() error { return e.cause }
+
+func (e *browserSessionRetryError) SafeToRetry() bool { return e.safe }
+
+type browserSessionQueryDB struct {
+	dbsqlc.DBTX
+	queryRow func(context.Context, string, ...any) pgx.Row
+}
+
+func (db browserSessionQueryDB) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
+	return db.queryRow(ctx, sql, args...)
+}
+
+type browserSessionQueryRow func(...any) error
+
+func (row browserSessionQueryRow) Scan(dest ...any) error { return row(dest...) }

--- a/internal/storage/identitystore/browser_sessions_store_test.go
+++ b/internal/storage/identitystore/browser_sessions_store_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/uuid"
@@ -48,17 +49,40 @@ func TestAuthenticateBrowserSessionRetry(t *testing.T) {
 	userID, sessionID := uuid.New(), uuid.New()
 	wantPrincipal := NewBrowserSessionPrincipal(userID, sessionID)
 	for _, tt := range []struct {
-		name       string
-		errs       []error
-		cancel     bool
-		emptyToken bool
-		expired    bool
-		wantErr    error
+		name        string
+		errs        []error
+		cancel      bool
+		emptyToken  bool
+		expired     bool
+		wantErr     error
+		cancelAfter time.Duration
+		wantElapsed time.Duration
 	}{
 		{name: "success", errs: []error{nil}},
-		{name: "retry succeeds", errs: []error{retryable, nil}},
+		{name: "retry succeeds", errs: []error{retryable, nil}, wantElapsed: 25 * time.Millisecond},
 		{name: "wrapped retryable error", errs: []error{fmt.Errorf("wrapped: %w", retryable), nil}},
-		{name: "retry exhausted", errs: []error{retryable, retryable}, wantErr: retryable},
+		{name: "second retry succeeds", errs: []error{retryable, retryable, nil}, wantElapsed: 75 * time.Millisecond},
+		{
+			name: "retry exhausted", errs: []error{retryable, retryable, writeTimeout},
+			wantErr: writeTimeout, wantElapsed: 75 * time.Millisecond,
+		},
+		{
+			name: "canceled during first backoff", errs: []error{writeTimeout},
+			cancelAfter: 10 * time.Millisecond, wantErr: context.Canceled, wantElapsed: 10 * time.Millisecond,
+		},
+		{
+			name: "canceled during second backoff", errs: []error{retryable, writeTimeout},
+			cancelAfter: 40 * time.Millisecond, wantErr: context.Canceled, wantElapsed: 40 * time.Millisecond,
+		},
+		{
+			name: "non-timeout canceled during first backoff", errs: []error{retryable},
+			cancelAfter: 10 * time.Millisecond, wantErr: context.Canceled, wantElapsed: 10 * time.Millisecond,
+		},
+		{
+			name: "non-timeout canceled during second backoff", errs: []error{retryable, retryable},
+			cancelAfter: 40 * time.Millisecond, wantErr: context.Canceled, wantElapsed: 40 * time.Millisecond,
+		},
+		{name: "retry returns partial write", errs: []error{retryable, partialTimeout}, wantErr: partialTimeout},
 		{name: "retry returns different error", errs: []error{retryable, queryError}, wantErr: queryError},
 		{name: "retry returns unauthorized", errs: []error{retryable, pgx.ErrNoRows}, wantErr: storeerr.ErrUnauthorized},
 		{name: "unauthorized", errs: []error{pgx.ErrNoRows}, wantErr: storeerr.ErrUnauthorized},
@@ -86,63 +110,73 @@ func TestAuthenticateBrowserSessionRetry(t *testing.T) {
 		{name: "empty token", emptyToken: true, wantErr: storeerr.ErrUnauthorized},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			if tt.expired {
-				expiredCtx, expireCancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
-				defer expireCancel()
-				ctx = expiredCtx
-			}
-			calls := 0
-			token := "session-token"
-			if tt.emptyToken {
-				token = ""
-			}
-			wantArgs := []any{HashBearerToken(token), int64(7 * 24 * 60 * 60), int64(5 * 60)}
-			db := browserSessionQueryDB{queryRow: func(gotCtx context.Context, _ string, args ...any) pgx.Row {
-				if gotCtx != ctx {
-					t.Fatal("query did not preserve request context")
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				if tt.cancelAfter > 0 {
+					timer := time.AfterFunc(tt.cancelAfter, cancel)
+					defer timer.Stop()
 				}
-				if !reflect.DeepEqual(args, wantArgs) {
-					t.Fatalf("query args = %v, want %v", args, wantArgs)
+				if tt.expired {
+					expiredCtx, expireCancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
+					defer expireCancel()
+					ctx = expiredCtx
 				}
-				if calls >= len(tt.errs) {
-					t.Fatalf("unexpected query attempt %d", calls+1)
+				calls := 0
+				token := "session-token"
+				if tt.emptyToken {
+					token = ""
 				}
-				err := tt.errs[calls]
-				calls++
-				return browserSessionQueryRow(func(dest ...any) error {
-					if tt.cancel && calls == len(tt.errs) {
-						cancel()
+				wantArgs := []any{HashBearerToken(token), int64(7 * 24 * 60 * 60), int64(5 * 60)}
+				db := browserSessionQueryDB{queryRow: func(gotCtx context.Context, _ string, args ...any) pgx.Row {
+					if gotCtx != ctx {
+						t.Fatal("query did not preserve request context")
 					}
-					if err != nil {
-						return err
+					if !reflect.DeepEqual(args, wantArgs) {
+						t.Fatalf("query args = %v, want %v", args, wantArgs)
 					}
-					*testutil.RequireType[*uuid.UUID](t, dest[0]) = userID
-					*testutil.RequireType[*uuid.UUID](t, dest[1]) = sessionID
-					*testutil.RequireType[*string](t, dest[2]) = "csrf-hash"
-					*testutil.RequireType[*time.Time](t, dest[3]) = time.Now()
-					return nil
-				})
-			}}
-			s := &Store{q: dbsqlc.New(db)}
-			principal, csrfHash, err := s.AuthenticateBrowserSession(ctx, token)
-			if !errors.Is(err, tt.wantErr) {
-				t.Fatalf("error = %v, want %v", err, tt.wantErr)
-			}
-			if errors.Is(tt.wantErr, context.Canceled) && !strings.Contains(err.Error(), tt.errs[len(tt.errs)-1].Error()) {
-				t.Fatalf("cancellation lost socket error detail: %v", err)
-			}
-			if calls != len(tt.errs) {
-				t.Fatalf("query attempts = %d, want %d", calls, len(tt.errs))
-			}
-			if err == nil {
-				if !reflect.DeepEqual(principal, wantPrincipal) || csrfHash != "csrf-hash" {
-					t.Fatalf("authentication = %+v, %q; want %+v, csrf-hash", principal, csrfHash, wantPrincipal)
+					if calls >= len(tt.errs) {
+						t.Fatalf("unexpected query attempt %d", calls+1)
+					}
+					err := tt.errs[calls]
+					calls++
+					return browserSessionQueryRow(func(dest ...any) error {
+						if tt.cancel && calls == len(tt.errs) {
+							cancel()
+						}
+						if err != nil {
+							return err
+						}
+						*testutil.RequireType[*uuid.UUID](t, dest[0]) = userID
+						*testutil.RequireType[*uuid.UUID](t, dest[1]) = sessionID
+						*testutil.RequireType[*string](t, dest[2]) = "csrf-hash"
+						*testutil.RequireType[*time.Time](t, dest[3]) = time.Now()
+						return nil
+					})
+				}}
+				s := &Store{q: dbsqlc.New(db)}
+				started := time.Now()
+				principal, csrfHash, err := s.AuthenticateBrowserSession(ctx, token)
+				if tt.wantElapsed > 0 && time.Since(started) != tt.wantElapsed {
+					t.Fatalf("elapsed = %s, want %s", time.Since(started), tt.wantElapsed)
 				}
-			} else if !reflect.DeepEqual(principal, PrincipalRecord{}) || csrfHash != "" {
-				t.Fatalf("failed authentication returned credentials: %+v, %q", principal, csrfHash)
-			}
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("error = %v, want %v", err, tt.wantErr)
+				}
+				if errors.Is(tt.wantErr, context.Canceled) && !strings.Contains(err.Error(), tt.errs[len(tt.errs)-1].Error()) {
+					t.Fatalf("cancellation lost socket error detail: %v", err)
+				}
+				if calls != len(tt.errs) {
+					t.Fatalf("query attempts = %d, want %d", calls, len(tt.errs))
+				}
+				if err == nil {
+					if !reflect.DeepEqual(principal, wantPrincipal) || csrfHash != "csrf-hash" {
+						t.Fatalf("authentication = %+v, %q; want %+v, csrf-hash", principal, csrfHash, wantPrincipal)
+					}
+				} else if !reflect.DeepEqual(principal, PrincipalRecord{}) || csrfHash != "" {
+					t.Fatalf("failed authentication returned credentials: %+v, %q", principal, csrfHash)
+				}
+			})
 		})
 	}
 }


### PR DESCRIPTION
- Recover browser-session authentication from stale pooled connections with up to three total attempts and 25/50 ms backoff, retrying only when pgx confirms replay is safe.
- Stop retries when the request ends, classify canceled socket operations and retry waits as client cancellations, and avoid writing a 503 response for those cancellations.
- Preserve genuine connection-acquisition failures and keep partial writes ineligible for retry.
